### PR TITLE
Add KDL v2 syntax support while preserving existing KDL v1 compatibility

### DIFF
--- a/examples/16-kdl-v2-literals.kdl
+++ b/examples/16-kdl-v2-literals.kdl
@@ -1,0 +1,7 @@
+// KDL v2-style booleans, null, and keyword-like numbers.
+
+enabled #true
+disabled #false
+empty #null
+
+limits #inf #-inf #nan

--- a/examples/17-kdl-v2-strings.kdl
+++ b/examples/17-kdl-v2-strings.kdl
@@ -1,0 +1,16 @@
+// KDL v2-style multiline and raw string forms.
+
+( "tag" ) "quoted node" key = #true
+
+raw-string #"hello, world"#
+
+multi-line """
+hello
+world
+"""
+
+raw-multi-line #"""
+raw
+multiline
+string
+"""#

--- a/grammar.js
+++ b/grammar.js
@@ -53,6 +53,25 @@ const ANNOTATION_BUILTINS = [
   'base64',
 ];
 
+// Support KDL v1, v2.
+const BOOLEAN_KEYWORDS = ['true', 'false', '#true', '#false'];
+const NULL_KEYWORDS = ['null', '#null'];
+const KEYWORD_NUMBERS = ['#inf', '#-inf', '#nan'];
+
+function linespacedNodes($) {
+  return seq(
+    repeat($._linespace),
+    optional(seq(
+      $.node,
+      repeat(seq(
+        repeat($._linespace),
+        $.node,
+      )),
+    )),
+    repeat($._linespace),
+  );
+}
+
 module.exports = grammar({
   name: 'kdl',
 
@@ -60,11 +79,13 @@ module.exports = grammar({
     [$.document],
     [$._node_space],
     [$.node_children],
+    [$.identifier, $.value],
   ],
 
   externals: $ => [
     $._eof,
     $.multi_line_comment,
+    $.multi_line_string,
     $._raw_string,
   ],
 
@@ -74,24 +95,17 @@ module.exports = grammar({
 
   rules: {
     // nodes := linespace* (node nodes?)? linespace*
-    document: $ =>
-      seq(
-        repeat($._linespace),
-        optional(seq(
-          $.node,
-          repeat(seq(
-            repeat($._linespace),
-            $.node,
-          )),
-        )),
-        repeat($._linespace),
-      ),
+    document: $ => linespacedNodes($),
+
 
     // node := ('/-' node-space*)? type? identifier (node-space+ node-prop-or-arg)* (node-space* node-children ws*)? node-space* node-terminator
+    // Compatibility grammar: node names stay under `identifier` to preserve the
+    // existing AST shape, even though `identifier` itself already includes
+    // quoted/raw string forms via `$.string`.
     node: $ => prec(1,
       seq(
         alias(optional(seq('/-', repeat($._node_space))), $.node_comment),
-        optional($.type),
+        optional(seq($.type, repeat($._node_space))),
         $.identifier,
         repeat(seq(repeat1($._node_space), $.node_field)),
         optional(seq(repeat($._node_space), field('children', $.node_children), repeat($._ws))),
@@ -133,6 +147,10 @@ module.exports = grammar({
 
     // identifier := string | bare-identifier
     identifier: $ => choice($.string, $._bare_identifier),
+    // Compatibility rule: exclude `#` from the first character so KDL v2 tokens
+    // like #true / #null / #inf do not get consumed as identifiers, but keep
+    // legacy/editor-friendly support for `#` in later positions.
+
     // bare-identifier := ((identifier-char - digit - sign) identifier-char* | sign ((identifier-char - digit) identifier-char*)?) - keyword
     _bare_identifier: $ =>
       choice(
@@ -143,7 +161,7 @@ module.exports = grammar({
     // _normal_bare_identifier: $ => $.__identifier_char_no_digit_sign,
     _normal_bare_identifier: _ => token(
       seq(
-        /[\u4E00-\u9FFF\p{L}\p{M}\p{N}\p{Emoji}_~!@#\$%\^&\*.:'\|\?&&[^\s\d\/(){}<>;\[\]=,"]]/,
+        /[\u4E00-\u9FFF\p{L}\p{M}\p{N}\p{Emoji}_~!@\$%\^&\*.:'\|\?&&[^\s\d\/(){}<>;\[\]=,"]]/,
         /[\u4E00-\u9FFF\p{L}\p{M}\p{N}\p{Emoji}\-_~!@#\$%\^&\*.:'\|\?+&&[^\s\/(){}<>;\[\]=,"]]*/,
       ),
     ),
@@ -154,40 +172,49 @@ module.exports = grammar({
 
     // can't start with a digit
     __identifier_char_no_digit: _ => token(
-      /[\u4E00-\u9FFF\p{L}\p{M}\p{N}\-_~!@#\$%\^&\*.:'\|\?+&&[^\s\d\/(){}<>;\[\]=,"]]/,
+      /[\u4E00-\u9FFF\p{L}\p{M}\p{N}\-_~!@\$%\^&\*.:'\|\?+&&[^\s\d\/(){}<>;\[\]=,"]]/,
     ),
 
     // can't start with a digit or sign
     __identifier_char_no_digit_sign: _ => token(
-      /[\u4E00-\u9FFF\p{L}\p{M}\p{N}\-_~!@#\$%\^&\*.:'\|\?&&[^\s\d\+\-\/(){}<>;\[\]=,"]]/,
+      /[\u4E00-\u9FFF\p{L}\p{M}\p{N}\-_~!@\$%\^&\*.:'\|\?&&[^\s\d\+\-\/(){}<>;\[\]=,"]]/,
     ),
 
-    // keyword := boolean | 'null'
-    keyword: $ => choice($.boolean, 'null'),
+    // Intentionally accept both v1 and v2 keywords here.
+    // If we ever add strict parsing modes, this is one of the first places to split.
+    keyword: $ => choice($.boolean, ...NULL_KEYWORDS),
+
     // type annotations
     annotation_type: _ => choice(...ANNOTATION_BUILTINS),
-    // prop := identifier '=' value
-    prop: $ => seq($.identifier, '=', $.value),
+
+    prop: $ => seq($.identifier, repeat($._node_space), '=', repeat($._node_space), $.value),
+
     // value := type? (string | number | keyword)
-    value: $ => seq(optional($.type), choice($.string, $.number, $.keyword)),
+    value: $ => seq(optional(seq($.type, repeat($._node_space))), choice($.string, $.number, $.keyword)),
+
     // type := '(' identifier ')'
-    type: $ => seq('(', choice($.identifier, $.annotation_type), ')'),
+    type: $ => seq('(', repeat($._node_space), choice($.identifier, $.annotation_type), repeat($._node_space), ')'),
 
     // String
-    // string := raw-string | escaped-string
-    string: $ => choice($._raw_string, $._escaped_string),
+    // `string` intentionally covers multiple concrete syntaxes:
+    // - v1 raw strings: r#"..."#
+    // - v2 raw strings: #"..."#
+    // - v2 multiline strings: """..."""
+    // The tricky delimiter matching lives in the external scanner.
+    string: $ => choice($._raw_string, $.multi_line_string, $._escaped_string),
     // escaped-string := '"' character* '"'
-    _escaped_string: $ => seq('"', alias(repeat(choice($.escape, /[^"]/)), $.string_fragment), '"'),
+    _escaped_string: $ => seq('"', alias(repeat(choice($.escape, $.escaped_whitespace, /[^"]/)), $.string_fragment), '"'),
     // character := '\' escape | [^\"]
-    _character: $ => choice($.escape, /[^"]/),
-    // escape := ["\\/bfnrt] | 'u{' hex-digit{1, 6} '}'
+    _character: $ => choice($.escape, $.escaped_whitespace, /[^"]/),
+    // escape := ["\\/bfnrts] | 'u{' hex-digit{1, 6} '}'
     escape: _ =>
-      token.immediate(/\\\\|\\"|\\\/|\\b|\\f|\\n|\\r|\\t|\\u\{[0-9a-fA-F]{1,6}\}/),
+      token.immediate(/\\\\|\\"|\\\/|\\b|\\f|\\n|\\r|\\t|\\s|\\u\{[0-9a-fA-F]{1,6}\}/),
+    escaped_whitespace: _ => token.immediate(/\\(?:\r\n|[\u0009\u0020\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\r\n\u0085\u000B\u000C\u2028\u2029])+/),
     // hex-digit := [0-9a-fA-F]
     _hex_digit: _ => /[0-9a-fA-F]/,
 
-    // number := decimal | hex | octal | binary
-    number: $ => choice($._decimal, $._hex, $._octal, $._binary),
+    // v2 adds keyword-like numeric literals such as #inf / #-inf / #nan.
+    number: $ => choice($.keyword_number, $._decimal, $._hex, $._octal, $._binary),
 
     // decimal := sign? integer ('.' integer)? exponent?
     _decimal: $ =>
@@ -214,8 +241,9 @@ module.exports = grammar({
     // binary := sign? '0b' ('0' | '1') ('0' | '1' | '_')*
     _binary: $ => seq(optional($._sign), '0b', choice('0', '1'), repeat(choice('0', '1', '_'))),
 
-    // boolean := 'true' | 'false'
-    boolean: _ => choice('true', 'false'),
+    keyword_number: _ => choice(...KEYWORD_NUMBERS),
+
+    boolean: _ => choice(...BOOLEAN_KEYWORDS),
 
     // escline := '\\' ws* (single-line-comment | newline)
     _escline: $ => seq('\\', repeat($._ws), choice($.single_line_comment, $._newline)),
@@ -238,8 +266,10 @@ module.exports = grammar({
     // │  PS       Paragraph Separator            U+2029          │
     // ╰──────────────────────────────────────────────────────────╯
     // Note that for the purpose of new lines, CRLF is considered a single newline.
-    _newline: _ => choice(/\r'/, /\n/, /\r\n/, /\u0085/, /\u000C/, /\u2028/, /\u2029/),
+    _newline: _ => choice(/\r\n/, /\r/, /\n/, /\u0085/, /\u000B/, /\u000C/, /\u2028/, /\u2029/),
 
+    // `ws` is non-newline whitespace.
+    // The long Unicode list is copied from the KDL spec on purpose.
     // ws := bom | unicode-space | multi-line-comment
     _ws: $ => choice($._bom, $._unicode_space, $.multi_line_comment),
 
@@ -278,7 +308,7 @@ module.exports = grammar({
     single_line_comment: $ =>
       seq(
         '//',
-        repeat(/[^\r\n\u0085\u000C\u2028\u2029]/),
+        repeat(/[^\r\n\u0085\u000B\u000C\u2028\u2029]/),
         choice($._newline, $._eof),
       ),
   },

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,6 +1,7 @@
 ; Types
 
 (node (identifier) @type)
+(node (identifier (string) @string))
 
 (type) @type
 
@@ -25,9 +26,13 @@
 
 (string) @string
 
+(multi_line_string) @string
+
 (escape) @string.escape
 
 (number) @number
+
+(keyword_number) @number
 
 (number (decimal) @float)
 (number (exponent) @float)
@@ -35,6 +40,7 @@
 (boolean) @boolean
 
 "null" @constant.builtin
+"#null" @constant.builtin
 
 ; Punctuation
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -96,8 +96,20 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "type"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "type"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_node_space"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -442,7 +454,7 @@
         "members": [
           {
             "type": "PATTERN",
-            "value": "[\\u4E00-\\u9FFF\\p{L}\\p{M}\\p{N}\\p{Emoji}_~!@#\\$%\\^&\\*.:'\\|\\?&&[^\\s\\d\\/(){}<>;\\[\\]=,\"]]"
+            "value": "[\\u4E00-\\u9FFF\\p{L}\\p{M}\\p{N}\\p{Emoji}_~!@\\$%\\^&\\*.:'\\|\\?&&[^\\s\\d\\/(){}<>;\\[\\]=,\"]]"
           },
           {
             "type": "PATTERN",
@@ -462,14 +474,14 @@
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "[\\u4E00-\\u9FFF\\p{L}\\p{M}\\p{N}\\-_~!@#\\$%\\^&\\*.:'\\|\\?+&&[^\\s\\d\\/(){}<>;\\[\\]=,\"]]"
+        "value": "[\\u4E00-\\u9FFF\\p{L}\\p{M}\\p{N}\\-_~!@\\$%\\^&\\*.:'\\|\\?+&&[^\\s\\d\\/(){}<>;\\[\\]=,\"]]"
       }
     },
     "__identifier_char_no_digit_sign": {
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "[\\u4E00-\\u9FFF\\p{L}\\p{M}\\p{N}\\-_~!@#\\$%\\^&\\*.:'\\|\\?&&[^\\s\\d\\+\\-\\/(){}<>;\\[\\]=,\"]]"
+        "value": "[\\u4E00-\\u9FFF\\p{L}\\p{M}\\p{N}\\-_~!@\\$%\\^&\\*.:'\\|\\?&&[^\\s\\d\\+\\-\\/(){}<>;\\[\\]=,\"]]"
       }
     },
     "keyword": {
@@ -482,6 +494,10 @@
         {
           "type": "STRING",
           "value": "null"
+        },
+        {
+          "type": "STRING",
+          "value": "#null"
         }
       ]
     },
@@ -646,8 +662,22 @@
           "name": "identifier"
         },
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_node_space"
+          }
+        },
+        {
           "type": "STRING",
           "value": "="
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_node_space"
+          }
         },
         {
           "type": "SYMBOL",
@@ -662,8 +692,20 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "type"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_node_space"
+                  }
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -697,6 +739,13 @@
           "value": "("
         },
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_node_space"
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -710,6 +759,13 @@
           ]
         },
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_node_space"
+          }
+        },
+        {
           "type": "STRING",
           "value": ")"
         }
@@ -721,6 +777,10 @@
         {
           "type": "SYMBOL",
           "name": "_raw_string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "multi_line_string"
         },
         {
           "type": "SYMBOL",
@@ -747,6 +807,10 @@
                   "name": "escape"
                 },
                 {
+                  "type": "SYMBOL",
+                  "name": "escaped_whitespace"
+                },
+                {
                   "type": "PATTERN",
                   "value": "[^\"]"
                 }
@@ -770,6 +834,10 @@
           "name": "escape"
         },
         {
+          "type": "SYMBOL",
+          "name": "escaped_whitespace"
+        },
+        {
           "type": "PATTERN",
           "value": "[^\"]"
         }
@@ -779,7 +847,14 @@
       "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "\\\\\\\\|\\\\\"|\\\\\\/|\\\\b|\\\\f|\\\\n|\\\\r|\\\\t|\\\\u\\{[0-9a-fA-F]{1,6}\\}"
+        "value": "\\\\\\\\|\\\\\"|\\\\\\/|\\\\b|\\\\f|\\\\n|\\\\r|\\\\t|\\\\s|\\\\u\\{[0-9a-fA-F]{1,6}\\}"
+      }
+    },
+    "escaped_whitespace": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "\\\\(?:\\r\\n|[\\u0009\\u0020\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000\\r\\n\\u0085\\u000B\\u000C\\u2028\\u2029])+"
       }
     },
     "_hex_digit": {
@@ -789,6 +864,10 @@
     "number": {
       "type": "CHOICE",
       "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_number"
+        },
         {
           "type": "SYMBOL",
           "name": "_decimal"
@@ -1083,6 +1162,23 @@
         }
       ]
     },
+    "keyword_number": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#inf"
+        },
+        {
+          "type": "STRING",
+          "value": "#-inf"
+        },
+        {
+          "type": "STRING",
+          "value": "#nan"
+        }
+      ]
+    },
     "boolean": {
       "type": "CHOICE",
       "members": [
@@ -1093,6 +1189,14 @@
         {
           "type": "STRING",
           "value": "false"
+        },
+        {
+          "type": "STRING",
+          "value": "#true"
+        },
+        {
+          "type": "STRING",
+          "value": "#false"
         }
       ]
     },
@@ -1147,7 +1251,11 @@
       "members": [
         {
           "type": "PATTERN",
-          "value": "\\r'"
+          "value": "\\r\\n"
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\r"
         },
         {
           "type": "PATTERN",
@@ -1155,11 +1263,11 @@
         },
         {
           "type": "PATTERN",
-          "value": "\\r\\n"
+          "value": "\\u0085"
         },
         {
           "type": "PATTERN",
-          "value": "\\u0085"
+          "value": "\\u000B"
         },
         {
           "type": "PATTERN",
@@ -1211,7 +1319,7 @@
           "type": "REPEAT",
           "content": {
             "type": "PATTERN",
-            "value": "[^\\r\\n\\u0085\\u000C\\u2028\\u2029]"
+            "value": "[^\\r\\n\\u0085\\u000B\\u000C\\u2028\\u2029]"
           }
         },
         {
@@ -1245,6 +1353,10 @@
     ],
     [
       "node_children"
+    ],
+    [
+      "identifier",
+      "value"
     ]
   ],
   "precedences": [],
@@ -1259,9 +1371,14 @@
     },
     {
       "type": "SYMBOL",
+      "name": "multi_line_string"
+    },
+    {
+      "type": "SYMBOL",
       "name": "_raw_string"
     }
   ],
   "inline": [],
   "supertypes": []
 }
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -73,6 +73,11 @@
     }
   },
   {
+    "type": "keyword_number",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "node",
     "named": true,
     "fields": {
@@ -229,6 +234,10 @@
         {
           "type": "exponent",
           "named": true
+        },
+        {
+          "type": "keyword_number",
+          "named": true
         }
       ]
     }
@@ -243,6 +252,14 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "multi_line_comment",
+          "named": true
+        },
+        {
+          "type": "single_line_comment",
           "named": true
         },
         {
@@ -266,6 +283,10 @@
       "required": false,
       "types": [
         {
+          "type": "multi_line_string",
+          "named": true
+        },
+        {
           "type": "string_fragment",
           "named": true
         }
@@ -283,6 +304,10 @@
         {
           "type": "escape",
           "named": true
+        },
+        {
+          "type": "escaped_whitespace",
+          "named": true
         }
       ]
     }
@@ -292,7 +317,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
@@ -301,6 +326,14 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "multi_line_comment",
+          "named": true
+        },
+        {
+          "type": "single_line_comment",
           "named": true
         }
       ]
@@ -319,7 +352,15 @@
           "named": true
         },
         {
+          "type": "multi_line_comment",
+          "named": true
+        },
+        {
           "type": "number",
+          "named": true
+        },
+        {
+          "type": "single_line_comment",
           "named": true
         },
         {
@@ -335,6 +376,30 @@
   },
   {
     "type": "\"",
+    "named": false
+  },
+  {
+    "type": "#-inf",
+    "named": false
+  },
+  {
+    "type": "#false",
+    "named": false
+  },
+  {
+    "type": "#inf",
+    "named": false
+  },
+  {
+    "type": "#nan",
+    "named": false
+  },
+  {
+    "type": "#null",
+    "named": false
+  },
+  {
+    "type": "#true",
     "named": false
   },
   {
@@ -458,6 +523,10 @@
     "named": true
   },
   {
+    "type": "escaped_whitespace",
+    "named": true
+  },
+  {
     "type": "f32",
     "named": false
   },
@@ -519,6 +588,10 @@
   },
   {
     "type": "multi_line_comment",
+    "named": true
+  },
+  {
+    "type": "multi_line_string",
     "named": true
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,21 +1,22 @@
-#include "tree_sitter/parser.h"
+#include <tree_sitter/parser.h>
 
 #if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 304
-#define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 127
+#define STATE_COUNT 369
+#define LARGE_STATE_COUNT 11
+#define SYMBOL_COUNT 137
 #define ALIAS_COUNT 4
-#define TOKEN_COUNT 84
-#define EXTERNAL_TOKEN_COUNT 3
+#define TOKEN_COUNT 93
+#define EXTERNAL_TOKEN_COUNT 4
 #define FIELD_COUNT 1
-#define MAX_ALIAS_SEQUENCE_LENGTH 10
-#define PRODUCTION_ID_COUNT 17
+#define MAX_ALIAS_SEQUENCE_LENGTH 11
+#define PRODUCTION_ID_COUNT 19
 
-enum ts_symbol_identifiers {
+enum {
   sym__normal_bare_identifier = 1,
   anon_sym_SLASH_DASH = 2,
   anon_sym_LBRACE = 3,
@@ -25,127 +26,137 @@ enum ts_symbol_identifiers {
   sym___identifier_char_no_digit = 7,
   sym___identifier_char_no_digit_sign = 8,
   anon_sym_null = 9,
-  anon_sym_i8 = 10,
-  anon_sym_i16 = 11,
-  anon_sym_i32 = 12,
-  anon_sym_i64 = 13,
-  anon_sym_u8 = 14,
-  anon_sym_u16 = 15,
-  anon_sym_u32 = 16,
-  anon_sym_u64 = 17,
-  anon_sym_isize = 18,
-  anon_sym_usize = 19,
-  anon_sym_f32 = 20,
-  anon_sym_f64 = 21,
-  anon_sym_decimal64 = 22,
-  anon_sym_decimal128 = 23,
-  anon_sym_date_DASHtime = 24,
-  anon_sym_time = 25,
-  anon_sym_date = 26,
-  anon_sym_duration = 27,
-  anon_sym_decimal = 28,
-  anon_sym_currency = 29,
-  anon_sym_country_DASH2 = 30,
-  anon_sym_country_DASH3 = 31,
-  anon_sym_country_DASHsubdivision = 32,
-  anon_sym_email = 33,
-  anon_sym_idn_DASHemail = 34,
-  anon_sym_hostname = 35,
-  anon_sym_idn_DASHhostname = 36,
-  anon_sym_ipv4 = 37,
-  anon_sym_ipv6 = 38,
-  anon_sym_url = 39,
-  anon_sym_url_DASHreference = 40,
-  anon_sym_irl = 41,
-  anon_sym_iri_DASHreference = 42,
-  anon_sym_url_DASHtemplate = 43,
-  anon_sym_uuid = 44,
-  anon_sym_regex = 45,
-  anon_sym_base64 = 46,
-  anon_sym_EQ = 47,
-  anon_sym_LPAREN = 48,
-  anon_sym_RPAREN = 49,
-  anon_sym_DQUOTE = 50,
-  aux_sym__escaped_string_token1 = 51,
-  sym_escape = 52,
-  sym__hex_digit = 53,
-  anon_sym_DOT = 54,
-  anon_sym_e = 55,
-  anon_sym_E = 56,
-  anon_sym__ = 57,
-  sym__digit = 58,
-  anon_sym_PLUS = 59,
-  anon_sym_DASH = 60,
-  anon_sym_0x = 61,
-  anon_sym_0o = 62,
-  aux_sym__octal_token1 = 63,
-  anon_sym_0b = 64,
-  anon_sym_0 = 65,
-  anon_sym_1 = 66,
-  anon_sym_true = 67,
-  anon_sym_false = 68,
-  anon_sym_BSLASH = 69,
-  aux_sym__newline_token1 = 70,
-  aux_sym__newline_token2 = 71,
-  aux_sym__newline_token3 = 72,
-  aux_sym__newline_token4 = 73,
-  aux_sym__newline_token5 = 74,
-  aux_sym__newline_token6 = 75,
-  aux_sym__newline_token7 = 76,
-  sym__bom = 77,
-  sym__unicode_space = 78,
-  anon_sym_SLASH_SLASH = 79,
-  aux_sym_single_line_comment_token1 = 80,
-  sym__eof = 81,
-  sym_multi_line_comment = 82,
-  sym__raw_string = 83,
-  sym_document = 84,
-  sym_node = 85,
-  sym_node_field = 86,
-  sym__node_field_comment = 87,
-  sym__node_field = 88,
-  sym_node_children = 89,
-  sym__node_space = 90,
-  sym__node_terminator = 91,
-  sym_identifier = 92,
-  sym__bare_identifier = 93,
-  sym_keyword = 94,
-  sym_annotation_type = 95,
-  sym_prop = 96,
-  sym_value = 97,
-  sym_type = 98,
-  sym_string = 99,
-  sym__escaped_string = 100,
-  sym_number = 101,
-  sym__decimal = 102,
-  sym__exponent = 103,
-  sym__integer = 104,
-  sym__sign = 105,
-  sym__hex = 106,
-  sym__octal = 107,
-  sym__binary = 108,
-  sym_boolean = 109,
-  sym__escline = 110,
-  sym__linespace = 111,
-  sym__newline = 112,
-  sym__ws = 113,
-  sym_single_line_comment = 114,
-  aux_sym_document_repeat1 = 115,
-  aux_sym_document_repeat2 = 116,
-  aux_sym_node_repeat1 = 117,
-  aux_sym_node_repeat2 = 118,
-  aux_sym_node_repeat3 = 119,
-  aux_sym__bare_identifier_repeat1 = 120,
-  aux_sym__escaped_string_repeat1 = 121,
-  aux_sym__integer_repeat1 = 122,
-  aux_sym__hex_repeat1 = 123,
-  aux_sym__octal_repeat1 = 124,
-  aux_sym__binary_repeat1 = 125,
-  aux_sym_single_line_comment_repeat1 = 126,
-  alias_sym_decimal = 127,
-  alias_sym_node_children_comment = 128,
-  alias_sym_node_field_comment = 129,
-  alias_sym_string_fragment = 130,
+  anon_sym_POUNDnull = 10,
+  anon_sym_i8 = 11,
+  anon_sym_i16 = 12,
+  anon_sym_i32 = 13,
+  anon_sym_i64 = 14,
+  anon_sym_u8 = 15,
+  anon_sym_u16 = 16,
+  anon_sym_u32 = 17,
+  anon_sym_u64 = 18,
+  anon_sym_isize = 19,
+  anon_sym_usize = 20,
+  anon_sym_f32 = 21,
+  anon_sym_f64 = 22,
+  anon_sym_decimal64 = 23,
+  anon_sym_decimal128 = 24,
+  anon_sym_date_DASHtime = 25,
+  anon_sym_time = 26,
+  anon_sym_date = 27,
+  anon_sym_duration = 28,
+  anon_sym_decimal = 29,
+  anon_sym_currency = 30,
+  anon_sym_country_DASH2 = 31,
+  anon_sym_country_DASH3 = 32,
+  anon_sym_country_DASHsubdivision = 33,
+  anon_sym_email = 34,
+  anon_sym_idn_DASHemail = 35,
+  anon_sym_hostname = 36,
+  anon_sym_idn_DASHhostname = 37,
+  anon_sym_ipv4 = 38,
+  anon_sym_ipv6 = 39,
+  anon_sym_url = 40,
+  anon_sym_url_DASHreference = 41,
+  anon_sym_irl = 42,
+  anon_sym_iri_DASHreference = 43,
+  anon_sym_url_DASHtemplate = 44,
+  anon_sym_uuid = 45,
+  anon_sym_regex = 46,
+  anon_sym_base64 = 47,
+  anon_sym_EQ = 48,
+  anon_sym_LPAREN = 49,
+  anon_sym_RPAREN = 50,
+  anon_sym_DQUOTE = 51,
+  aux_sym__escaped_string_token1 = 52,
+  sym_escape = 53,
+  sym_escaped_whitespace = 54,
+  sym__hex_digit = 55,
+  anon_sym_DOT = 56,
+  anon_sym_e = 57,
+  anon_sym_E = 58,
+  anon_sym__ = 59,
+  sym__digit = 60,
+  anon_sym_PLUS = 61,
+  anon_sym_DASH = 62,
+  anon_sym_0x = 63,
+  anon_sym_0o = 64,
+  aux_sym__octal_token1 = 65,
+  anon_sym_0b = 66,
+  anon_sym_0 = 67,
+  anon_sym_1 = 68,
+  anon_sym_POUNDinf = 69,
+  anon_sym_POUND_DASHinf = 70,
+  anon_sym_POUNDnan = 71,
+  anon_sym_true = 72,
+  anon_sym_false = 73,
+  anon_sym_POUNDtrue = 74,
+  anon_sym_POUNDfalse = 75,
+  anon_sym_BSLASH = 76,
+  aux_sym__newline_token1 = 77,
+  aux_sym__newline_token2 = 78,
+  aux_sym__newline_token3 = 79,
+  aux_sym__newline_token4 = 80,
+  aux_sym__newline_token5 = 81,
+  aux_sym__newline_token6 = 82,
+  aux_sym__newline_token7 = 83,
+  aux_sym__newline_token8 = 84,
+  sym__bom = 85,
+  sym__unicode_space = 86,
+  anon_sym_SLASH_SLASH = 87,
+  aux_sym_single_line_comment_token1 = 88,
+  sym__eof = 89,
+  sym_multi_line_comment = 90,
+  sym_multi_line_string = 91,
+  sym__raw_string = 92,
+  sym_document = 93,
+  sym_node = 94,
+  sym_node_field = 95,
+  sym__node_field_comment = 96,
+  sym__node_field = 97,
+  sym_node_children = 98,
+  sym__node_space = 99,
+  sym__node_terminator = 100,
+  sym_identifier = 101,
+  sym__bare_identifier = 102,
+  sym_keyword = 103,
+  sym_annotation_type = 104,
+  sym_prop = 105,
+  sym_value = 106,
+  sym_type = 107,
+  sym_string = 108,
+  sym__escaped_string = 109,
+  sym_number = 110,
+  sym__decimal = 111,
+  sym__exponent = 112,
+  sym__integer = 113,
+  sym__sign = 114,
+  sym__hex = 115,
+  sym__octal = 116,
+  sym__binary = 117,
+  sym_keyword_number = 118,
+  sym_boolean = 119,
+  sym__escline = 120,
+  sym__linespace = 121,
+  sym__newline = 122,
+  sym__ws = 123,
+  sym_single_line_comment = 124,
+  aux_sym_document_repeat1 = 125,
+  aux_sym_document_repeat2 = 126,
+  aux_sym_node_repeat1 = 127,
+  aux_sym_node_repeat2 = 128,
+  aux_sym_node_repeat3 = 129,
+  aux_sym__bare_identifier_repeat1 = 130,
+  aux_sym__escaped_string_repeat1 = 131,
+  aux_sym__integer_repeat1 = 132,
+  aux_sym__hex_repeat1 = 133,
+  aux_sym__octal_repeat1 = 134,
+  aux_sym__binary_repeat1 = 135,
+  aux_sym_single_line_comment_repeat1 = 136,
+  alias_sym_decimal = 137,
+  alias_sym_node_children_comment = 138,
+  alias_sym_node_field_comment = 139,
+  alias_sym_string_fragment = 140,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -159,6 +170,7 @@ static const char * const ts_symbol_names[] = {
   [sym___identifier_char_no_digit] = "__identifier_char_no_digit",
   [sym___identifier_char_no_digit_sign] = "__identifier_char_no_digit_sign",
   [anon_sym_null] = "null",
+  [anon_sym_POUNDnull] = "#null",
   [anon_sym_i8] = "i8",
   [anon_sym_i16] = "i16",
   [anon_sym_i32] = "i32",
@@ -202,6 +214,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_DQUOTE] = "\"",
   [aux_sym__escaped_string_token1] = "_escaped_string_token1",
   [sym_escape] = "escape",
+  [sym_escaped_whitespace] = "escaped_whitespace",
   [sym__hex_digit] = "_hex_digit",
   [anon_sym_DOT] = ".",
   [anon_sym_e] = "e",
@@ -216,8 +229,13 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_0b] = "0b",
   [anon_sym_0] = "0",
   [anon_sym_1] = "1",
+  [anon_sym_POUNDinf] = "#inf",
+  [anon_sym_POUND_DASHinf] = "#-inf",
+  [anon_sym_POUNDnan] = "#nan",
   [anon_sym_true] = "true",
   [anon_sym_false] = "false",
+  [anon_sym_POUNDtrue] = "#true",
+  [anon_sym_POUNDfalse] = "#false",
   [anon_sym_BSLASH] = "\\",
   [aux_sym__newline_token1] = "_newline_token1",
   [aux_sym__newline_token2] = "_newline_token2",
@@ -226,12 +244,14 @@ static const char * const ts_symbol_names[] = {
   [aux_sym__newline_token5] = "_newline_token5",
   [aux_sym__newline_token6] = "_newline_token6",
   [aux_sym__newline_token7] = "_newline_token7",
+  [aux_sym__newline_token8] = "_newline_token8",
   [sym__bom] = "_bom",
   [sym__unicode_space] = "_unicode_space",
   [anon_sym_SLASH_SLASH] = "//",
   [aux_sym_single_line_comment_token1] = "single_line_comment_token1",
   [sym__eof] = "_eof",
   [sym_multi_line_comment] = "multi_line_comment",
+  [sym_multi_line_string] = "multi_line_string",
   [sym__raw_string] = "_raw_string",
   [sym_document] = "document",
   [sym_node] = "node",
@@ -258,6 +278,7 @@ static const char * const ts_symbol_names[] = {
   [sym__hex] = "_hex",
   [sym__octal] = "_octal",
   [sym__binary] = "_binary",
+  [sym_keyword_number] = "keyword_number",
   [sym_boolean] = "boolean",
   [sym__escline] = "_escline",
   [sym__linespace] = "_linespace",
@@ -293,6 +314,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym___identifier_char_no_digit] = sym___identifier_char_no_digit,
   [sym___identifier_char_no_digit_sign] = sym___identifier_char_no_digit_sign,
   [anon_sym_null] = anon_sym_null,
+  [anon_sym_POUNDnull] = anon_sym_POUNDnull,
   [anon_sym_i8] = anon_sym_i8,
   [anon_sym_i16] = anon_sym_i16,
   [anon_sym_i32] = anon_sym_i32,
@@ -336,6 +358,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_DQUOTE] = anon_sym_DQUOTE,
   [aux_sym__escaped_string_token1] = aux_sym__escaped_string_token1,
   [sym_escape] = sym_escape,
+  [sym_escaped_whitespace] = sym_escaped_whitespace,
   [sym__hex_digit] = sym__hex_digit,
   [anon_sym_DOT] = anon_sym_DOT,
   [anon_sym_e] = anon_sym_e,
@@ -350,8 +373,13 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_0b] = anon_sym_0b,
   [anon_sym_0] = anon_sym_0,
   [anon_sym_1] = anon_sym_1,
+  [anon_sym_POUNDinf] = anon_sym_POUNDinf,
+  [anon_sym_POUND_DASHinf] = anon_sym_POUND_DASHinf,
+  [anon_sym_POUNDnan] = anon_sym_POUNDnan,
   [anon_sym_true] = anon_sym_true,
   [anon_sym_false] = anon_sym_false,
+  [anon_sym_POUNDtrue] = anon_sym_POUNDtrue,
+  [anon_sym_POUNDfalse] = anon_sym_POUNDfalse,
   [anon_sym_BSLASH] = anon_sym_BSLASH,
   [aux_sym__newline_token1] = aux_sym__newline_token1,
   [aux_sym__newline_token2] = aux_sym__newline_token2,
@@ -360,12 +388,14 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym__newline_token5] = aux_sym__newline_token5,
   [aux_sym__newline_token6] = aux_sym__newline_token6,
   [aux_sym__newline_token7] = aux_sym__newline_token7,
+  [aux_sym__newline_token8] = aux_sym__newline_token8,
   [sym__bom] = sym__bom,
   [sym__unicode_space] = sym__unicode_space,
   [anon_sym_SLASH_SLASH] = anon_sym_SLASH_SLASH,
   [aux_sym_single_line_comment_token1] = aux_sym_single_line_comment_token1,
   [sym__eof] = sym__eof,
   [sym_multi_line_comment] = sym_multi_line_comment,
+  [sym_multi_line_string] = sym_multi_line_string,
   [sym__raw_string] = sym__raw_string,
   [sym_document] = sym_document,
   [sym_node] = sym_node,
@@ -392,6 +422,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym__hex] = sym__hex,
   [sym__octal] = sym__octal,
   [sym__binary] = sym__binary,
+  [sym_keyword_number] = sym_keyword_number,
   [sym_boolean] = sym_boolean,
   [sym__escline] = sym__escline,
   [sym__linespace] = sym__linespace,
@@ -454,6 +485,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [anon_sym_null] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUNDnull] = {
     .visible = true,
     .named = false,
   },
@@ -629,6 +664,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_escaped_whitespace] = {
+    .visible = true,
+    .named = true,
+  },
   [sym__hex_digit] = {
     .visible = false,
     .named = true,
@@ -685,11 +724,31 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_POUNDinf] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUND_DASHinf] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUNDnan] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_true] = {
     .visible = true,
     .named = false,
   },
   [anon_sym_false] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUNDtrue] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUNDfalse] = {
     .visible = true,
     .named = false,
   },
@@ -725,6 +784,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym__newline_token8] = {
+    .visible = false,
+    .named = false,
+  },
   [sym__bom] = {
     .visible = false,
     .named = true,
@@ -746,6 +809,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [sym_multi_line_comment] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_multi_line_string] = {
     .visible = true,
     .named = true,
   },
@@ -853,6 +920,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = true,
   },
+  [sym_keyword_number] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_boolean] = {
     .visible = true,
     .named = true,
@@ -943,7 +1014,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
 };
 
-enum ts_field_identifiers {
+enum {
   field_children = 1,
 };
 
@@ -962,6 +1033,8 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [14] = {.index = 4, .length = 1},
   [15] = {.index = 4, .length = 1},
   [16] = {.index = 5, .length = 1},
+  [17] = {.index = 5, .length = 1},
+  [18] = {.index = 6, .length = 1},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -977,6 +1050,8 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_children, 5},
   [5] =
     {field_children, 6},
+  [6] =
+    {field_children, 7},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -1014,7 +1089,10 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
   [15] = {
     [1] = anon_sym_SLASH_DASH,
   },
-  [16] = {
+  [17] = {
+    [1] = anon_sym_SLASH_DASH,
+  },
+  [18] = {
     [1] = anon_sym_SLASH_DASH,
   },
 };
@@ -1052,8 +1130,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [12] = 12,
   [13] = 13,
   [14] = 14,
-  [15] = 15,
-  [16] = 16,
+  [15] = 14,
+  [16] = 13,
   [17] = 17,
   [18] = 18,
   [19] = 19,
@@ -1069,24 +1147,24 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [29] = 29,
   [30] = 30,
   [31] = 31,
-  [32] = 32,
+  [32] = 17,
   [33] = 33,
   [34] = 34,
   [35] = 35,
   [36] = 36,
-  [37] = 37,
-  [38] = 38,
+  [37] = 18,
+  [38] = 23,
   [39] = 39,
-  [40] = 40,
-  [41] = 41,
-  [42] = 42,
-  [43] = 43,
+  [40] = 24,
+  [41] = 19,
+  [42] = 21,
+  [43] = 20,
   [44] = 44,
-  [45] = 45,
-  [46] = 46,
-  [47] = 47,
-  [48] = 48,
-  [49] = 49,
+  [45] = 11,
+  [46] = 28,
+  [47] = 29,
+  [48] = 26,
+  [49] = 12,
   [50] = 50,
   [51] = 51,
   [52] = 52,
@@ -1096,9 +1174,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [56] = 56,
   [57] = 57,
   [58] = 58,
-  [59] = 55,
+  [59] = 59,
   [60] = 60,
-  [61] = 60,
+  [61] = 61,
   [62] = 62,
   [63] = 63,
   [64] = 64,
@@ -1111,7 +1189,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [71] = 71,
   [72] = 72,
   [73] = 73,
-  [74] = 15,
+  [74] = 74,
   [75] = 75,
   [76] = 76,
   [77] = 77,
@@ -1120,13 +1198,13 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [80] = 80,
   [81] = 81,
   [82] = 82,
-  [83] = 83,
-  [84] = 84,
-  [85] = 85,
-  [86] = 86,
-  [87] = 87,
-  [88] = 88,
-  [89] = 89,
+  [83] = 17,
+  [84] = 18,
+  [85] = 21,
+  [86] = 23,
+  [87] = 24,
+  [88] = 19,
+  [89] = 20,
   [90] = 90,
   [91] = 91,
   [92] = 92,
@@ -1137,18 +1215,18 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [97] = 97,
   [98] = 98,
   [99] = 99,
-  [100] = 27,
+  [100] = 100,
   [101] = 101,
   [102] = 102,
   [103] = 103,
   [104] = 104,
-  [105] = 105,
+  [105] = 26,
   [106] = 106,
-  [107] = 107,
-  [108] = 108,
-  [109] = 109,
+  [107] = 29,
+  [108] = 28,
+  [109] = 11,
   [110] = 110,
-  [111] = 111,
+  [111] = 12,
   [112] = 112,
   [113] = 113,
   [114] = 114,
@@ -1158,12 +1236,12 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [118] = 118,
   [119] = 119,
   [120] = 120,
-  [121] = 39,
-  [122] = 53,
-  [123] = 38,
+  [121] = 121,
+  [122] = 122,
+  [123] = 123,
   [124] = 124,
-  [125] = 34,
-  [126] = 49,
+  [125] = 125,
+  [126] = 126,
   [127] = 127,
   [128] = 128,
   [129] = 129,
@@ -1216,21 +1294,21 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [176] = 176,
   [177] = 177,
   [178] = 178,
-  [179] = 57,
+  [179] = 179,
   [180] = 180,
   [181] = 181,
   [182] = 182,
-  [183] = 56,
+  [183] = 183,
   [184] = 184,
   [185] = 185,
-  [186] = 58,
-  [187] = 15,
+  [186] = 186,
+  [187] = 187,
   [188] = 188,
   [189] = 189,
   [190] = 190,
   [191] = 191,
   [192] = 192,
-  [193] = 27,
+  [193] = 193,
   [194] = 194,
   [195] = 195,
   [196] = 196,
@@ -1238,18 +1316,18 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [198] = 198,
   [199] = 199,
   [200] = 200,
-  [201] = 38,
+  [201] = 201,
   [202] = 202,
   [203] = 203,
   [204] = 204,
-  [205] = 49,
-  [206] = 39,
-  [207] = 53,
+  [205] = 205,
+  [206] = 206,
+  [207] = 207,
   [208] = 208,
   [209] = 209,
   [210] = 210,
   [211] = 211,
-  [212] = 34,
+  [212] = 212,
   [213] = 213,
   [214] = 214,
   [215] = 215,
@@ -1261,369 +1339,5774 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [221] = 221,
   [222] = 222,
   [223] = 223,
-  [224] = 223,
-  [225] = 223,
-  [226] = 223,
+  [224] = 224,
+  [225] = 225,
+  [226] = 226,
   [227] = 227,
-  [228] = 227,
-  [229] = 227,
-  [230] = 49,
-  [231] = 227,
+  [228] = 228,
+  [229] = 229,
+  [230] = 230,
+  [231] = 231,
   [232] = 232,
-  [233] = 233,
-  [234] = 58,
+  [233] = 17,
+  [234] = 234,
   [235] = 235,
-  [236] = 57,
-  [237] = 55,
+  [236] = 236,
+  [237] = 237,
   [238] = 238,
   [239] = 239,
   [240] = 240,
   [241] = 241,
-  [242] = 242,
+  [242] = 23,
   [243] = 243,
-  [244] = 60,
+  [244] = 244,
   [245] = 245,
-  [246] = 56,
+  [246] = 246,
   [247] = 247,
-  [248] = 248,
-  [249] = 249,
+  [248] = 18,
+  [249] = 24,
   [250] = 250,
-  [251] = 250,
-  [252] = 249,
-  [253] = 249,
-  [254] = 250,
-  [255] = 250,
-  [256] = 249,
+  [251] = 251,
+  [252] = 252,
+  [253] = 253,
+  [254] = 254,
+  [255] = 255,
+  [256] = 256,
   [257] = 257,
   [258] = 258,
   [259] = 259,
   [260] = 260,
   [261] = 261,
-  [262] = 15,
+  [262] = 262,
   [263] = 263,
-  [264] = 264,
-  [265] = 27,
-  [266] = 38,
-  [267] = 39,
-  [268] = 53,
-  [269] = 34,
-  [270] = 270,
-  [271] = 271,
-  [272] = 55,
+  [264] = 19,
+  [265] = 265,
+  [266] = 266,
+  [267] = 20,
+  [268] = 268,
+  [269] = 269,
+  [270] = 23,
+  [271] = 21,
+  [272] = 272,
   [273] = 273,
-  [274] = 60,
-  [275] = 58,
-  [276] = 56,
+  [274] = 274,
+  [275] = 275,
+  [276] = 276,
   [277] = 277,
-  [278] = 189,
-  [279] = 188,
-  [280] = 273,
-  [281] = 57,
-  [282] = 277,
-  [283] = 283,
-  [284] = 190,
-  [285] = 285,
-  [286] = 286,
-  [287] = 287,
+  [278] = 278,
+  [279] = 279,
+  [280] = 279,
+  [281] = 278,
+  [282] = 279,
+  [283] = 278,
+  [284] = 278,
+  [285] = 279,
+  [286] = 278,
+  [287] = 279,
   [288] = 288,
   [289] = 289,
-  [290] = 218,
+  [290] = 290,
   [291] = 291,
-  [292] = 192,
-  [293] = 197,
-  [294] = 196,
+  [292] = 292,
+  [293] = 293,
+  [294] = 294,
   [295] = 295,
-  [296] = 194,
-  [297] = 297,
-  [298] = 298,
-  [299] = 299,
-  [300] = 300,
-  [301] = 301,
+  [296] = 296,
+  [297] = 29,
+  [298] = 12,
+  [299] = 26,
+  [300] = 28,
+  [301] = 11,
   [302] = 302,
   [303] = 303,
+  [304] = 304,
+  [305] = 304,
+  [306] = 304,
+  [307] = 307,
+  [308] = 307,
+  [309] = 304,
+  [310] = 307,
+  [311] = 304,
+  [312] = 307,
+  [313] = 307,
+  [314] = 314,
+  [315] = 17,
+  [316] = 316,
+  [317] = 190,
+  [318] = 318,
+  [319] = 319,
+  [320] = 320,
+  [321] = 18,
+  [322] = 322,
+  [323] = 319,
+  [324] = 194,
+  [325] = 325,
+  [326] = 209,
+  [327] = 327,
+  [328] = 318,
+  [329] = 329,
+  [330] = 329,
+  [331] = 325,
+  [332] = 332,
+  [333] = 21,
+  [334] = 24,
+  [335] = 19,
+  [336] = 20,
+  [337] = 239,
+  [338] = 238,
+  [339] = 240,
+  [340] = 28,
+  [341] = 11,
+  [342] = 26,
+  [343] = 12,
+  [344] = 29,
+  [345] = 345,
+  [346] = 346,
+  [347] = 346,
+  [348] = 243,
+  [349] = 349,
+  [350] = 349,
+  [351] = 268,
+  [352] = 352,
+  [353] = 353,
+  [354] = 247,
+  [355] = 241,
+  [356] = 356,
+  [357] = 245,
+  [358] = 358,
+  [359] = 359,
+  [360] = 360,
+  [361] = 361,
+  [362] = 362,
+  [363] = 363,
+  [364] = 364,
+  [365] = 365,
+  [366] = 366,
+  [367] = 367,
+  [368] = 368,
 };
 
-static TSCharacterRange sym__normal_bare_identifier_character_set_2[] = {
-  {'!', '!'}, {'#', '\''}, {'*', '+'}, {'-', '.'}, {'0', ':'}, {'?', 'Z'}, {'^', '_'}, {'a', 'z'},
-  {'|', '|'}, {'~', '~'}, {0xa9, 0xaa}, {0xae, 0xae}, {0xb2, 0xb3}, {0xb5, 0xb5}, {0xb9, 0xba}, {0xbc, 0xbe},
-  {0xc0, 0xd6}, {0xd8, 0xf6}, {0xf8, 0x2c1}, {0x2c6, 0x2d1}, {0x2e0, 0x2e4}, {0x2ec, 0x2ec}, {0x2ee, 0x2ee}, {0x300, 0x374},
-  {0x376, 0x377}, {0x37a, 0x37d}, {0x37f, 0x37f}, {0x386, 0x386}, {0x388, 0x38a}, {0x38c, 0x38c}, {0x38e, 0x3a1}, {0x3a3, 0x3f5},
-  {0x3f7, 0x481}, {0x483, 0x52f}, {0x531, 0x556}, {0x559, 0x559}, {0x560, 0x588}, {0x591, 0x5bd}, {0x5bf, 0x5bf}, {0x5c1, 0x5c2},
-  {0x5c4, 0x5c5}, {0x5c7, 0x5c7}, {0x5d0, 0x5ea}, {0x5ef, 0x5f2}, {0x610, 0x61a}, {0x620, 0x669}, {0x66e, 0x6d3}, {0x6d5, 0x6dc},
-  {0x6df, 0x6e8}, {0x6ea, 0x6fc}, {0x6ff, 0x6ff}, {0x710, 0x74a}, {0x74d, 0x7b1}, {0x7c0, 0x7f5}, {0x7fa, 0x7fa}, {0x7fd, 0x7fd},
-  {0x800, 0x82d}, {0x840, 0x85b}, {0x860, 0x86a}, {0x870, 0x887}, {0x889, 0x88e}, {0x898, 0x8e1}, {0x8e3, 0x963}, {0x966, 0x96f},
-  {0x971, 0x983}, {0x985, 0x98c}, {0x98f, 0x990}, {0x993, 0x9a8}, {0x9aa, 0x9b0}, {0x9b2, 0x9b2}, {0x9b6, 0x9b9}, {0x9bc, 0x9c4},
-  {0x9c7, 0x9c8}, {0x9cb, 0x9ce}, {0x9d7, 0x9d7}, {0x9dc, 0x9dd}, {0x9df, 0x9e3}, {0x9e6, 0x9f1}, {0x9f4, 0x9f9}, {0x9fc, 0x9fc},
-  {0x9fe, 0x9fe}, {0xa01, 0xa03}, {0xa05, 0xa0a}, {0xa0f, 0xa10}, {0xa13, 0xa28}, {0xa2a, 0xa30}, {0xa32, 0xa33}, {0xa35, 0xa36},
-  {0xa38, 0xa39}, {0xa3c, 0xa3c}, {0xa3e, 0xa42}, {0xa47, 0xa48}, {0xa4b, 0xa4d}, {0xa51, 0xa51}, {0xa59, 0xa5c}, {0xa5e, 0xa5e},
-  {0xa66, 0xa75}, {0xa81, 0xa83}, {0xa85, 0xa8d}, {0xa8f, 0xa91}, {0xa93, 0xaa8}, {0xaaa, 0xab0}, {0xab2, 0xab3}, {0xab5, 0xab9},
-  {0xabc, 0xac5}, {0xac7, 0xac9}, {0xacb, 0xacd}, {0xad0, 0xad0}, {0xae0, 0xae3}, {0xae6, 0xaef}, {0xaf9, 0xaff}, {0xb01, 0xb03},
-  {0xb05, 0xb0c}, {0xb0f, 0xb10}, {0xb13, 0xb28}, {0xb2a, 0xb30}, {0xb32, 0xb33}, {0xb35, 0xb39}, {0xb3c, 0xb44}, {0xb47, 0xb48},
-  {0xb4b, 0xb4d}, {0xb55, 0xb57}, {0xb5c, 0xb5d}, {0xb5f, 0xb63}, {0xb66, 0xb6f}, {0xb71, 0xb77}, {0xb82, 0xb83}, {0xb85, 0xb8a},
-  {0xb8e, 0xb90}, {0xb92, 0xb95}, {0xb99, 0xb9a}, {0xb9c, 0xb9c}, {0xb9e, 0xb9f}, {0xba3, 0xba4}, {0xba8, 0xbaa}, {0xbae, 0xbb9},
-  {0xbbe, 0xbc2}, {0xbc6, 0xbc8}, {0xbca, 0xbcd}, {0xbd0, 0xbd0}, {0xbd7, 0xbd7}, {0xbe6, 0xbf2}, {0xc00, 0xc0c}, {0xc0e, 0xc10},
-  {0xc12, 0xc28}, {0xc2a, 0xc39}, {0xc3c, 0xc44}, {0xc46, 0xc48}, {0xc4a, 0xc4d}, {0xc55, 0xc56}, {0xc58, 0xc5a}, {0xc5d, 0xc5d},
-  {0xc60, 0xc63}, {0xc66, 0xc6f}, {0xc78, 0xc7e}, {0xc80, 0xc83}, {0xc85, 0xc8c}, {0xc8e, 0xc90}, {0xc92, 0xca8}, {0xcaa, 0xcb3},
-  {0xcb5, 0xcb9}, {0xcbc, 0xcc4}, {0xcc6, 0xcc8}, {0xcca, 0xccd}, {0xcd5, 0xcd6}, {0xcdd, 0xcde}, {0xce0, 0xce3}, {0xce6, 0xcef},
-  {0xcf1, 0xcf3}, {0xd00, 0xd0c}, {0xd0e, 0xd10}, {0xd12, 0xd44}, {0xd46, 0xd48}, {0xd4a, 0xd4e}, {0xd54, 0xd63}, {0xd66, 0xd78},
-  {0xd7a, 0xd7f}, {0xd81, 0xd83}, {0xd85, 0xd96}, {0xd9a, 0xdb1}, {0xdb3, 0xdbb}, {0xdbd, 0xdbd}, {0xdc0, 0xdc6}, {0xdca, 0xdca},
-  {0xdcf, 0xdd4}, {0xdd6, 0xdd6}, {0xdd8, 0xddf}, {0xde6, 0xdef}, {0xdf2, 0xdf3}, {0xe01, 0xe3a}, {0xe40, 0xe4e}, {0xe50, 0xe59},
-  {0xe81, 0xe82}, {0xe84, 0xe84}, {0xe86, 0xe8a}, {0xe8c, 0xea3}, {0xea5, 0xea5}, {0xea7, 0xebd}, {0xec0, 0xec4}, {0xec6, 0xec6},
-  {0xec8, 0xece}, {0xed0, 0xed9}, {0xedc, 0xedf}, {0xf00, 0xf00}, {0xf18, 0xf19}, {0xf20, 0xf33}, {0xf35, 0xf35}, {0xf37, 0xf37},
-  {0xf39, 0xf39}, {0xf3e, 0xf47}, {0xf49, 0xf6c}, {0xf71, 0xf84}, {0xf86, 0xf97}, {0xf99, 0xfbc}, {0xfc6, 0xfc6}, {0x1000, 0x1049},
-  {0x1050, 0x109d}, {0x10a0, 0x10c5}, {0x10c7, 0x10c7}, {0x10cd, 0x10cd}, {0x10d0, 0x10fa}, {0x10fc, 0x1248}, {0x124a, 0x124d}, {0x1250, 0x1256},
-  {0x1258, 0x1258}, {0x125a, 0x125d}, {0x1260, 0x1288}, {0x128a, 0x128d}, {0x1290, 0x12b0}, {0x12b2, 0x12b5}, {0x12b8, 0x12be}, {0x12c0, 0x12c0},
-  {0x12c2, 0x12c5}, {0x12c8, 0x12d6}, {0x12d8, 0x1310}, {0x1312, 0x1315}, {0x1318, 0x135a}, {0x135d, 0x135f}, {0x1369, 0x137c}, {0x1380, 0x138f},
-  {0x13a0, 0x13f5}, {0x13f8, 0x13fd}, {0x1401, 0x166c}, {0x166f, 0x167f}, {0x1681, 0x169a}, {0x16a0, 0x16ea}, {0x16ee, 0x16f8}, {0x1700, 0x1715},
-  {0x171f, 0x1734}, {0x1740, 0x1753}, {0x1760, 0x176c}, {0x176e, 0x1770}, {0x1772, 0x1773}, {0x1780, 0x17d3}, {0x17d7, 0x17d7}, {0x17dc, 0x17dd},
-  {0x17e0, 0x17e9}, {0x17f0, 0x17f9}, {0x180b, 0x180d}, {0x180f, 0x1819}, {0x1820, 0x1878}, {0x1880, 0x18aa}, {0x18b0, 0x18f5}, {0x1900, 0x191e},
-  {0x1920, 0x192b}, {0x1930, 0x193b}, {0x1946, 0x196d}, {0x1970, 0x1974}, {0x1980, 0x19ab}, {0x19b0, 0x19c9}, {0x19d0, 0x19da}, {0x1a00, 0x1a1b},
-  {0x1a20, 0x1a5e}, {0x1a60, 0x1a7c}, {0x1a7f, 0x1a89}, {0x1a90, 0x1a99}, {0x1aa7, 0x1aa7}, {0x1ab0, 0x1ace}, {0x1b00, 0x1b4c}, {0x1b50, 0x1b59},
-  {0x1b6b, 0x1b73}, {0x1b80, 0x1bf3}, {0x1c00, 0x1c37}, {0x1c40, 0x1c49}, {0x1c4d, 0x1c7d}, {0x1c80, 0x1c88}, {0x1c90, 0x1cba}, {0x1cbd, 0x1cbf},
-  {0x1cd0, 0x1cd2}, {0x1cd4, 0x1cfa}, {0x1d00, 0x1f15}, {0x1f18, 0x1f1d}, {0x1f20, 0x1f45}, {0x1f48, 0x1f4d}, {0x1f50, 0x1f57}, {0x1f59, 0x1f59},
-  {0x1f5b, 0x1f5b}, {0x1f5d, 0x1f5d}, {0x1f5f, 0x1f7d}, {0x1f80, 0x1fb4}, {0x1fb6, 0x1fbc}, {0x1fbe, 0x1fbe}, {0x1fc2, 0x1fc4}, {0x1fc6, 0x1fcc},
-  {0x1fd0, 0x1fd3}, {0x1fd6, 0x1fdb}, {0x1fe0, 0x1fec}, {0x1ff2, 0x1ff4}, {0x1ff6, 0x1ffc}, {0x203c, 0x203c}, {0x2049, 0x2049}, {0x2070, 0x2071},
-  {0x2074, 0x2079}, {0x207f, 0x2089}, {0x2090, 0x209c}, {0x20d0, 0x20f0}, {0x2102, 0x2102}, {0x2107, 0x2107}, {0x210a, 0x2113}, {0x2115, 0x2115},
-  {0x2119, 0x211d}, {0x2122, 0x2122}, {0x2124, 0x2124}, {0x2126, 0x2126}, {0x2128, 0x2128}, {0x212a, 0x212d}, {0x212f, 0x2139}, {0x213c, 0x213f},
-  {0x2145, 0x2149}, {0x214e, 0x214e}, {0x2150, 0x2189}, {0x2194, 0x2199}, {0x21a9, 0x21aa}, {0x231a, 0x231b}, {0x2328, 0x2328}, {0x23cf, 0x23cf},
-  {0x23e9, 0x23f3}, {0x23f8, 0x23fa}, {0x2460, 0x249b}, {0x24c2, 0x24c2}, {0x24ea, 0x24ff}, {0x25aa, 0x25ab}, {0x25b6, 0x25b6}, {0x25c0, 0x25c0},
-  {0x25fb, 0x25fe}, {0x2600, 0x2604}, {0x260e, 0x260e}, {0x2611, 0x2611}, {0x2614, 0x2615}, {0x2618, 0x2618}, {0x261d, 0x261d}, {0x2620, 0x2620},
-  {0x2622, 0x2623}, {0x2626, 0x2626}, {0x262a, 0x262a}, {0x262e, 0x262f}, {0x2638, 0x263a}, {0x2640, 0x2640}, {0x2642, 0x2642}, {0x2648, 0x2653},
-  {0x265f, 0x2660}, {0x2663, 0x2663}, {0x2665, 0x2666}, {0x2668, 0x2668}, {0x267b, 0x267b}, {0x267e, 0x267f}, {0x2692, 0x2697}, {0x2699, 0x2699},
-  {0x269b, 0x269c}, {0x26a0, 0x26a1}, {0x26a7, 0x26a7}, {0x26aa, 0x26ab}, {0x26b0, 0x26b1}, {0x26bd, 0x26be}, {0x26c4, 0x26c5}, {0x26c8, 0x26c8},
-  {0x26ce, 0x26cf}, {0x26d1, 0x26d1}, {0x26d3, 0x26d4}, {0x26e9, 0x26ea}, {0x26f0, 0x26f5}, {0x26f7, 0x26fa}, {0x26fd, 0x26fd}, {0x2702, 0x2702},
-  {0x2705, 0x2705}, {0x2708, 0x270d}, {0x270f, 0x270f}, {0x2712, 0x2712}, {0x2714, 0x2714}, {0x2716, 0x2716}, {0x271d, 0x271d}, {0x2721, 0x2721},
-  {0x2728, 0x2728}, {0x2733, 0x2734}, {0x2744, 0x2744}, {0x2747, 0x2747}, {0x274c, 0x274c}, {0x274e, 0x274e}, {0x2753, 0x2755}, {0x2757, 0x2757},
-  {0x2763, 0x2764}, {0x2776, 0x2793}, {0x2795, 0x2797}, {0x27a1, 0x27a1}, {0x27b0, 0x27b0}, {0x27bf, 0x27bf}, {0x2934, 0x2935}, {0x2b05, 0x2b07},
-  {0x2b1b, 0x2b1c}, {0x2b50, 0x2b50}, {0x2b55, 0x2b55}, {0x2c00, 0x2ce4}, {0x2ceb, 0x2cf3}, {0x2cfd, 0x2cfd}, {0x2d00, 0x2d25}, {0x2d27, 0x2d27},
-  {0x2d2d, 0x2d2d}, {0x2d30, 0x2d67}, {0x2d6f, 0x2d6f}, {0x2d7f, 0x2d96}, {0x2da0, 0x2da6}, {0x2da8, 0x2dae}, {0x2db0, 0x2db6}, {0x2db8, 0x2dbe},
-  {0x2dc0, 0x2dc6}, {0x2dc8, 0x2dce}, {0x2dd0, 0x2dd6}, {0x2dd8, 0x2dde}, {0x2de0, 0x2dff}, {0x2e2f, 0x2e2f}, {0x3005, 0x3007}, {0x3021, 0x3035},
-  {0x3038, 0x303d}, {0x3041, 0x3096}, {0x3099, 0x309a}, {0x309d, 0x309f}, {0x30a1, 0x30fa}, {0x30fc, 0x30ff}, {0x3105, 0x312f}, {0x3131, 0x318e},
-  {0x3192, 0x3195}, {0x31a0, 0x31bf}, {0x31f0, 0x31ff}, {0x3220, 0x3229}, {0x3248, 0x324f}, {0x3251, 0x325f}, {0x3280, 0x3289}, {0x3297, 0x3297},
-  {0x3299, 0x3299}, {0x32b1, 0x32bf}, {0x3400, 0x3400}, {0x4dbf, 0x4dbf}, {0x4e00, 0xa48c}, {0xa4d0, 0xa4fd}, {0xa500, 0xa60c}, {0xa610, 0xa62b},
-  {0xa640, 0xa672}, {0xa674, 0xa67d}, {0xa67f, 0xa6f1}, {0xa717, 0xa71f}, {0xa722, 0xa788}, {0xa78b, 0xa7ca}, {0xa7d0, 0xa7d1}, {0xa7d3, 0xa7d3},
-  {0xa7d5, 0xa7d9}, {0xa7f2, 0xa827}, {0xa82c, 0xa82c}, {0xa830, 0xa835}, {0xa840, 0xa873}, {0xa880, 0xa8c5}, {0xa8d0, 0xa8d9}, {0xa8e0, 0xa8f7},
-  {0xa8fb, 0xa8fb}, {0xa8fd, 0xa92d}, {0xa930, 0xa953}, {0xa960, 0xa97c}, {0xa980, 0xa9c0}, {0xa9cf, 0xa9d9}, {0xa9e0, 0xa9fe}, {0xaa00, 0xaa36},
-  {0xaa40, 0xaa4d}, {0xaa50, 0xaa59}, {0xaa60, 0xaa76}, {0xaa7a, 0xaac2}, {0xaadb, 0xaadd}, {0xaae0, 0xaaef}, {0xaaf2, 0xaaf6}, {0xab01, 0xab06},
-  {0xab09, 0xab0e}, {0xab11, 0xab16}, {0xab20, 0xab26}, {0xab28, 0xab2e}, {0xab30, 0xab5a}, {0xab5c, 0xab69}, {0xab70, 0xabea}, {0xabec, 0xabed},
-  {0xabf0, 0xabf9}, {0xac00, 0xac00}, {0xd7a3, 0xd7a3}, {0xd7b0, 0xd7c6}, {0xd7cb, 0xd7fb}, {0xf900, 0xfa6d}, {0xfa70, 0xfad9}, {0xfb00, 0xfb06},
-  {0xfb13, 0xfb17}, {0xfb1d, 0xfb28}, {0xfb2a, 0xfb36}, {0xfb38, 0xfb3c}, {0xfb3e, 0xfb3e}, {0xfb40, 0xfb41}, {0xfb43, 0xfb44}, {0xfb46, 0xfbb1},
-  {0xfbd3, 0xfd3d}, {0xfd50, 0xfd8f}, {0xfd92, 0xfdc7}, {0xfdf0, 0xfdfb}, {0xfe00, 0xfe0f}, {0xfe20, 0xfe2f}, {0xfe70, 0xfe74}, {0xfe76, 0xfefc},
-  {0xff10, 0xff19}, {0xff21, 0xff3a}, {0xff41, 0xff5a}, {0xff66, 0xffbe}, {0xffc2, 0xffc7}, {0xffca, 0xffcf}, {0xffd2, 0xffd7}, {0xffda, 0xffdc},
-  {0x10000, 0x1000b}, {0x1000d, 0x10026}, {0x10028, 0x1003a}, {0x1003c, 0x1003d}, {0x1003f, 0x1004d}, {0x10050, 0x1005d}, {0x10080, 0x100fa}, {0x10107, 0x10133},
-  {0x10140, 0x10178}, {0x1018a, 0x1018b}, {0x101fd, 0x101fd}, {0x10280, 0x1029c}, {0x102a0, 0x102d0}, {0x102e0, 0x102fb}, {0x10300, 0x10323}, {0x1032d, 0x1034a},
-  {0x10350, 0x1037a}, {0x10380, 0x1039d}, {0x103a0, 0x103c3}, {0x103c8, 0x103cf}, {0x103d1, 0x103d5}, {0x10400, 0x1049d}, {0x104a0, 0x104a9}, {0x104b0, 0x104d3},
-  {0x104d8, 0x104fb}, {0x10500, 0x10527}, {0x10530, 0x10563}, {0x10570, 0x1057a}, {0x1057c, 0x1058a}, {0x1058c, 0x10592}, {0x10594, 0x10595}, {0x10597, 0x105a1},
-  {0x105a3, 0x105b1}, {0x105b3, 0x105b9}, {0x105bb, 0x105bc}, {0x10600, 0x10736}, {0x10740, 0x10755}, {0x10760, 0x10767}, {0x10780, 0x10785}, {0x10787, 0x107b0},
-  {0x107b2, 0x107ba}, {0x10800, 0x10805}, {0x10808, 0x10808}, {0x1080a, 0x10835}, {0x10837, 0x10838}, {0x1083c, 0x1083c}, {0x1083f, 0x10855}, {0x10858, 0x10876},
-  {0x10879, 0x1089e}, {0x108a7, 0x108af}, {0x108e0, 0x108f2}, {0x108f4, 0x108f5}, {0x108fb, 0x1091b}, {0x1f004, 0x1f004}, {0x1f0cf, 0x1f0cf}, {0x1f170, 0x1f171},
-  {0x1f17e, 0x1f17f}, {0x1f18e, 0x1f18e}, {0x1f191, 0x1f19a}, {0x1f1e6, 0x1f1ff}, {0x1f201, 0x1f202}, {0x1f21a, 0x1f21a}, {0x1f22f, 0x1f22f}, {0x1f232, 0x1f23a},
-  {0x1f250, 0x1f251}, {0x1f300, 0x1f321}, {0x1f324, 0x1f393}, {0x1f396, 0x1f397}, {0x1f399, 0x1f39b}, {0x1f39e, 0x1f3f0}, {0x1f3f3, 0x1f3f5}, {0x1f3f7, 0x1f4fd},
-  {0x1f4ff, 0x1f53d}, {0x1f549, 0x1f54e}, {0x1f550, 0x1f567}, {0x1f56f, 0x1f570}, {0x1f573, 0x1f57a}, {0x1f587, 0x1f587}, {0x1f58a, 0x1f58d}, {0x1f590, 0x1f590},
-  {0x1f595, 0x1f596}, {0x1f5a4, 0x1f5a5}, {0x1f5a8, 0x1f5a8}, {0x1f5b1, 0x1f5b2}, {0x1f5bc, 0x1f5bc}, {0x1f5c2, 0x1f5c4}, {0x1f5d1, 0x1f5d3}, {0x1f5dc, 0x1f5de},
-  {0x1f5e1, 0x1f5e1}, {0x1f5e3, 0x1f5e3}, {0x1f5e8, 0x1f5e8}, {0x1f5ef, 0x1f5ef}, {0x1f5f3, 0x1f5f3}, {0x1f5fa, 0x1f64f}, {0x1f680, 0x1f6c5}, {0x1f6cb, 0x1f6d2},
-  {0x1f6d5, 0x1f6d7}, {0x1f6dc, 0x1f6e5}, {0x1f6e9, 0x1f6e9}, {0x1f6eb, 0x1f6ec}, {0x1f6f0, 0x1f6f0}, {0x1f6f3, 0x1f6fc}, {0x1f7e0, 0x1f7eb}, {0x1f7f0, 0x1f7f0},
-  {0x1f90c, 0x1f93a}, {0x1f93c, 0x1f945}, {0x1f947, 0x1f9ff}, {0x1fa70, 0x1fa7c}, {0x1fa80, 0x1fa88}, {0x1fa90, 0x1fabd}, {0x1fabf, 0x1fac5}, {0x1face, 0x1fadb},
-  {0x1fae0, 0x1fae8}, {0x1faf0, 0x1faf8},
-};
+static inline bool sym__normal_bare_identifier_character_set_1(int32_t c) {
+  return (c < 10145
+    ? (c < 9854
+      ? (c < 9742
+        ? (c < 9167
+          ? (c < 8482
+            ? (c < 8252
+              ? (c < 174
+                ? c == 169
+                : c <= 174)
+              : (c <= 8252 || c == 8265))
+            : (c <= 8482 || (c < 8986
+              ? (c < 8617
+                ? (c >= 8596 && c <= 8601)
+                : c <= 8618)
+              : (c <= 8987 || c == 9000))))
+          : (c <= 9167 || (c < 9654
+            ? (c < 9410
+              ? (c < 9208
+                ? (c >= 9193 && c <= 9203)
+                : c <= 9210)
+              : (c <= 9410 || (c >= 9642 && c <= 9643)))
+            : (c <= 9654 || (c < 9723
+              ? c == 9664
+              : (c <= 9726 || (c >= 9728 && c <= 9732)))))))
+        : (c <= 9742 || (c < 9784
+          ? (c < 9760
+            ? (c < 9752
+              ? (c < 9748
+                ? c == 9745
+                : c <= 9749)
+              : (c <= 9752 || c == 9757))
+            : (c <= 9760 || (c < 9770
+              ? (c < 9766
+                ? (c >= 9762 && c <= 9763)
+                : c <= 9766)
+              : (c <= 9770 || (c >= 9774 && c <= 9775)))))
+          : (c <= 9786 || (c < 9827
+            ? (c < 9800
+              ? (c < 9794
+                ? c == 9792
+                : c <= 9794)
+              : (c <= 9811 || (c >= 9823 && c <= 9824)))
+            : (c <= 9827 || (c < 9832
+              ? (c >= 9829 && c <= 9830)
+              : (c <= 9832 || c == 9851))))))))
+      : (c <= 9855 || (c < 9989
+        ? (c < 9928
+          ? (c < 9895
+            ? (c < 9883
+              ? (c < 9881
+                ? (c >= 9874 && c <= 9879)
+                : c <= 9881)
+              : (c <= 9884 || (c >= 9888 && c <= 9889)))
+            : (c <= 9895 || (c < 9917
+              ? (c < 9904
+                ? (c >= 9898 && c <= 9899)
+                : c <= 9905)
+              : (c <= 9918 || (c >= 9924 && c <= 9925)))))
+          : (c <= 9928 || (c < 9968
+            ? (c < 9939
+              ? (c < 9937
+                ? (c >= 9934 && c <= 9935)
+                : c <= 9937)
+              : (c <= 9940 || (c >= 9961 && c <= 9962)))
+            : (c <= 9973 || (c < 9981
+              ? (c >= 9975 && c <= 9978)
+              : (c <= 9981 || c == 9986))))))
+        : (c <= 9989 || (c < 10035
+          ? (c < 10006
+            ? (c < 10002
+              ? (c < 9999
+                ? (c >= 9992 && c <= 9997)
+                : c <= 9999)
+              : (c <= 10002 || c == 10004))
+            : (c <= 10006 || (c < 10017
+              ? c == 10013
+              : (c <= 10017 || c == 10024))))
+          : (c <= 10036 || (c < 10067
+            ? (c < 10060
+              ? (c < 10055
+                ? c == 10052
+                : c <= 10055)
+              : (c <= 10060 || c == 10062))
+            : (c <= 10069 || (c < 10083
+              ? c == 10071
+              : (c <= 10084 || (c >= 10133 && c <= 10135)))))))))))
+    : (c <= 10145 || (c < 128400
+      ? (c < 127489
+        ? (c < 12951
+          ? (c < 11035
+            ? (c < 10548
+              ? (c < 10175
+                ? c == 10160
+                : c <= 10175)
+              : (c <= 10549 || (c >= 11013 && c <= 11015)))
+            : (c <= 11036 || (c < 12336
+              ? (c < 11093
+                ? c == 11088
+                : c <= 11093)
+              : (c <= 12336 || c == 12349))))
+          : (c <= 12951 || (c < 127358
+            ? (c < 127183
+              ? (c < 126980
+                ? c == 12953
+                : c <= 126980)
+              : (c <= 127183 || (c >= 127344 && c <= 127345)))
+            : (c <= 127359 || (c < 127377
+              ? c == 127374
+              : (c <= 127386 || (c >= 127462 && c <= 127487)))))))
+        : (c <= 127490 || (c < 127987
+          ? (c < 127744
+            ? (c < 127538
+              ? (c < 127535
+                ? c == 127514
+                : c <= 127535)
+              : (c <= 127546 || (c >= 127568 && c <= 127569)))
+            : (c <= 127777 || (c < 127897
+              ? (c < 127894
+                ? (c >= 127780 && c <= 127891)
+                : c <= 127895)
+              : (c <= 127899 || (c >= 127902 && c <= 127984)))))
+          : (c <= 127989 || (c < 128367
+            ? (c < 128329
+              ? (c < 128255
+                ? (c >= 127991 && c <= 128253)
+                : c <= 128317)
+              : (c <= 128334 || (c >= 128336 && c <= 128359)))
+            : (c <= 128368 || (c < 128391
+              ? (c >= 128371 && c <= 128378)
+              : (c <= 128391 || (c >= 128394 && c <= 128397)))))))))
+      : (c <= 128400 || (c < 128745
+        ? (c < 128483
+          ? (c < 128444
+            ? (c < 128424
+              ? (c < 128420
+                ? (c >= 128405 && c <= 128406)
+                : c <= 128421)
+              : (c <= 128424 || (c >= 128433 && c <= 128434)))
+            : (c <= 128444 || (c < 128476
+              ? (c < 128465
+                ? (c >= 128450 && c <= 128452)
+                : c <= 128467)
+              : (c <= 128478 || c == 128481))))
+          : (c <= 128483 || (c < 128640
+            ? (c < 128499
+              ? (c < 128495
+                ? c == 128488
+                : c <= 128495)
+              : (c <= 128499 || (c >= 128506 && c <= 128591)))
+            : (c <= 128709 || (c < 128725
+              ? (c >= 128715 && c <= 128722)
+              : (c <= 128727 || (c >= 128733 && c <= 128741)))))))
+        : (c <= 128745 || (c < 129648
+          ? (c < 129008
+            ? (c < 128755
+              ? (c < 128752
+                ? (c >= 128747 && c <= 128748)
+                : c <= 128752)
+              : (c <= 128764 || (c >= 128992 && c <= 129003)))
+            : (c <= 129008 || (c < 129340
+              ? (c >= 129292 && c <= 129338)
+              : (c <= 129349 || (c >= 129351 && c <= 129535)))))
+          : (c <= 129652 || (c < 129728
+            ? (c < 129680
+              ? (c < 129664
+                ? (c >= 129656 && c <= 129660)
+                : c <= 129670)
+              : (c <= 129708 || (c >= 129712 && c <= 129722)))
+            : (c <= 129733 || (c < 129760
+              ? (c >= 129744 && c <= 129753)
+              : (c <= 129767 || (c >= 129776 && c <= 129782)))))))))))));
+}
 
-static TSCharacterRange sym__identifier_char_character_set_1[] = {
-  {'!', '!'}, {'#', '\''}, {'*', '+'}, {'-', '.'}, {'0', ':'}, {'?', 'Z'}, {'^', '_'}, {'a', 'z'},
-  {'|', '|'}, {'~', '~'}, {0xaa, 0xaa}, {0xb2, 0xb3}, {0xb5, 0xb5}, {0xb9, 0xba}, {0xbc, 0xbe}, {0xc0, 0xd6},
-  {0xd8, 0xf6}, {0xf8, 0x2c1}, {0x2c6, 0x2d1}, {0x2e0, 0x2e4}, {0x2ec, 0x2ec}, {0x2ee, 0x2ee}, {0x300, 0x374}, {0x376, 0x377},
-  {0x37a, 0x37d}, {0x37f, 0x37f}, {0x386, 0x386}, {0x388, 0x38a}, {0x38c, 0x38c}, {0x38e, 0x3a1}, {0x3a3, 0x3f5}, {0x3f7, 0x481},
-  {0x483, 0x52f}, {0x531, 0x556}, {0x559, 0x559}, {0x560, 0x588}, {0x591, 0x5bd}, {0x5bf, 0x5bf}, {0x5c1, 0x5c2}, {0x5c4, 0x5c5},
-  {0x5c7, 0x5c7}, {0x5d0, 0x5ea}, {0x5ef, 0x5f2}, {0x610, 0x61a}, {0x620, 0x669}, {0x66e, 0x6d3}, {0x6d5, 0x6dc}, {0x6df, 0x6e8},
-  {0x6ea, 0x6fc}, {0x6ff, 0x6ff}, {0x710, 0x74a}, {0x74d, 0x7b1}, {0x7c0, 0x7f5}, {0x7fa, 0x7fa}, {0x7fd, 0x7fd}, {0x800, 0x82d},
-  {0x840, 0x85b}, {0x860, 0x86a}, {0x870, 0x887}, {0x889, 0x88e}, {0x898, 0x8e1}, {0x8e3, 0x963}, {0x966, 0x96f}, {0x971, 0x983},
-  {0x985, 0x98c}, {0x98f, 0x990}, {0x993, 0x9a8}, {0x9aa, 0x9b0}, {0x9b2, 0x9b2}, {0x9b6, 0x9b9}, {0x9bc, 0x9c4}, {0x9c7, 0x9c8},
-  {0x9cb, 0x9ce}, {0x9d7, 0x9d7}, {0x9dc, 0x9dd}, {0x9df, 0x9e3}, {0x9e6, 0x9f1}, {0x9f4, 0x9f9}, {0x9fc, 0x9fc}, {0x9fe, 0x9fe},
-  {0xa01, 0xa03}, {0xa05, 0xa0a}, {0xa0f, 0xa10}, {0xa13, 0xa28}, {0xa2a, 0xa30}, {0xa32, 0xa33}, {0xa35, 0xa36}, {0xa38, 0xa39},
-  {0xa3c, 0xa3c}, {0xa3e, 0xa42}, {0xa47, 0xa48}, {0xa4b, 0xa4d}, {0xa51, 0xa51}, {0xa59, 0xa5c}, {0xa5e, 0xa5e}, {0xa66, 0xa75},
-  {0xa81, 0xa83}, {0xa85, 0xa8d}, {0xa8f, 0xa91}, {0xa93, 0xaa8}, {0xaaa, 0xab0}, {0xab2, 0xab3}, {0xab5, 0xab9}, {0xabc, 0xac5},
-  {0xac7, 0xac9}, {0xacb, 0xacd}, {0xad0, 0xad0}, {0xae0, 0xae3}, {0xae6, 0xaef}, {0xaf9, 0xaff}, {0xb01, 0xb03}, {0xb05, 0xb0c},
-  {0xb0f, 0xb10}, {0xb13, 0xb28}, {0xb2a, 0xb30}, {0xb32, 0xb33}, {0xb35, 0xb39}, {0xb3c, 0xb44}, {0xb47, 0xb48}, {0xb4b, 0xb4d},
-  {0xb55, 0xb57}, {0xb5c, 0xb5d}, {0xb5f, 0xb63}, {0xb66, 0xb6f}, {0xb71, 0xb77}, {0xb82, 0xb83}, {0xb85, 0xb8a}, {0xb8e, 0xb90},
-  {0xb92, 0xb95}, {0xb99, 0xb9a}, {0xb9c, 0xb9c}, {0xb9e, 0xb9f}, {0xba3, 0xba4}, {0xba8, 0xbaa}, {0xbae, 0xbb9}, {0xbbe, 0xbc2},
-  {0xbc6, 0xbc8}, {0xbca, 0xbcd}, {0xbd0, 0xbd0}, {0xbd7, 0xbd7}, {0xbe6, 0xbf2}, {0xc00, 0xc0c}, {0xc0e, 0xc10}, {0xc12, 0xc28},
-  {0xc2a, 0xc39}, {0xc3c, 0xc44}, {0xc46, 0xc48}, {0xc4a, 0xc4d}, {0xc55, 0xc56}, {0xc58, 0xc5a}, {0xc5d, 0xc5d}, {0xc60, 0xc63},
-  {0xc66, 0xc6f}, {0xc78, 0xc7e}, {0xc80, 0xc83}, {0xc85, 0xc8c}, {0xc8e, 0xc90}, {0xc92, 0xca8}, {0xcaa, 0xcb3}, {0xcb5, 0xcb9},
-  {0xcbc, 0xcc4}, {0xcc6, 0xcc8}, {0xcca, 0xccd}, {0xcd5, 0xcd6}, {0xcdd, 0xcde}, {0xce0, 0xce3}, {0xce6, 0xcef}, {0xcf1, 0xcf3},
-  {0xd00, 0xd0c}, {0xd0e, 0xd10}, {0xd12, 0xd44}, {0xd46, 0xd48}, {0xd4a, 0xd4e}, {0xd54, 0xd63}, {0xd66, 0xd78}, {0xd7a, 0xd7f},
-  {0xd81, 0xd83}, {0xd85, 0xd96}, {0xd9a, 0xdb1}, {0xdb3, 0xdbb}, {0xdbd, 0xdbd}, {0xdc0, 0xdc6}, {0xdca, 0xdca}, {0xdcf, 0xdd4},
-  {0xdd6, 0xdd6}, {0xdd8, 0xddf}, {0xde6, 0xdef}, {0xdf2, 0xdf3}, {0xe01, 0xe3a}, {0xe40, 0xe4e}, {0xe50, 0xe59}, {0xe81, 0xe82},
-  {0xe84, 0xe84}, {0xe86, 0xe8a}, {0xe8c, 0xea3}, {0xea5, 0xea5}, {0xea7, 0xebd}, {0xec0, 0xec4}, {0xec6, 0xec6}, {0xec8, 0xece},
-  {0xed0, 0xed9}, {0xedc, 0xedf}, {0xf00, 0xf00}, {0xf18, 0xf19}, {0xf20, 0xf33}, {0xf35, 0xf35}, {0xf37, 0xf37}, {0xf39, 0xf39},
-  {0xf3e, 0xf47}, {0xf49, 0xf6c}, {0xf71, 0xf84}, {0xf86, 0xf97}, {0xf99, 0xfbc}, {0xfc6, 0xfc6}, {0x1000, 0x1049}, {0x1050, 0x109d},
-  {0x10a0, 0x10c5}, {0x10c7, 0x10c7}, {0x10cd, 0x10cd}, {0x10d0, 0x10fa}, {0x10fc, 0x1248}, {0x124a, 0x124d}, {0x1250, 0x1256}, {0x1258, 0x1258},
-  {0x125a, 0x125d}, {0x1260, 0x1288}, {0x128a, 0x128d}, {0x1290, 0x12b0}, {0x12b2, 0x12b5}, {0x12b8, 0x12be}, {0x12c0, 0x12c0}, {0x12c2, 0x12c5},
-  {0x12c8, 0x12d6}, {0x12d8, 0x1310}, {0x1312, 0x1315}, {0x1318, 0x135a}, {0x135d, 0x135f}, {0x1369, 0x137c}, {0x1380, 0x138f}, {0x13a0, 0x13f5},
-  {0x13f8, 0x13fd}, {0x1401, 0x166c}, {0x166f, 0x167f}, {0x1681, 0x169a}, {0x16a0, 0x16ea}, {0x16ee, 0x16f8}, {0x1700, 0x1715}, {0x171f, 0x1734},
-  {0x1740, 0x1753}, {0x1760, 0x176c}, {0x176e, 0x1770}, {0x1772, 0x1773}, {0x1780, 0x17d3}, {0x17d7, 0x17d7}, {0x17dc, 0x17dd}, {0x17e0, 0x17e9},
-  {0x17f0, 0x17f9}, {0x180b, 0x180d}, {0x180f, 0x1819}, {0x1820, 0x1878}, {0x1880, 0x18aa}, {0x18b0, 0x18f5}, {0x1900, 0x191e}, {0x1920, 0x192b},
-  {0x1930, 0x193b}, {0x1946, 0x196d}, {0x1970, 0x1974}, {0x1980, 0x19ab}, {0x19b0, 0x19c9}, {0x19d0, 0x19da}, {0x1a00, 0x1a1b}, {0x1a20, 0x1a5e},
-  {0x1a60, 0x1a7c}, {0x1a7f, 0x1a89}, {0x1a90, 0x1a99}, {0x1aa7, 0x1aa7}, {0x1ab0, 0x1ace}, {0x1b00, 0x1b4c}, {0x1b50, 0x1b59}, {0x1b6b, 0x1b73},
-  {0x1b80, 0x1bf3}, {0x1c00, 0x1c37}, {0x1c40, 0x1c49}, {0x1c4d, 0x1c7d}, {0x1c80, 0x1c88}, {0x1c90, 0x1cba}, {0x1cbd, 0x1cbf}, {0x1cd0, 0x1cd2},
-  {0x1cd4, 0x1cfa}, {0x1d00, 0x1f15}, {0x1f18, 0x1f1d}, {0x1f20, 0x1f45}, {0x1f48, 0x1f4d}, {0x1f50, 0x1f57}, {0x1f59, 0x1f59}, {0x1f5b, 0x1f5b},
-  {0x1f5d, 0x1f5d}, {0x1f5f, 0x1f7d}, {0x1f80, 0x1fb4}, {0x1fb6, 0x1fbc}, {0x1fbe, 0x1fbe}, {0x1fc2, 0x1fc4}, {0x1fc6, 0x1fcc}, {0x1fd0, 0x1fd3},
-  {0x1fd6, 0x1fdb}, {0x1fe0, 0x1fec}, {0x1ff2, 0x1ff4}, {0x1ff6, 0x1ffc}, {0x2070, 0x2071}, {0x2074, 0x2079}, {0x207f, 0x2089}, {0x2090, 0x209c},
-  {0x20d0, 0x20f0}, {0x2102, 0x2102}, {0x2107, 0x2107}, {0x210a, 0x2113}, {0x2115, 0x2115}, {0x2119, 0x211d}, {0x2124, 0x2124}, {0x2126, 0x2126},
-  {0x2128, 0x2128}, {0x212a, 0x212d}, {0x212f, 0x2139}, {0x213c, 0x213f}, {0x2145, 0x2149}, {0x214e, 0x214e}, {0x2150, 0x2189}, {0x2460, 0x249b},
-  {0x24ea, 0x24ff}, {0x2776, 0x2793}, {0x2c00, 0x2ce4}, {0x2ceb, 0x2cf3}, {0x2cfd, 0x2cfd}, {0x2d00, 0x2d25}, {0x2d27, 0x2d27}, {0x2d2d, 0x2d2d},
-  {0x2d30, 0x2d67}, {0x2d6f, 0x2d6f}, {0x2d7f, 0x2d96}, {0x2da0, 0x2da6}, {0x2da8, 0x2dae}, {0x2db0, 0x2db6}, {0x2db8, 0x2dbe}, {0x2dc0, 0x2dc6},
-  {0x2dc8, 0x2dce}, {0x2dd0, 0x2dd6}, {0x2dd8, 0x2dde}, {0x2de0, 0x2dff}, {0x2e2f, 0x2e2f}, {0x3005, 0x3007}, {0x3021, 0x302f}, {0x3031, 0x3035},
-  {0x3038, 0x303c}, {0x3041, 0x3096}, {0x3099, 0x309a}, {0x309d, 0x309f}, {0x30a1, 0x30fa}, {0x30fc, 0x30ff}, {0x3105, 0x312f}, {0x3131, 0x318e},
-  {0x3192, 0x3195}, {0x31a0, 0x31bf}, {0x31f0, 0x31ff}, {0x3220, 0x3229}, {0x3248, 0x324f}, {0x3251, 0x325f}, {0x3280, 0x3289}, {0x32b1, 0x32bf},
-  {0x3400, 0x3400}, {0x4dbf, 0x4dbf}, {0x4e00, 0xa48c}, {0xa4d0, 0xa4fd}, {0xa500, 0xa60c}, {0xa610, 0xa62b}, {0xa640, 0xa672}, {0xa674, 0xa67d},
-  {0xa67f, 0xa6f1}, {0xa717, 0xa71f}, {0xa722, 0xa788}, {0xa78b, 0xa7ca}, {0xa7d0, 0xa7d1}, {0xa7d3, 0xa7d3}, {0xa7d5, 0xa7d9}, {0xa7f2, 0xa827},
-  {0xa82c, 0xa82c}, {0xa830, 0xa835}, {0xa840, 0xa873}, {0xa880, 0xa8c5}, {0xa8d0, 0xa8d9}, {0xa8e0, 0xa8f7}, {0xa8fb, 0xa8fb}, {0xa8fd, 0xa92d},
-  {0xa930, 0xa953}, {0xa960, 0xa97c}, {0xa980, 0xa9c0}, {0xa9cf, 0xa9d9}, {0xa9e0, 0xa9fe}, {0xaa00, 0xaa36}, {0xaa40, 0xaa4d}, {0xaa50, 0xaa59},
-  {0xaa60, 0xaa76}, {0xaa7a, 0xaac2}, {0xaadb, 0xaadd}, {0xaae0, 0xaaef}, {0xaaf2, 0xaaf6}, {0xab01, 0xab06}, {0xab09, 0xab0e}, {0xab11, 0xab16},
-  {0xab20, 0xab26}, {0xab28, 0xab2e}, {0xab30, 0xab5a}, {0xab5c, 0xab69}, {0xab70, 0xabea}, {0xabec, 0xabed}, {0xabf0, 0xabf9}, {0xac00, 0xac00},
-  {0xd7a3, 0xd7a3}, {0xd7b0, 0xd7c6}, {0xd7cb, 0xd7fb}, {0xf900, 0xfa6d}, {0xfa70, 0xfad9}, {0xfb00, 0xfb06}, {0xfb13, 0xfb17}, {0xfb1d, 0xfb28},
-  {0xfb2a, 0xfb36}, {0xfb38, 0xfb3c}, {0xfb3e, 0xfb3e}, {0xfb40, 0xfb41}, {0xfb43, 0xfb44}, {0xfb46, 0xfbb1}, {0xfbd3, 0xfd3d}, {0xfd50, 0xfd8f},
-  {0xfd92, 0xfdc7}, {0xfdf0, 0xfdfb}, {0xfe00, 0xfe0f}, {0xfe20, 0xfe2f}, {0xfe70, 0xfe74}, {0xfe76, 0xfefc}, {0xff10, 0xff19}, {0xff21, 0xff3a},
-  {0xff41, 0xff5a}, {0xff66, 0xffbe}, {0xffc2, 0xffc7}, {0xffca, 0xffcf}, {0xffd2, 0xffd7}, {0xffda, 0xffdc}, {0x10000, 0x1000b}, {0x1000d, 0x10026},
-  {0x10028, 0x1003a}, {0x1003c, 0x1003d}, {0x1003f, 0x1004d}, {0x10050, 0x1005d}, {0x10080, 0x100fa}, {0x10107, 0x10133}, {0x10140, 0x10178}, {0x1018a, 0x1018b},
-  {0x101fd, 0x101fd}, {0x10280, 0x1029c}, {0x102a0, 0x102d0}, {0x102e0, 0x102fb}, {0x10300, 0x10323}, {0x1032d, 0x1034a}, {0x10350, 0x1037a}, {0x10380, 0x1039d},
-  {0x103a0, 0x103c3}, {0x103c8, 0x103cf}, {0x103d1, 0x103d5}, {0x10400, 0x1049d}, {0x104a0, 0x104a9}, {0x104b0, 0x104d3}, {0x104d8, 0x104fb}, {0x10500, 0x10527},
-  {0x10530, 0x10563}, {0x10570, 0x1057a}, {0x1057c, 0x1058a}, {0x1058c, 0x10592}, {0x10594, 0x10595}, {0x10597, 0x105a1}, {0x105a3, 0x105b1}, {0x105b3, 0x105b9},
-  {0x105bb, 0x105bc}, {0x10600, 0x10736}, {0x10740, 0x10755}, {0x10760, 0x10767}, {0x10780, 0x10785}, {0x10787, 0x107b0}, {0x107b2, 0x107ba}, {0x10800, 0x10805},
-  {0x10808, 0x10808}, {0x1080a, 0x10835}, {0x10837, 0x10838}, {0x1083c, 0x1083c}, {0x1083f, 0x10855}, {0x10858, 0x10876}, {0x10879, 0x1089e}, {0x108a7, 0x108af},
-  {0x108e0, 0x108f2}, {0x108f4, 0x108f5}, {0x108fb, 0x1091b},
-};
+static inline bool sym__normal_bare_identifier_character_set_2(int32_t c) {
+  return (c < 6016
+    ? (c < 2962
+      ? (c < 2451
+        ? (c < 1376
+          ? (c < 748
+            ? (c < 181
+              ? (c < '^'
+                ? (c < ':'
+                  ? (c >= '!' && c <= '*')
+                  : (c <= ':' || (c >= '?' && c <= 'Z')))
+                : (c <= '^' || (c < 170
+                  ? (c >= 'g' && c <= '~')
+                  : (c <= 170 || (c >= 178 && c <= 179)))))
+              : (c <= 181 || (c < 216
+                ? (c < 188
+                  ? (c >= 185 && c <= 186)
+                  : (c <= 190 || (c >= 192 && c <= 214)))
+                : (c <= 246 || (c < 710
+                  ? (c >= 248 && c <= 705)
+                  : (c <= 721 || (c >= 736 && c <= 740)))))))
+            : (c <= 748 || (c < 908
+              ? (c < 890
+                ? (c < 768
+                  ? c == 750
+                  : (c <= 884 || (c >= 886 && c <= 887)))
+                : (c <= 893 || (c < 902
+                  ? c == 895
+                  : (c <= 902 || (c >= 904 && c <= 906)))))
+              : (c <= 908 || (c < 1155
+                ? (c < 931
+                  ? (c >= 910 && c <= 929)
+                  : (c <= 1013 || (c >= 1015 && c <= 1153)))
+                : (c <= 1327 || (c < 1369
+                  ? (c >= 1329 && c <= 1366)
+                  : c <= 1369)))))))
+          : (c <= 1416 || (c < 1869
+            ? (c < 1552
+              ? (c < 1476
+                ? (c < 1471
+                  ? (c >= 1425 && c <= 1469)
+                  : (c <= 1471 || (c >= 1473 && c <= 1474)))
+                : (c <= 1477 || (c < 1488
+                  ? c == 1479
+                  : (c <= 1514 || (c >= 1519 && c <= 1522)))))
+              : (c <= 1562 || (c < 1759
+                ? (c < 1646
+                  ? (c >= 1568 && c <= 1641)
+                  : (c <= 1747 || (c >= 1749 && c <= 1756)))
+                : (c <= 1768 || (c < 1791
+                  ? (c >= 1770 && c <= 1788)
+                  : (c <= 1791 || (c >= 1808 && c <= 1866)))))))
+            : (c <= 1969 || (c < 2185
+              ? (c < 2048
+                ? (c < 2042
+                  ? (c >= 1984 && c <= 2037)
+                  : (c <= 2042 || c == 2045))
+                : (c <= 2093 || (c < 2144
+                  ? (c >= 2112 && c <= 2139)
+                  : (c <= 2154 || (c >= 2160 && c <= 2183)))))
+              : (c <= 2190 || (c < 2417
+                ? (c < 2275
+                  ? (c >= 2200 && c <= 2273)
+                  : (c <= 2403 || (c >= 2406 && c <= 2415)))
+                : (c <= 2435 || (c < 2447
+                  ? (c >= 2437 && c <= 2444)
+                  : c <= 2448)))))))))
+        : (c <= 2472 || (c < 2693
+          ? (c < 2575
+            ? (c < 2524
+              ? (c < 2492
+                ? (c < 2482
+                  ? (c >= 2474 && c <= 2480)
+                  : (c <= 2482 || (c >= 2486 && c <= 2489)))
+                : (c <= 2500 || (c < 2507
+                  ? (c >= 2503 && c <= 2504)
+                  : (c <= 2510 || c == 2519))))
+              : (c <= 2525 || (c < 2556
+                ? (c < 2534
+                  ? (c >= 2527 && c <= 2531)
+                  : (c <= 2545 || (c >= 2548 && c <= 2553)))
+                : (c <= 2556 || (c < 2561
+                  ? c == 2558
+                  : (c <= 2563 || (c >= 2565 && c <= 2570)))))))
+            : (c <= 2576 || (c < 2631
+              ? (c < 2613
+                ? (c < 2602
+                  ? (c >= 2579 && c <= 2600)
+                  : (c <= 2608 || (c >= 2610 && c <= 2611)))
+                : (c <= 2614 || (c < 2620
+                  ? (c >= 2616 && c <= 2617)
+                  : (c <= 2620 || (c >= 2622 && c <= 2626)))))
+              : (c <= 2632 || (c < 2654
+                ? (c < 2641
+                  ? (c >= 2635 && c <= 2637)
+                  : (c <= 2641 || (c >= 2649 && c <= 2652)))
+                : (c <= 2654 || (c < 2689
+                  ? (c >= 2662 && c <= 2677)
+                  : c <= 2691)))))))
+          : (c <= 2701 || (c < 2835
+            ? (c < 2763
+              ? (c < 2738
+                ? (c < 2707
+                  ? (c >= 2703 && c <= 2705)
+                  : (c <= 2728 || (c >= 2730 && c <= 2736)))
+                : (c <= 2739 || (c < 2748
+                  ? (c >= 2741 && c <= 2745)
+                  : (c <= 2757 || (c >= 2759 && c <= 2761)))))
+              : (c <= 2765 || (c < 2809
+                ? (c < 2784
+                  ? c == 2768
+                  : (c <= 2787 || (c >= 2790 && c <= 2799)))
+                : (c <= 2815 || (c < 2821
+                  ? (c >= 2817 && c <= 2819)
+                  : (c <= 2828 || (c >= 2831 && c <= 2832)))))))
+            : (c <= 2856 || (c < 2908
+              ? (c < 2876
+                ? (c < 2866
+                  ? (c >= 2858 && c <= 2864)
+                  : (c <= 2867 || (c >= 2869 && c <= 2873)))
+                : (c <= 2884 || (c < 2891
+                  ? (c >= 2887 && c <= 2888)
+                  : (c <= 2893 || (c >= 2901 && c <= 2903)))))
+              : (c <= 2909 || (c < 2946
+                ? (c < 2918
+                  ? (c >= 2911 && c <= 2915)
+                  : (c <= 2927 || (c >= 2929 && c <= 2935)))
+                : (c <= 2947 || (c < 2958
+                  ? (c >= 2949 && c <= 2954)
+                  : c <= 2960)))))))))))
+      : (c <= 2965 || (c < 3664
+        ? (c < 3253
+          ? (c < 3114
+            ? (c < 3014
+              ? (c < 2979
+                ? (c < 2972
+                  ? (c >= 2969 && c <= 2970)
+                  : (c <= 2972 || (c >= 2974 && c <= 2975)))
+                : (c <= 2980 || (c < 2990
+                  ? (c >= 2984 && c <= 2986)
+                  : (c <= 3001 || (c >= 3006 && c <= 3010)))))
+              : (c <= 3016 || (c < 3046
+                ? (c < 3024
+                  ? (c >= 3018 && c <= 3021)
+                  : (c <= 3024 || c == 3031))
+                : (c <= 3058 || (c < 3086
+                  ? (c >= 3072 && c <= 3084)
+                  : (c <= 3088 || (c >= 3090 && c <= 3112)))))))
+            : (c <= 3129 || (c < 3174
+              ? (c < 3157
+                ? (c < 3142
+                  ? (c >= 3132 && c <= 3140)
+                  : (c <= 3144 || (c >= 3146 && c <= 3149)))
+                : (c <= 3158 || (c < 3165
+                  ? (c >= 3160 && c <= 3162)
+                  : (c <= 3165 || (c >= 3168 && c <= 3171)))))
+              : (c <= 3183 || (c < 3214
+                ? (c < 3200
+                  ? (c >= 3192 && c <= 3198)
+                  : (c <= 3203 || (c >= 3205 && c <= 3212)))
+                : (c <= 3216 || (c < 3242
+                  ? (c >= 3218 && c <= 3240)
+                  : c <= 3251)))))))
+          : (c <= 3257 || (c < 3450
+            ? (c < 3313
+              ? (c < 3285
+                ? (c < 3270
+                  ? (c >= 3260 && c <= 3268)
+                  : (c <= 3272 || (c >= 3274 && c <= 3277)))
+                : (c <= 3286 || (c < 3296
+                  ? (c >= 3293 && c <= 3294)
+                  : (c <= 3299 || (c >= 3302 && c <= 3311)))))
+              : (c <= 3314 || (c < 3398
+                ? (c < 3342
+                  ? (c >= 3328 && c <= 3340)
+                  : (c <= 3344 || (c >= 3346 && c <= 3396)))
+                : (c <= 3400 || (c < 3412
+                  ? (c >= 3402 && c <= 3406)
+                  : (c <= 3427 || (c >= 3430 && c <= 3448)))))))
+            : (c <= 3455 || (c < 3535
+              ? (c < 3507
+                ? (c < 3461
+                  ? (c >= 3457 && c <= 3459)
+                  : (c <= 3478 || (c >= 3482 && c <= 3505)))
+                : (c <= 3515 || (c < 3520
+                  ? c == 3517
+                  : (c <= 3526 || c == 3530))))
+              : (c <= 3540 || (c < 3570
+                ? (c < 3544
+                  ? c == 3542
+                  : (c <= 3551 || (c >= 3558 && c <= 3567)))
+                : (c <= 3571 || (c < 3648
+                  ? (c >= 3585 && c <= 3642)
+                  : c <= 3662)))))))))
+        : (c <= 3673 || (c < 4682
+          ? (c < 3895
+            ? (c < 3782
+              ? (c < 3724
+                ? (c < 3716
+                  ? (c >= 3713 && c <= 3714)
+                  : (c <= 3716 || (c >= 3718 && c <= 3722)))
+                : (c <= 3747 || (c < 3751
+                  ? c == 3749
+                  : (c <= 3773 || (c >= 3776 && c <= 3780)))))
+              : (c <= 3782 || (c < 3840
+                ? (c < 3792
+                  ? (c >= 3784 && c <= 3789)
+                  : (c <= 3801 || (c >= 3804 && c <= 3807)))
+                : (c <= 3840 || (c < 3872
+                  ? (c >= 3864 && c <= 3865)
+                  : (c <= 3891 || c == 3893))))))
+            : (c <= 3895 || (c < 4096
+              ? (c < 3953
+                ? (c < 3902
+                  ? c == 3897
+                  : (c <= 3911 || (c >= 3913 && c <= 3948)))
+                : (c <= 3972 || (c < 3993
+                  ? (c >= 3974 && c <= 3991)
+                  : (c <= 4028 || c == 4038))))
+              : (c <= 4169 || (c < 4301
+                ? (c < 4256
+                  ? (c >= 4176 && c <= 4253)
+                  : (c <= 4293 || c == 4295))
+                : (c <= 4301 || (c < 4348
+                  ? (c >= 4304 && c <= 4346)
+                  : c <= 4680)))))))
+          : (c <= 4685 || (c < 4957
+            ? (c < 4792
+              ? (c < 4704
+                ? (c < 4696
+                  ? (c >= 4688 && c <= 4694)
+                  : (c <= 4696 || (c >= 4698 && c <= 4701)))
+                : (c <= 4744 || (c < 4752
+                  ? (c >= 4746 && c <= 4749)
+                  : (c <= 4784 || (c >= 4786 && c <= 4789)))))
+              : (c <= 4798 || (c < 4824
+                ? (c < 4802
+                  ? c == 4800
+                  : (c <= 4805 || (c >= 4808 && c <= 4822)))
+                : (c <= 4880 || (c < 4888
+                  ? (c >= 4882 && c <= 4885)
+                  : c <= 4954)))))
+            : (c <= 4959 || (c < 5870
+              ? (c < 5112
+                ? (c < 4992
+                  ? (c >= 4969 && c <= 4988)
+                  : (c <= 5007 || (c >= 5024 && c <= 5109)))
+                : (c <= 5117 || (c < 5743
+                  ? (c >= 5121 && c <= 5740)
+                  : (c <= 5786 || (c >= 5792 && c <= 5866)))))
+              : (c <= 5880 || (c < 5984
+                ? (c < 5919
+                  ? (c >= 5888 && c <= 5909)
+                  : (c <= 5940 || (c >= 5952 && c <= 5971)))
+                : (c <= 5996 || (c < 6002
+                  ? (c >= 5998 && c <= 6000)
+                  : c <= 6003)))))))))))))
+    : (c <= 6099 || (c < 42775
+      ? (c < 8455
+        ? (c < 7245
+          ? (c < 6576
+            ? (c < 6272
+              ? (c < 6128
+                ? (c < 6108
+                  ? c == 6103
+                  : (c <= 6109 || (c >= 6112 && c <= 6121)))
+                : (c <= 6137 || (c < 6159
+                  ? (c >= 6155 && c <= 6157)
+                  : (c <= 6169 || (c >= 6176 && c <= 6264)))))
+              : (c <= 6314 || (c < 6448
+                ? (c < 6400
+                  ? (c >= 6320 && c <= 6389)
+                  : (c <= 6430 || (c >= 6432 && c <= 6443)))
+                : (c <= 6459 || (c < 6512
+                  ? (c >= 6470 && c <= 6509)
+                  : (c <= 6516 || (c >= 6528 && c <= 6571)))))))
+            : (c <= 6601 || (c < 6832
+              ? (c < 6752
+                ? (c < 6656
+                  ? (c >= 6608 && c <= 6618)
+                  : (c <= 6683 || (c >= 6688 && c <= 6750)))
+                : (c <= 6780 || (c < 6800
+                  ? (c >= 6783 && c <= 6793)
+                  : (c <= 6809 || c == 6823))))
+              : (c <= 6862 || (c < 7040
+                ? (c < 6992
+                  ? (c >= 6912 && c <= 6988)
+                  : (c <= 7001 || (c >= 7019 && c <= 7027)))
+                : (c <= 7155 || (c < 7232
+                  ? (c >= 7168 && c <= 7223)
+                  : c <= 7241)))))))
+          : (c <= 7293 || (c < 8118
+            ? (c < 7968
+              ? (c < 7376
+                ? (c < 7312
+                  ? (c >= 7296 && c <= 7304)
+                  : (c <= 7354 || (c >= 7357 && c <= 7359)))
+                : (c <= 7378 || (c < 7424
+                  ? (c >= 7380 && c <= 7418)
+                  : (c <= 7957 || (c >= 7960 && c <= 7965)))))
+              : (c <= 8005 || (c < 8027
+                ? (c < 8016
+                  ? (c >= 8008 && c <= 8013)
+                  : (c <= 8023 || c == 8025))
+                : (c <= 8027 || (c < 8031
+                  ? c == 8029
+                  : (c <= 8061 || (c >= 8064 && c <= 8116)))))))
+            : (c <= 8124 || (c < 8182
+              ? (c < 8144
+                ? (c < 8130
+                  ? c == 8126
+                  : (c <= 8132 || (c >= 8134 && c <= 8140)))
+                : (c <= 8147 || (c < 8160
+                  ? (c >= 8150 && c <= 8155)
+                  : (c <= 8172 || (c >= 8178 && c <= 8180)))))
+              : (c <= 8188 || (c < 8336
+                ? (c < 8308
+                  ? (c >= 8304 && c <= 8305)
+                  : (c <= 8313 || (c >= 8319 && c <= 8329)))
+                : (c <= 8348 || (c < 8450
+                  ? (c >= 8400 && c <= 8432)
+                  : c <= 8450)))))))))
+        : (c <= 8455 || (c < 11728
+          ? (c < 11264
+            ? (c < 8495
+              ? (c < 8484
+                ? (c < 8469
+                  ? (c >= 8458 && c <= 8467)
+                  : (c <= 8469 || (c >= 8473 && c <= 8477)))
+                : (c <= 8484 || (c < 8488
+                  ? c == 8486
+                  : (c <= 8488 || (c >= 8490 && c <= 8493)))))
+              : (c <= 8505 || (c < 8528
+                ? (c < 8517
+                  ? (c >= 8508 && c <= 8511)
+                  : (c <= 8521 || c == 8526))
+                : (c <= 8585 || (c < 9450
+                  ? (c >= 9312 && c <= 9371)
+                  : (c <= 9471 || (c >= 10102 && c <= 10131)))))))
+            : (c <= 11492 || (c < 11647
+              ? (c < 11559
+                ? (c < 11517
+                  ? (c >= 11499 && c <= 11507)
+                  : (c <= 11517 || (c >= 11520 && c <= 11557)))
+                : (c <= 11559 || (c < 11568
+                  ? c == 11565
+                  : (c <= 11623 || c == 11631))))
+              : (c <= 11670 || (c < 11704
+                ? (c < 11688
+                  ? (c >= 11680 && c <= 11686)
+                  : (c <= 11694 || (c >= 11696 && c <= 11702)))
+                : (c <= 11710 || (c < 11720
+                  ? (c >= 11712 && c <= 11718)
+                  : c <= 11726)))))))
+          : (c <= 11734 || (c < 12784
+            ? (c < 12441
+              ? (c < 12293
+                ? (c < 11744
+                  ? (c >= 11736 && c <= 11742)
+                  : (c <= 11775 || c == 11823))
+                : (c <= 12295 || (c < 12344
+                  ? (c >= 12321 && c <= 12341)
+                  : (c <= 12348 || (c >= 12353 && c <= 12438)))))
+              : (c <= 12442 || (c < 12549
+                ? (c < 12449
+                  ? (c >= 12445 && c <= 12447)
+                  : (c <= 12538 || (c >= 12540 && c <= 12543)))
+                : (c <= 12591 || (c < 12690
+                  ? (c >= 12593 && c <= 12686)
+                  : (c <= 12693 || (c >= 12704 && c <= 12735)))))))
+            : (c <= 12799 || (c < 19968
+              ? (c < 12928
+                ? (c < 12872
+                  ? (c >= 12832 && c <= 12841)
+                  : (c <= 12879 || (c >= 12881 && c <= 12895)))
+                : (c <= 12937 || (c < 13312
+                  ? (c >= 12977 && c <= 12991)
+                  : (c <= 13312 || c == 19903))))
+              : (c <= 42124 || (c < 42560
+                ? (c < 42240
+                  ? (c >= 42192 && c <= 42237)
+                  : (c <= 42508 || (c >= 42512 && c <= 42539)))
+                : (c <= 42610 || (c < 42623
+                  ? (c >= 42612 && c <= 42621)
+                  : c <= 42737)))))))))))
+      : (c <= 42783 || (c < 65313
+        ? (c < 43808
+          ? (c < 43360
+            ? (c < 43056
+              ? (c < 42963
+                ? (c < 42891
+                  ? (c >= 42786 && c <= 42888)
+                  : (c <= 42954 || (c >= 42960 && c <= 42961)))
+                : (c <= 42963 || (c < 42994
+                  ? (c >= 42965 && c <= 42969)
+                  : (c <= 43047 || c == 43052))))
+              : (c <= 43061 || (c < 43232
+                ? (c < 43136
+                  ? (c >= 43072 && c <= 43123)
+                  : (c <= 43205 || (c >= 43216 && c <= 43225)))
+                : (c <= 43255 || (c < 43261
+                  ? c == 43259
+                  : (c <= 43309 || (c >= 43312 && c <= 43347)))))))
+            : (c <= 43388 || (c < 43642
+              ? (c < 43520
+                ? (c < 43471
+                  ? (c >= 43392 && c <= 43456)
+                  : (c <= 43481 || (c >= 43488 && c <= 43518)))
+                : (c <= 43574 || (c < 43600
+                  ? (c >= 43584 && c <= 43597)
+                  : (c <= 43609 || (c >= 43616 && c <= 43638)))))
+              : (c <= 43714 || (c < 43777
+                ? (c < 43744
+                  ? (c >= 43739 && c <= 43741)
+                  : (c <= 43759 || (c >= 43762 && c <= 43766)))
+                : (c <= 43782 || (c < 43793
+                  ? (c >= 43785 && c <= 43790)
+                  : c <= 43798)))))))
+          : (c <= 43814 || (c < 64298
+            ? (c < 55203
+              ? (c < 43888
+                ? (c < 43824
+                  ? (c >= 43816 && c <= 43822)
+                  : (c <= 43866 || (c >= 43868 && c <= 43881)))
+                : (c <= 44010 || (c < 44016
+                  ? (c >= 44012 && c <= 44013)
+                  : (c <= 44025 || c == 44032))))
+              : (c <= 55203 || (c < 64112
+                ? (c < 55243
+                  ? (c >= 55216 && c <= 55238)
+                  : (c <= 55291 || (c >= 63744 && c <= 64109)))
+                : (c <= 64217 || (c < 64275
+                  ? (c >= 64256 && c <= 64262)
+                  : (c <= 64279 || (c >= 64285 && c <= 64296)))))))
+            : (c <= 64310 || (c < 64914
+              ? (c < 64323
+                ? (c < 64318
+                  ? (c >= 64312 && c <= 64316)
+                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
+                : (c <= 64324 || (c < 64467
+                  ? (c >= 64326 && c <= 64433)
+                  : (c <= 64829 || (c >= 64848 && c <= 64911)))))
+              : (c <= 64967 || (c < 65136
+                ? (c < 65024
+                  ? (c >= 65008 && c <= 65019)
+                  : (c <= 65039 || (c >= 65056 && c <= 65071)))
+                : (c <= 65140 || (c < 65296
+                  ? (c >= 65142 && c <= 65276)
+                  : c <= 65305)))))))))
+        : (c <= 65338 || (c < 66776
+          ? (c < 65930
+            ? (c < 65549
+              ? (c < 65482
+                ? (c < 65382
+                  ? (c >= 65345 && c <= 65370)
+                  : (c <= 65470 || (c >= 65474 && c <= 65479)))
+                : (c <= 65487 || (c < 65498
+                  ? (c >= 65490 && c <= 65495)
+                  : (c <= 65500 || (c >= 65536 && c <= 65547)))))
+              : (c <= 65574 || (c < 65616
+                ? (c < 65596
+                  ? (c >= 65576 && c <= 65594)
+                  : (c <= 65597 || (c >= 65599 && c <= 65613)))
+                : (c <= 65629 || (c < 65799
+                  ? (c >= 65664 && c <= 65786)
+                  : (c <= 65843 || (c >= 65856 && c <= 65912)))))))
+            : (c <= 65931 || (c < 66432
+              ? (c < 66272
+                ? (c < 66176
+                  ? c == 66045
+                  : (c <= 66204 || (c >= 66208 && c <= 66256)))
+                : (c <= 66299 || (c < 66349
+                  ? (c >= 66304 && c <= 66339)
+                  : (c <= 66378 || (c >= 66384 && c <= 66426)))))
+              : (c <= 66461 || (c < 66560
+                ? (c < 66504
+                  ? (c >= 66464 && c <= 66499)
+                  : (c <= 66511 || (c >= 66513 && c <= 66517)))
+                : (c <= 66717 || (c < 66736
+                  ? (c >= 66720 && c <= 66729)
+                  : c <= 66771)))))))
+          : (c <= 66811 || (c < 67463
+            ? (c < 66979
+              ? (c < 66940
+                ? (c < 66864
+                  ? (c >= 66816 && c <= 66855)
+                  : (c <= 66915 || (c >= 66928 && c <= 66938)))
+                : (c <= 66954 || (c < 66964
+                  ? (c >= 66956 && c <= 66962)
+                  : (c <= 66965 || (c >= 66967 && c <= 66977)))))
+              : (c <= 66993 || (c < 67392
+                ? (c < 67003
+                  ? (c >= 66995 && c <= 67001)
+                  : (c <= 67004 || (c >= 67072 && c <= 67382)))
+                : (c <= 67413 || (c < 67456
+                  ? (c >= 67424 && c <= 67431)
+                  : c <= 67461)))))
+            : (c <= 67504 || (c < 67672
+              ? (c < 67594
+                ? (c < 67584
+                  ? (c >= 67506 && c <= 67514)
+                  : (c <= 67589 || c == 67592))
+                : (c <= 67637 || (c < 67644
+                  ? (c >= 67639 && c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67828
+                ? (c < 67751
+                  ? (c >= 67705 && c <= 67742)
+                  : (c <= 67759 || (c >= 67808 && c <= 67826)))
+                : (c <= 67829 || (c < 67872
+                  ? (c >= 67835 && c <= 67867)
+                  : c <= 67883)))))))))))))));
+}
 
-static TSCharacterRange sym___identifier_char_no_digit_character_set_1[] = {
-  {'!', '!'}, {'#', '\''}, {'*', '+'}, {'-', '.'}, {':', ':'}, {'?', 'Z'}, {'^', '_'}, {'a', 'z'},
-  {'|', '|'}, {'~', '~'}, {0xaa, 0xaa}, {0xb2, 0xb3}, {0xb5, 0xb5}, {0xb9, 0xba}, {0xbc, 0xbe}, {0xc0, 0xd6},
-  {0xd8, 0xf6}, {0xf8, 0x2c1}, {0x2c6, 0x2d1}, {0x2e0, 0x2e4}, {0x2ec, 0x2ec}, {0x2ee, 0x2ee}, {0x300, 0x374}, {0x376, 0x377},
-  {0x37a, 0x37d}, {0x37f, 0x37f}, {0x386, 0x386}, {0x388, 0x38a}, {0x38c, 0x38c}, {0x38e, 0x3a1}, {0x3a3, 0x3f5}, {0x3f7, 0x481},
-  {0x483, 0x52f}, {0x531, 0x556}, {0x559, 0x559}, {0x560, 0x588}, {0x591, 0x5bd}, {0x5bf, 0x5bf}, {0x5c1, 0x5c2}, {0x5c4, 0x5c5},
-  {0x5c7, 0x5c7}, {0x5d0, 0x5ea}, {0x5ef, 0x5f2}, {0x610, 0x61a}, {0x620, 0x669}, {0x66e, 0x6d3}, {0x6d5, 0x6dc}, {0x6df, 0x6e8},
-  {0x6ea, 0x6fc}, {0x6ff, 0x6ff}, {0x710, 0x74a}, {0x74d, 0x7b1}, {0x7c0, 0x7f5}, {0x7fa, 0x7fa}, {0x7fd, 0x7fd}, {0x800, 0x82d},
-  {0x840, 0x85b}, {0x860, 0x86a}, {0x870, 0x887}, {0x889, 0x88e}, {0x898, 0x8e1}, {0x8e3, 0x963}, {0x966, 0x96f}, {0x971, 0x983},
-  {0x985, 0x98c}, {0x98f, 0x990}, {0x993, 0x9a8}, {0x9aa, 0x9b0}, {0x9b2, 0x9b2}, {0x9b6, 0x9b9}, {0x9bc, 0x9c4}, {0x9c7, 0x9c8},
-  {0x9cb, 0x9ce}, {0x9d7, 0x9d7}, {0x9dc, 0x9dd}, {0x9df, 0x9e3}, {0x9e6, 0x9f1}, {0x9f4, 0x9f9}, {0x9fc, 0x9fc}, {0x9fe, 0x9fe},
-  {0xa01, 0xa03}, {0xa05, 0xa0a}, {0xa0f, 0xa10}, {0xa13, 0xa28}, {0xa2a, 0xa30}, {0xa32, 0xa33}, {0xa35, 0xa36}, {0xa38, 0xa39},
-  {0xa3c, 0xa3c}, {0xa3e, 0xa42}, {0xa47, 0xa48}, {0xa4b, 0xa4d}, {0xa51, 0xa51}, {0xa59, 0xa5c}, {0xa5e, 0xa5e}, {0xa66, 0xa75},
-  {0xa81, 0xa83}, {0xa85, 0xa8d}, {0xa8f, 0xa91}, {0xa93, 0xaa8}, {0xaaa, 0xab0}, {0xab2, 0xab3}, {0xab5, 0xab9}, {0xabc, 0xac5},
-  {0xac7, 0xac9}, {0xacb, 0xacd}, {0xad0, 0xad0}, {0xae0, 0xae3}, {0xae6, 0xaef}, {0xaf9, 0xaff}, {0xb01, 0xb03}, {0xb05, 0xb0c},
-  {0xb0f, 0xb10}, {0xb13, 0xb28}, {0xb2a, 0xb30}, {0xb32, 0xb33}, {0xb35, 0xb39}, {0xb3c, 0xb44}, {0xb47, 0xb48}, {0xb4b, 0xb4d},
-  {0xb55, 0xb57}, {0xb5c, 0xb5d}, {0xb5f, 0xb63}, {0xb66, 0xb6f}, {0xb71, 0xb77}, {0xb82, 0xb83}, {0xb85, 0xb8a}, {0xb8e, 0xb90},
-  {0xb92, 0xb95}, {0xb99, 0xb9a}, {0xb9c, 0xb9c}, {0xb9e, 0xb9f}, {0xba3, 0xba4}, {0xba8, 0xbaa}, {0xbae, 0xbb9}, {0xbbe, 0xbc2},
-  {0xbc6, 0xbc8}, {0xbca, 0xbcd}, {0xbd0, 0xbd0}, {0xbd7, 0xbd7}, {0xbe6, 0xbf2}, {0xc00, 0xc0c}, {0xc0e, 0xc10}, {0xc12, 0xc28},
-  {0xc2a, 0xc39}, {0xc3c, 0xc44}, {0xc46, 0xc48}, {0xc4a, 0xc4d}, {0xc55, 0xc56}, {0xc58, 0xc5a}, {0xc5d, 0xc5d}, {0xc60, 0xc63},
-  {0xc66, 0xc6f}, {0xc78, 0xc7e}, {0xc80, 0xc83}, {0xc85, 0xc8c}, {0xc8e, 0xc90}, {0xc92, 0xca8}, {0xcaa, 0xcb3}, {0xcb5, 0xcb9},
-  {0xcbc, 0xcc4}, {0xcc6, 0xcc8}, {0xcca, 0xccd}, {0xcd5, 0xcd6}, {0xcdd, 0xcde}, {0xce0, 0xce3}, {0xce6, 0xcef}, {0xcf1, 0xcf3},
-  {0xd00, 0xd0c}, {0xd0e, 0xd10}, {0xd12, 0xd44}, {0xd46, 0xd48}, {0xd4a, 0xd4e}, {0xd54, 0xd63}, {0xd66, 0xd78}, {0xd7a, 0xd7f},
-  {0xd81, 0xd83}, {0xd85, 0xd96}, {0xd9a, 0xdb1}, {0xdb3, 0xdbb}, {0xdbd, 0xdbd}, {0xdc0, 0xdc6}, {0xdca, 0xdca}, {0xdcf, 0xdd4},
-  {0xdd6, 0xdd6}, {0xdd8, 0xddf}, {0xde6, 0xdef}, {0xdf2, 0xdf3}, {0xe01, 0xe3a}, {0xe40, 0xe4e}, {0xe50, 0xe59}, {0xe81, 0xe82},
-  {0xe84, 0xe84}, {0xe86, 0xe8a}, {0xe8c, 0xea3}, {0xea5, 0xea5}, {0xea7, 0xebd}, {0xec0, 0xec4}, {0xec6, 0xec6}, {0xec8, 0xece},
-  {0xed0, 0xed9}, {0xedc, 0xedf}, {0xf00, 0xf00}, {0xf18, 0xf19}, {0xf20, 0xf33}, {0xf35, 0xf35}, {0xf37, 0xf37}, {0xf39, 0xf39},
-  {0xf3e, 0xf47}, {0xf49, 0xf6c}, {0xf71, 0xf84}, {0xf86, 0xf97}, {0xf99, 0xfbc}, {0xfc6, 0xfc6}, {0x1000, 0x1049}, {0x1050, 0x109d},
-  {0x10a0, 0x10c5}, {0x10c7, 0x10c7}, {0x10cd, 0x10cd}, {0x10d0, 0x10fa}, {0x10fc, 0x1248}, {0x124a, 0x124d}, {0x1250, 0x1256}, {0x1258, 0x1258},
-  {0x125a, 0x125d}, {0x1260, 0x1288}, {0x128a, 0x128d}, {0x1290, 0x12b0}, {0x12b2, 0x12b5}, {0x12b8, 0x12be}, {0x12c0, 0x12c0}, {0x12c2, 0x12c5},
-  {0x12c8, 0x12d6}, {0x12d8, 0x1310}, {0x1312, 0x1315}, {0x1318, 0x135a}, {0x135d, 0x135f}, {0x1369, 0x137c}, {0x1380, 0x138f}, {0x13a0, 0x13f5},
-  {0x13f8, 0x13fd}, {0x1401, 0x166c}, {0x166f, 0x167f}, {0x1681, 0x169a}, {0x16a0, 0x16ea}, {0x16ee, 0x16f8}, {0x1700, 0x1715}, {0x171f, 0x1734},
-  {0x1740, 0x1753}, {0x1760, 0x176c}, {0x176e, 0x1770}, {0x1772, 0x1773}, {0x1780, 0x17d3}, {0x17d7, 0x17d7}, {0x17dc, 0x17dd}, {0x17e0, 0x17e9},
-  {0x17f0, 0x17f9}, {0x180b, 0x180d}, {0x180f, 0x1819}, {0x1820, 0x1878}, {0x1880, 0x18aa}, {0x18b0, 0x18f5}, {0x1900, 0x191e}, {0x1920, 0x192b},
-  {0x1930, 0x193b}, {0x1946, 0x196d}, {0x1970, 0x1974}, {0x1980, 0x19ab}, {0x19b0, 0x19c9}, {0x19d0, 0x19da}, {0x1a00, 0x1a1b}, {0x1a20, 0x1a5e},
-  {0x1a60, 0x1a7c}, {0x1a7f, 0x1a89}, {0x1a90, 0x1a99}, {0x1aa7, 0x1aa7}, {0x1ab0, 0x1ace}, {0x1b00, 0x1b4c}, {0x1b50, 0x1b59}, {0x1b6b, 0x1b73},
-  {0x1b80, 0x1bf3}, {0x1c00, 0x1c37}, {0x1c40, 0x1c49}, {0x1c4d, 0x1c7d}, {0x1c80, 0x1c88}, {0x1c90, 0x1cba}, {0x1cbd, 0x1cbf}, {0x1cd0, 0x1cd2},
-  {0x1cd4, 0x1cfa}, {0x1d00, 0x1f15}, {0x1f18, 0x1f1d}, {0x1f20, 0x1f45}, {0x1f48, 0x1f4d}, {0x1f50, 0x1f57}, {0x1f59, 0x1f59}, {0x1f5b, 0x1f5b},
-  {0x1f5d, 0x1f5d}, {0x1f5f, 0x1f7d}, {0x1f80, 0x1fb4}, {0x1fb6, 0x1fbc}, {0x1fbe, 0x1fbe}, {0x1fc2, 0x1fc4}, {0x1fc6, 0x1fcc}, {0x1fd0, 0x1fd3},
-  {0x1fd6, 0x1fdb}, {0x1fe0, 0x1fec}, {0x1ff2, 0x1ff4}, {0x1ff6, 0x1ffc}, {0x2070, 0x2071}, {0x2074, 0x2079}, {0x207f, 0x2089}, {0x2090, 0x209c},
-  {0x20d0, 0x20f0}, {0x2102, 0x2102}, {0x2107, 0x2107}, {0x210a, 0x2113}, {0x2115, 0x2115}, {0x2119, 0x211d}, {0x2124, 0x2124}, {0x2126, 0x2126},
-  {0x2128, 0x2128}, {0x212a, 0x212d}, {0x212f, 0x2139}, {0x213c, 0x213f}, {0x2145, 0x2149}, {0x214e, 0x214e}, {0x2150, 0x2189}, {0x2460, 0x249b},
-  {0x24ea, 0x24ff}, {0x2776, 0x2793}, {0x2c00, 0x2ce4}, {0x2ceb, 0x2cf3}, {0x2cfd, 0x2cfd}, {0x2d00, 0x2d25}, {0x2d27, 0x2d27}, {0x2d2d, 0x2d2d},
-  {0x2d30, 0x2d67}, {0x2d6f, 0x2d6f}, {0x2d7f, 0x2d96}, {0x2da0, 0x2da6}, {0x2da8, 0x2dae}, {0x2db0, 0x2db6}, {0x2db8, 0x2dbe}, {0x2dc0, 0x2dc6},
-  {0x2dc8, 0x2dce}, {0x2dd0, 0x2dd6}, {0x2dd8, 0x2dde}, {0x2de0, 0x2dff}, {0x2e2f, 0x2e2f}, {0x3005, 0x3007}, {0x3021, 0x302f}, {0x3031, 0x3035},
-  {0x3038, 0x303c}, {0x3041, 0x3096}, {0x3099, 0x309a}, {0x309d, 0x309f}, {0x30a1, 0x30fa}, {0x30fc, 0x30ff}, {0x3105, 0x312f}, {0x3131, 0x318e},
-  {0x3192, 0x3195}, {0x31a0, 0x31bf}, {0x31f0, 0x31ff}, {0x3220, 0x3229}, {0x3248, 0x324f}, {0x3251, 0x325f}, {0x3280, 0x3289}, {0x32b1, 0x32bf},
-  {0x3400, 0x3400}, {0x4dbf, 0x4dbf}, {0x4e00, 0xa48c}, {0xa4d0, 0xa4fd}, {0xa500, 0xa60c}, {0xa610, 0xa62b}, {0xa640, 0xa672}, {0xa674, 0xa67d},
-  {0xa67f, 0xa6f1}, {0xa717, 0xa71f}, {0xa722, 0xa788}, {0xa78b, 0xa7ca}, {0xa7d0, 0xa7d1}, {0xa7d3, 0xa7d3}, {0xa7d5, 0xa7d9}, {0xa7f2, 0xa827},
-  {0xa82c, 0xa82c}, {0xa830, 0xa835}, {0xa840, 0xa873}, {0xa880, 0xa8c5}, {0xa8d0, 0xa8d9}, {0xa8e0, 0xa8f7}, {0xa8fb, 0xa8fb}, {0xa8fd, 0xa92d},
-  {0xa930, 0xa953}, {0xa960, 0xa97c}, {0xa980, 0xa9c0}, {0xa9cf, 0xa9d9}, {0xa9e0, 0xa9fe}, {0xaa00, 0xaa36}, {0xaa40, 0xaa4d}, {0xaa50, 0xaa59},
-  {0xaa60, 0xaa76}, {0xaa7a, 0xaac2}, {0xaadb, 0xaadd}, {0xaae0, 0xaaef}, {0xaaf2, 0xaaf6}, {0xab01, 0xab06}, {0xab09, 0xab0e}, {0xab11, 0xab16},
-  {0xab20, 0xab26}, {0xab28, 0xab2e}, {0xab30, 0xab5a}, {0xab5c, 0xab69}, {0xab70, 0xabea}, {0xabec, 0xabed}, {0xabf0, 0xabf9}, {0xac00, 0xac00},
-  {0xd7a3, 0xd7a3}, {0xd7b0, 0xd7c6}, {0xd7cb, 0xd7fb}, {0xf900, 0xfa6d}, {0xfa70, 0xfad9}, {0xfb00, 0xfb06}, {0xfb13, 0xfb17}, {0xfb1d, 0xfb28},
-  {0xfb2a, 0xfb36}, {0xfb38, 0xfb3c}, {0xfb3e, 0xfb3e}, {0xfb40, 0xfb41}, {0xfb43, 0xfb44}, {0xfb46, 0xfbb1}, {0xfbd3, 0xfd3d}, {0xfd50, 0xfd8f},
-  {0xfd92, 0xfdc7}, {0xfdf0, 0xfdfb}, {0xfe00, 0xfe0f}, {0xfe20, 0xfe2f}, {0xfe70, 0xfe74}, {0xfe76, 0xfefc}, {0xff10, 0xff19}, {0xff21, 0xff3a},
-  {0xff41, 0xff5a}, {0xff66, 0xffbe}, {0xffc2, 0xffc7}, {0xffca, 0xffcf}, {0xffd2, 0xffd7}, {0xffda, 0xffdc}, {0x10000, 0x1000b}, {0x1000d, 0x10026},
-  {0x10028, 0x1003a}, {0x1003c, 0x1003d}, {0x1003f, 0x1004d}, {0x10050, 0x1005d}, {0x10080, 0x100fa}, {0x10107, 0x10133}, {0x10140, 0x10178}, {0x1018a, 0x1018b},
-  {0x101fd, 0x101fd}, {0x10280, 0x1029c}, {0x102a0, 0x102d0}, {0x102e0, 0x102fb}, {0x10300, 0x10323}, {0x1032d, 0x1034a}, {0x10350, 0x1037a}, {0x10380, 0x1039d},
-  {0x103a0, 0x103c3}, {0x103c8, 0x103cf}, {0x103d1, 0x103d5}, {0x10400, 0x1049d}, {0x104a0, 0x104a9}, {0x104b0, 0x104d3}, {0x104d8, 0x104fb}, {0x10500, 0x10527},
-  {0x10530, 0x10563}, {0x10570, 0x1057a}, {0x1057c, 0x1058a}, {0x1058c, 0x10592}, {0x10594, 0x10595}, {0x10597, 0x105a1}, {0x105a3, 0x105b1}, {0x105b3, 0x105b9},
-  {0x105bb, 0x105bc}, {0x10600, 0x10736}, {0x10740, 0x10755}, {0x10760, 0x10767}, {0x10780, 0x10785}, {0x10787, 0x107b0}, {0x107b2, 0x107ba}, {0x10800, 0x10805},
-  {0x10808, 0x10808}, {0x1080a, 0x10835}, {0x10837, 0x10838}, {0x1083c, 0x1083c}, {0x1083f, 0x10855}, {0x10858, 0x10876}, {0x10879, 0x1089e}, {0x108a7, 0x108af},
-  {0x108e0, 0x108f2}, {0x108f4, 0x108f5}, {0x108fb, 0x1091b},
-};
+static inline bool sym__normal_bare_identifier_character_set_3(int32_t c) {
+  return (c < 8488
+    ? (c < 3274
+      ? (c < 2575
+        ? (c < 1519
+          ? (c < 768
+            ? (c < 181
+              ? (c < 'a'
+                ? (c < '.'
+                  ? (c < '*'
+                    ? (c >= '!' && c <= '\'')
+                    : c <= '*')
+                  : (c <= ':' || (c < '^'
+                    ? (c >= '?' && c <= 'Z')
+                    : c <= '_')))
+                : (c <= '|' || (c < 174
+                  ? (c < 169
+                    ? c == '~'
+                    : c <= 170)
+                  : (c <= 174 || (c >= 178 && c <= 179)))))
+              : (c <= 181 || (c < 248
+                ? (c < 192
+                  ? (c < 188
+                    ? (c >= 185 && c <= 186)
+                    : c <= 190)
+                  : (c <= 214 || (c >= 216 && c <= 246)))
+                : (c <= 705 || (c < 748
+                  ? (c < 736
+                    ? (c >= 710 && c <= 721)
+                    : c <= 740)
+                  : (c <= 748 || c == 750))))))
+            : (c <= 884 || (c < 1155
+              ? (c < 904
+                ? (c < 895
+                  ? (c < 890
+                    ? (c >= 886 && c <= 887)
+                    : c <= 893)
+                  : (c <= 895 || c == 902))
+                : (c <= 906 || (c < 931
+                  ? (c < 910
+                    ? c == 908
+                    : c <= 929)
+                  : (c <= 1013 || (c >= 1015 && c <= 1153)))))
+              : (c <= 1327 || (c < 1471
+                ? (c < 1376
+                  ? (c < 1369
+                    ? (c >= 1329 && c <= 1366)
+                    : c <= 1369)
+                  : (c <= 1416 || (c >= 1425 && c <= 1469)))
+                : (c <= 1471 || (c < 1479
+                  ? (c < 1476
+                    ? (c >= 1473 && c <= 1474)
+                    : c <= 1477)
+                  : (c <= 1479 || (c >= 1488 && c <= 1514)))))))))
+          : (c <= 1522 || (c < 2406
+            ? (c < 1984
+              ? (c < 1759
+                ? (c < 1646
+                  ? (c < 1568
+                    ? (c >= 1552 && c <= 1562)
+                    : c <= 1641)
+                  : (c <= 1747 || (c >= 1749 && c <= 1756)))
+                : (c <= 1768 || (c < 1808
+                  ? (c < 1791
+                    ? (c >= 1770 && c <= 1788)
+                    : c <= 1791)
+                  : (c <= 1866 || (c >= 1869 && c <= 1969)))))
+              : (c <= 2037 || (c < 2144
+                ? (c < 2048
+                  ? (c < 2045
+                    ? c == 2042
+                    : c <= 2045)
+                  : (c <= 2093 || (c >= 2112 && c <= 2139)))
+                : (c <= 2154 || (c < 2200
+                  ? (c < 2185
+                    ? (c >= 2160 && c <= 2183)
+                    : c <= 2190)
+                  : (c <= 2273 || (c >= 2275 && c <= 2403)))))))
+            : (c <= 2415 || (c < 2507
+              ? (c < 2474
+                ? (c < 2447
+                  ? (c < 2437
+                    ? (c >= 2417 && c <= 2435)
+                    : c <= 2444)
+                  : (c <= 2448 || (c >= 2451 && c <= 2472)))
+                : (c <= 2480 || (c < 2492
+                  ? (c < 2486
+                    ? c == 2482
+                    : c <= 2489)
+                  : (c <= 2500 || (c >= 2503 && c <= 2504)))))
+              : (c <= 2510 || (c < 2548
+                ? (c < 2527
+                  ? (c < 2524
+                    ? c == 2519
+                    : c <= 2525)
+                  : (c <= 2531 || (c >= 2534 && c <= 2545)))
+                : (c <= 2553 || (c < 2561
+                  ? (c < 2558
+                    ? c == 2556
+                    : c <= 2558)
+                  : (c <= 2563 || (c >= 2565 && c <= 2570)))))))))))
+        : (c <= 2576 || (c < 2911
+          ? (c < 2741
+            ? (c < 2641
+              ? (c < 2616
+                ? (c < 2610
+                  ? (c < 2602
+                    ? (c >= 2579 && c <= 2600)
+                    : c <= 2608)
+                  : (c <= 2611 || (c >= 2613 && c <= 2614)))
+                : (c <= 2617 || (c < 2631
+                  ? (c < 2622
+                    ? c == 2620
+                    : c <= 2626)
+                  : (c <= 2632 || (c >= 2635 && c <= 2637)))))
+              : (c <= 2641 || (c < 2693
+                ? (c < 2662
+                  ? (c < 2654
+                    ? (c >= 2649 && c <= 2652)
+                    : c <= 2654)
+                  : (c <= 2677 || (c >= 2689 && c <= 2691)))
+                : (c <= 2701 || (c < 2730
+                  ? (c < 2707
+                    ? (c >= 2703 && c <= 2705)
+                    : c <= 2728)
+                  : (c <= 2736 || (c >= 2738 && c <= 2739)))))))
+            : (c <= 2745 || (c < 2831
+              ? (c < 2784
+                ? (c < 2763
+                  ? (c < 2759
+                    ? (c >= 2748 && c <= 2757)
+                    : c <= 2761)
+                  : (c <= 2765 || c == 2768))
+                : (c <= 2787 || (c < 2817
+                  ? (c < 2809
+                    ? (c >= 2790 && c <= 2799)
+                    : c <= 2815)
+                  : (c <= 2819 || (c >= 2821 && c <= 2828)))))
+              : (c <= 2832 || (c < 2876
+                ? (c < 2866
+                  ? (c < 2858
+                    ? (c >= 2835 && c <= 2856)
+                    : c <= 2864)
+                  : (c <= 2867 || (c >= 2869 && c <= 2873)))
+                : (c <= 2884 || (c < 2901
+                  ? (c < 2891
+                    ? (c >= 2887 && c <= 2888)
+                    : c <= 2893)
+                  : (c <= 2903 || (c >= 2908 && c <= 2909)))))))))
+          : (c <= 2915 || (c < 3086
+            ? (c < 2979
+              ? (c < 2958
+                ? (c < 2946
+                  ? (c < 2929
+                    ? (c >= 2918 && c <= 2927)
+                    : c <= 2935)
+                  : (c <= 2947 || (c >= 2949 && c <= 2954)))
+                : (c <= 2960 || (c < 2972
+                  ? (c < 2969
+                    ? (c >= 2962 && c <= 2965)
+                    : c <= 2970)
+                  : (c <= 2972 || (c >= 2974 && c <= 2975)))))
+              : (c <= 2980 || (c < 3018
+                ? (c < 3006
+                  ? (c < 2990
+                    ? (c >= 2984 && c <= 2986)
+                    : c <= 3001)
+                  : (c <= 3010 || (c >= 3014 && c <= 3016)))
+                : (c <= 3021 || (c < 3046
+                  ? (c < 3031
+                    ? c == 3024
+                    : c <= 3031)
+                  : (c <= 3058 || (c >= 3072 && c <= 3084)))))))
+            : (c <= 3088 || (c < 3174
+              ? (c < 3146
+                ? (c < 3132
+                  ? (c < 3114
+                    ? (c >= 3090 && c <= 3112)
+                    : c <= 3129)
+                  : (c <= 3140 || (c >= 3142 && c <= 3144)))
+                : (c <= 3149 || (c < 3165
+                  ? (c < 3160
+                    ? (c >= 3157 && c <= 3158)
+                    : c <= 3162)
+                  : (c <= 3165 || (c >= 3168 && c <= 3171)))))
+              : (c <= 3183 || (c < 3218
+                ? (c < 3205
+                  ? (c < 3200
+                    ? (c >= 3192 && c <= 3198)
+                    : c <= 3203)
+                  : (c <= 3212 || (c >= 3214 && c <= 3216)))
+                : (c <= 3240 || (c < 3260
+                  ? (c < 3253
+                    ? (c >= 3242 && c <= 3251)
+                    : c <= 3257)
+                  : (c <= 3268 || (c >= 3270 && c <= 3272)))))))))))))
+      : (c <= 3277 || (c < 5743
+        ? (c < 3840
+          ? (c < 3530
+            ? (c < 3402
+              ? (c < 3313
+                ? (c < 3296
+                  ? (c < 3293
+                    ? (c >= 3285 && c <= 3286)
+                    : c <= 3294)
+                  : (c <= 3299 || (c >= 3302 && c <= 3311)))
+                : (c <= 3314 || (c < 3346
+                  ? (c < 3342
+                    ? (c >= 3328 && c <= 3340)
+                    : c <= 3344)
+                  : (c <= 3396 || (c >= 3398 && c <= 3400)))))
+              : (c <= 3406 || (c < 3461
+                ? (c < 3450
+                  ? (c < 3430
+                    ? (c >= 3412 && c <= 3427)
+                    : c <= 3448)
+                  : (c <= 3455 || (c >= 3457 && c <= 3459)))
+                : (c <= 3478 || (c < 3517
+                  ? (c < 3507
+                    ? (c >= 3482 && c <= 3505)
+                    : c <= 3515)
+                  : (c <= 3517 || (c >= 3520 && c <= 3526)))))))
+            : (c <= 3530 || (c < 3716
+              ? (c < 3570
+                ? (c < 3544
+                  ? (c < 3542
+                    ? (c >= 3535 && c <= 3540)
+                    : c <= 3542)
+                  : (c <= 3551 || (c >= 3558 && c <= 3567)))
+                : (c <= 3571 || (c < 3664
+                  ? (c < 3648
+                    ? (c >= 3585 && c <= 3642)
+                    : c <= 3662)
+                  : (c <= 3673 || (c >= 3713 && c <= 3714)))))
+              : (c <= 3716 || (c < 3776
+                ? (c < 3749
+                  ? (c < 3724
+                    ? (c >= 3718 && c <= 3722)
+                    : c <= 3747)
+                  : (c <= 3749 || (c >= 3751 && c <= 3773)))
+                : (c <= 3780 || (c < 3792
+                  ? (c < 3784
+                    ? c == 3782
+                    : c <= 3789)
+                  : (c <= 3801 || (c >= 3804 && c <= 3807)))))))))
+          : (c <= 3840 || (c < 4688
+            ? (c < 3993
+              ? (c < 3897
+                ? (c < 3893
+                  ? (c < 3872
+                    ? (c >= 3864 && c <= 3865)
+                    : c <= 3891)
+                  : (c <= 3893 || c == 3895))
+                : (c <= 3897 || (c < 3953
+                  ? (c < 3913
+                    ? (c >= 3902 && c <= 3911)
+                    : c <= 3948)
+                  : (c <= 3972 || (c >= 3974 && c <= 3991)))))
+              : (c <= 4028 || (c < 4295
+                ? (c < 4176
+                  ? (c < 4096
+                    ? c == 4038
+                    : c <= 4169)
+                  : (c <= 4253 || (c >= 4256 && c <= 4293)))
+                : (c <= 4295 || (c < 4348
+                  ? (c < 4304
+                    ? c == 4301
+                    : c <= 4346)
+                  : (c <= 4680 || (c >= 4682 && c <= 4685)))))))
+            : (c <= 4694 || (c < 4808
+              ? (c < 4752
+                ? (c < 4704
+                  ? (c < 4698
+                    ? c == 4696
+                    : c <= 4701)
+                  : (c <= 4744 || (c >= 4746 && c <= 4749)))
+                : (c <= 4784 || (c < 4800
+                  ? (c < 4792
+                    ? (c >= 4786 && c <= 4789)
+                    : c <= 4798)
+                  : (c <= 4800 || (c >= 4802 && c <= 4805)))))
+              : (c <= 4822 || (c < 4969
+                ? (c < 4888
+                  ? (c < 4882
+                    ? (c >= 4824 && c <= 4880)
+                    : c <= 4885)
+                  : (c <= 4954 || (c >= 4957 && c <= 4959)))
+                : (c <= 4988 || (c < 5112
+                  ? (c < 5024
+                    ? (c >= 4992 && c <= 5007)
+                    : c <= 5109)
+                  : (c <= 5117 || (c >= 5121 && c <= 5740)))))))))))
+        : (c <= 5786 || (c < 7245
+          ? (c < 6432
+            ? (c < 6103
+              ? (c < 5952
+                ? (c < 5888
+                  ? (c < 5870
+                    ? (c >= 5792 && c <= 5866)
+                    : c <= 5880)
+                  : (c <= 5909 || (c >= 5919 && c <= 5940)))
+                : (c <= 5971 || (c < 6002
+                  ? (c < 5998
+                    ? (c >= 5984 && c <= 5996)
+                    : c <= 6000)
+                  : (c <= 6003 || (c >= 6016 && c <= 6099)))))
+              : (c <= 6103 || (c < 6159
+                ? (c < 6128
+                  ? (c < 6112
+                    ? (c >= 6108 && c <= 6109)
+                    : c <= 6121)
+                  : (c <= 6137 || (c >= 6155 && c <= 6157)))
+                : (c <= 6169 || (c < 6320
+                  ? (c < 6272
+                    ? (c >= 6176 && c <= 6264)
+                    : c <= 6314)
+                  : (c <= 6389 || (c >= 6400 && c <= 6430)))))))
+            : (c <= 6443 || (c < 6783
+              ? (c < 6576
+                ? (c < 6512
+                  ? (c < 6470
+                    ? (c >= 6448 && c <= 6459)
+                    : c <= 6509)
+                  : (c <= 6516 || (c >= 6528 && c <= 6571)))
+                : (c <= 6601 || (c < 6688
+                  ? (c < 6656
+                    ? (c >= 6608 && c <= 6618)
+                    : c <= 6683)
+                  : (c <= 6750 || (c >= 6752 && c <= 6780)))))
+              : (c <= 6793 || (c < 6992
+                ? (c < 6832
+                  ? (c < 6823
+                    ? (c >= 6800 && c <= 6809)
+                    : c <= 6823)
+                  : (c <= 6862 || (c >= 6912 && c <= 6988)))
+                : (c <= 7001 || (c < 7168
+                  ? (c < 7040
+                    ? (c >= 7019 && c <= 7027)
+                    : c <= 7155)
+                  : (c <= 7223 || (c >= 7232 && c <= 7241)))))))))
+          : (c <= 7293 || (c < 8144
+            ? (c < 8016
+              ? (c < 7380
+                ? (c < 7357
+                  ? (c < 7312
+                    ? (c >= 7296 && c <= 7304)
+                    : c <= 7354)
+                  : (c <= 7359 || (c >= 7376 && c <= 7378)))
+                : (c <= 7418 || (c < 7968
+                  ? (c < 7960
+                    ? (c >= 7424 && c <= 7957)
+                    : c <= 7965)
+                  : (c <= 8005 || (c >= 8008 && c <= 8013)))))
+              : (c <= 8023 || (c < 8064
+                ? (c < 8029
+                  ? (c < 8027
+                    ? c == 8025
+                    : c <= 8027)
+                  : (c <= 8029 || (c >= 8031 && c <= 8061)))
+                : (c <= 8116 || (c < 8130
+                  ? (c < 8126
+                    ? (c >= 8118 && c <= 8124)
+                    : c <= 8126)
+                  : (c <= 8132 || (c >= 8134 && c <= 8140)))))))
+            : (c <= 8147 || (c < 8336
+              ? (c < 8252
+                ? (c < 8178
+                  ? (c < 8160
+                    ? (c >= 8150 && c <= 8155)
+                    : c <= 8172)
+                  : (c <= 8180 || (c >= 8182 && c <= 8188)))
+                : (c <= 8252 || (c < 8308
+                  ? (c < 8304
+                    ? c == 8265
+                    : c <= 8305)
+                  : (c <= 8313 || (c >= 8319 && c <= 8329)))))
+              : (c <= 8348 || (c < 8469
+                ? (c < 8455
+                  ? (c < 8450
+                    ? (c >= 8400 && c <= 8432)
+                    : c <= 8450)
+                  : (c <= 8455 || (c >= 8458 && c <= 8467)))
+                : (c <= 8469 || (c < 8484
+                  ? (c < 8482
+                    ? (c >= 8473 && c <= 8477)
+                    : c <= 8482)
+                  : (c <= 8484 || c == 8486))))))))))))))
+    : (c <= 8488 || (c < 43744
+      ? (c < 10175
+        ? (c < 9854
+          ? (c < 9728
+            ? (c < 9167
+              ? (c < 8528
+                ? (c < 8508
+                  ? (c < 8495
+                    ? (c >= 8490 && c <= 8493)
+                    : c <= 8505)
+                  : (c <= 8511 || (c < 8526
+                    ? (c >= 8517 && c <= 8521)
+                    : c <= 8526)))
+                : (c <= 8585 || (c < 8986
+                  ? (c < 8617
+                    ? (c >= 8596 && c <= 8601)
+                    : c <= 8618)
+                  : (c <= 8987 || c == 9000))))
+              : (c <= 9167 || (c < 9450
+                ? (c < 9312
+                  ? (c < 9208
+                    ? (c >= 9193 && c <= 9203)
+                    : c <= 9210)
+                  : (c <= 9371 || c == 9410))
+                : (c <= 9471 || (c < 9664
+                  ? (c < 9654
+                    ? (c >= 9642 && c <= 9643)
+                    : c <= 9654)
+                  : (c <= 9664 || (c >= 9723 && c <= 9726)))))))
+            : (c <= 9732 || (c < 9774
+              ? (c < 9757
+                ? (c < 9748
+                  ? (c < 9745
+                    ? c == 9742
+                    : c <= 9745)
+                  : (c <= 9749 || c == 9752))
+                : (c <= 9757 || (c < 9766
+                  ? (c < 9762
+                    ? c == 9760
+                    : c <= 9763)
+                  : (c <= 9766 || c == 9770))))
+              : (c <= 9775 || (c < 9823
+                ? (c < 9794
+                  ? (c < 9792
+                    ? (c >= 9784 && c <= 9786)
+                    : c <= 9792)
+                  : (c <= 9794 || (c >= 9800 && c <= 9811)))
+                : (c <= 9824 || (c < 9832
+                  ? (c < 9829
+                    ? c == 9827
+                    : c <= 9830)
+                  : (c <= 9832 || c == 9851))))))))
+          : (c <= 9855 || (c < 9992
+            ? (c < 9928
+              ? (c < 9895
+                ? (c < 9883
+                  ? (c < 9881
+                    ? (c >= 9874 && c <= 9879)
+                    : c <= 9881)
+                  : (c <= 9884 || (c >= 9888 && c <= 9889)))
+                : (c <= 9895 || (c < 9917
+                  ? (c < 9904
+                    ? (c >= 9898 && c <= 9899)
+                    : c <= 9905)
+                  : (c <= 9918 || (c >= 9924 && c <= 9925)))))
+              : (c <= 9928 || (c < 9968
+                ? (c < 9939
+                  ? (c < 9937
+                    ? (c >= 9934 && c <= 9935)
+                    : c <= 9937)
+                  : (c <= 9940 || (c >= 9961 && c <= 9962)))
+                : (c <= 9973 || (c < 9986
+                  ? (c < 9981
+                    ? (c >= 9975 && c <= 9978)
+                    : c <= 9981)
+                  : (c <= 9986 || c == 9989))))))
+            : (c <= 9997 || (c < 10055
+              ? (c < 10013
+                ? (c < 10004
+                  ? (c < 10002
+                    ? c == 9999
+                    : c <= 10002)
+                  : (c <= 10004 || c == 10006))
+                : (c <= 10013 || (c < 10035
+                  ? (c < 10024
+                    ? c == 10017
+                    : c <= 10024)
+                  : (c <= 10036 || c == 10052))))
+              : (c <= 10055 || (c < 10083
+                ? (c < 10067
+                  ? (c < 10062
+                    ? c == 10060
+                    : c <= 10062)
+                  : (c <= 10069 || c == 10071))
+                : (c <= 10084 || (c < 10145
+                  ? (c < 10133
+                    ? (c >= 10102 && c <= 10131)
+                    : c <= 10135)
+                  : (c <= 10145 || c == 10160))))))))))
+        : (c <= 10175 || (c < 12881
+          ? (c < 11720
+            ? (c < 11559
+              ? (c < 11093
+                ? (c < 11035
+                  ? (c < 11013
+                    ? (c >= 10548 && c <= 10549)
+                    : c <= 11015)
+                  : (c <= 11036 || c == 11088))
+                : (c <= 11093 || (c < 11517
+                  ? (c < 11499
+                    ? (c >= 11264 && c <= 11492)
+                    : c <= 11507)
+                  : (c <= 11517 || (c >= 11520 && c <= 11557)))))
+              : (c <= 11559 || (c < 11680
+                ? (c < 11631
+                  ? (c < 11568
+                    ? c == 11565
+                    : c <= 11623)
+                  : (c <= 11631 || (c >= 11647 && c <= 11670)))
+                : (c <= 11686 || (c < 11704
+                  ? (c < 11696
+                    ? (c >= 11688 && c <= 11694)
+                    : c <= 11702)
+                  : (c <= 11710 || (c >= 11712 && c <= 11718)))))))
+            : (c <= 11726 || (c < 12445
+              ? (c < 12293
+                ? (c < 11744
+                  ? (c < 11736
+                    ? (c >= 11728 && c <= 11734)
+                    : c <= 11742)
+                  : (c <= 11775 || c == 11823))
+                : (c <= 12295 || (c < 12353
+                  ? (c < 12344
+                    ? (c >= 12321 && c <= 12341)
+                    : c <= 12349)
+                  : (c <= 12438 || (c >= 12441 && c <= 12442)))))
+              : (c <= 12447 || (c < 12690
+                ? (c < 12549
+                  ? (c < 12540
+                    ? (c >= 12449 && c <= 12538)
+                    : c <= 12543)
+                  : (c <= 12591 || (c >= 12593 && c <= 12686)))
+                : (c <= 12693 || (c < 12832
+                  ? (c < 12784
+                    ? (c >= 12704 && c <= 12735)
+                    : c <= 12799)
+                  : (c <= 12841 || (c >= 12872 && c <= 12879)))))))))
+          : (c <= 12895 || (c < 42994
+            ? (c < 42512
+              ? (c < 13312
+                ? (c < 12953
+                  ? (c < 12951
+                    ? (c >= 12928 && c <= 12937)
+                    : c <= 12951)
+                  : (c <= 12953 || (c >= 12977 && c <= 12991)))
+                : (c <= 13312 || (c < 42192
+                  ? (c < 19968
+                    ? c == 19903
+                    : c <= 42124)
+                  : (c <= 42237 || (c >= 42240 && c <= 42508)))))
+              : (c <= 42539 || (c < 42786
+                ? (c < 42623
+                  ? (c < 42612
+                    ? (c >= 42560 && c <= 42610)
+                    : c <= 42621)
+                  : (c <= 42737 || (c >= 42775 && c <= 42783)))
+                : (c <= 42888 || (c < 42963
+                  ? (c < 42960
+                    ? (c >= 42891 && c <= 42954)
+                    : c <= 42961)
+                  : (c <= 42963 || (c >= 42965 && c <= 42969)))))))
+            : (c <= 43047 || (c < 43360
+              ? (c < 43216
+                ? (c < 43072
+                  ? (c < 43056
+                    ? c == 43052
+                    : c <= 43061)
+                  : (c <= 43123 || (c >= 43136 && c <= 43205)))
+                : (c <= 43225 || (c < 43261
+                  ? (c < 43259
+                    ? (c >= 43232 && c <= 43255)
+                    : c <= 43259)
+                  : (c <= 43309 || (c >= 43312 && c <= 43347)))))
+              : (c <= 43388 || (c < 43584
+                ? (c < 43488
+                  ? (c < 43471
+                    ? (c >= 43392 && c <= 43456)
+                    : c <= 43481)
+                  : (c <= 43518 || (c >= 43520 && c <= 43574)))
+                : (c <= 43597 || (c < 43642
+                  ? (c < 43616
+                    ? (c >= 43600 && c <= 43609)
+                    : c <= 43638)
+                  : (c <= 43714 || (c >= 43739 && c <= 43741)))))))))))))
+      : (c <= 43759 || (c < 67424
+        ? (c < 65482
+          ? (c < 64285
+            ? (c < 44012
+              ? (c < 43808
+                ? (c < 43785
+                  ? (c < 43777
+                    ? (c >= 43762 && c <= 43766)
+                    : c <= 43782)
+                  : (c <= 43790 || (c >= 43793 && c <= 43798)))
+                : (c <= 43814 || (c < 43868
+                  ? (c < 43824
+                    ? (c >= 43816 && c <= 43822)
+                    : c <= 43866)
+                  : (c <= 43881 || (c >= 43888 && c <= 44010)))))
+              : (c <= 44013 || (c < 55243
+                ? (c < 55203
+                  ? (c < 44032
+                    ? (c >= 44016 && c <= 44025)
+                    : c <= 44032)
+                  : (c <= 55203 || (c >= 55216 && c <= 55238)))
+                : (c <= 55291 || (c < 64256
+                  ? (c < 64112
+                    ? (c >= 63744 && c <= 64109)
+                    : c <= 64217)
+                  : (c <= 64262 || (c >= 64275 && c <= 64279)))))))
+            : (c <= 64296 || (c < 65008
+              ? (c < 64323
+                ? (c < 64318
+                  ? (c < 64312
+                    ? (c >= 64298 && c <= 64310)
+                    : c <= 64316)
+                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
+                : (c <= 64324 || (c < 64848
+                  ? (c < 64467
+                    ? (c >= 64326 && c <= 64433)
+                    : c <= 64829)
+                  : (c <= 64911 || (c >= 64914 && c <= 64967)))))
+              : (c <= 65019 || (c < 65296
+                ? (c < 65136
+                  ? (c < 65056
+                    ? (c >= 65024 && c <= 65039)
+                    : c <= 65071)
+                  : (c <= 65140 || (c >= 65142 && c <= 65276)))
+                : (c <= 65305 || (c < 65382
+                  ? (c < 65345
+                    ? (c >= 65313 && c <= 65338)
+                    : c <= 65370)
+                  : (c <= 65470 || (c >= 65474 && c <= 65479)))))))))
+          : (c <= 65487 || (c < 66432
+            ? (c < 65799
+              ? (c < 65576
+                ? (c < 65536
+                  ? (c < 65498
+                    ? (c >= 65490 && c <= 65495)
+                    : c <= 65500)
+                  : (c <= 65547 || (c >= 65549 && c <= 65574)))
+                : (c <= 65594 || (c < 65616
+                  ? (c < 65599
+                    ? (c >= 65596 && c <= 65597)
+                    : c <= 65613)
+                  : (c <= 65629 || (c >= 65664 && c <= 65786)))))
+              : (c <= 65843 || (c < 66208
+                ? (c < 66045
+                  ? (c < 65930
+                    ? (c >= 65856 && c <= 65912)
+                    : c <= 65931)
+                  : (c <= 66045 || (c >= 66176 && c <= 66204)))
+                : (c <= 66256 || (c < 66349
+                  ? (c < 66304
+                    ? (c >= 66272 && c <= 66299)
+                    : c <= 66339)
+                  : (c <= 66378 || (c >= 66384 && c <= 66426)))))))
+            : (c <= 66461 || (c < 66928
+              ? (c < 66720
+                ? (c < 66513
+                  ? (c < 66504
+                    ? (c >= 66464 && c <= 66499)
+                    : c <= 66511)
+                  : (c <= 66517 || (c >= 66560 && c <= 66717)))
+                : (c <= 66729 || (c < 66816
+                  ? (c < 66776
+                    ? (c >= 66736 && c <= 66771)
+                    : c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))))
+              : (c <= 66938 || (c < 66979
+                ? (c < 66964
+                  ? (c < 66956
+                    ? (c >= 66940 && c <= 66954)
+                    : c <= 66962)
+                  : (c <= 66965 || (c >= 66967 && c <= 66977)))
+                : (c <= 66993 || (c < 67072
+                  ? (c < 67003
+                    ? (c >= 66995 && c <= 67001)
+                    : c <= 67004)
+                  : (c <= 67382 || (c >= 67392 && c <= 67413)))))))))))
+        : (c <= 67431 || (c < 128371
+          ? (c < 127358
+            ? (c < 67672
+              ? (c < 67592
+                ? (c < 67506
+                  ? (c < 67463
+                    ? (c >= 67456 && c <= 67461)
+                    : c <= 67504)
+                  : (c <= 67514 || (c >= 67584 && c <= 67589)))
+                : (c <= 67592 || (c < 67644
+                  ? (c < 67639
+                    ? (c >= 67594 && c <= 67637)
+                    : c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67835
+                ? (c < 67808
+                  ? (c < 67751
+                    ? (c >= 67705 && c <= 67742)
+                    : c <= 67759)
+                  : (c <= 67826 || (c >= 67828 && c <= 67829)))
+                : (c <= 67867 || (c < 127183
+                  ? (c < 126980
+                    ? (c >= 67872 && c <= 67883)
+                    : c <= 126980)
+                  : (c <= 127183 || (c >= 127344 && c <= 127345)))))))
+            : (c <= 127359 || (c < 127780
+              ? (c < 127514
+                ? (c < 127462
+                  ? (c < 127377
+                    ? c == 127374
+                    : c <= 127386)
+                  : (c <= 127487 || (c >= 127489 && c <= 127490)))
+                : (c <= 127514 || (c < 127568
+                  ? (c < 127538
+                    ? c == 127535
+                    : c <= 127546)
+                  : (c <= 127569 || (c >= 127744 && c <= 127777)))))
+              : (c <= 127891 || (c < 127991
+                ? (c < 127902
+                  ? (c < 127897
+                    ? (c >= 127894 && c <= 127895)
+                    : c <= 127899)
+                  : (c <= 127984 || (c >= 127987 && c <= 127989)))
+                : (c <= 128253 || (c < 128336
+                  ? (c < 128329
+                    ? (c >= 128255 && c <= 128317)
+                    : c <= 128334)
+                  : (c <= 128359 || (c >= 128367 && c <= 128368)))))))))
+          : (c <= 128378 || (c < 128725
+            ? (c < 128465
+              ? (c < 128420
+                ? (c < 128400
+                  ? (c < 128394
+                    ? c == 128391
+                    : c <= 128397)
+                  : (c <= 128400 || (c >= 128405 && c <= 128406)))
+                : (c <= 128421 || (c < 128444
+                  ? (c < 128433
+                    ? c == 128424
+                    : c <= 128434)
+                  : (c <= 128444 || (c >= 128450 && c <= 128452)))))
+              : (c <= 128467 || (c < 128495
+                ? (c < 128483
+                  ? (c < 128481
+                    ? (c >= 128476 && c <= 128478)
+                    : c <= 128481)
+                  : (c <= 128483 || c == 128488))
+                : (c <= 128495 || (c < 128640
+                  ? (c < 128506
+                    ? c == 128499
+                    : c <= 128591)
+                  : (c <= 128709 || (c >= 128715 && c <= 128722)))))))
+            : (c <= 128727 || (c < 129351
+              ? (c < 128755
+                ? (c < 128747
+                  ? (c < 128745
+                    ? (c >= 128733 && c <= 128741)
+                    : c <= 128745)
+                  : (c <= 128748 || c == 128752))
+                : (c <= 128764 || (c < 129292
+                  ? (c < 129008
+                    ? (c >= 128992 && c <= 129003)
+                    : c <= 129008)
+                  : (c <= 129338 || (c >= 129340 && c <= 129349)))))
+              : (c <= 129535 || (c < 129712
+                ? (c < 129664
+                  ? (c < 129656
+                    ? (c >= 129648 && c <= 129652)
+                    : c <= 129660)
+                  : (c <= 129670 || (c >= 129680 && c <= 129708)))
+                : (c <= 129722 || (c < 129760
+                  ? (c < 129744
+                    ? (c >= 129728 && c <= 129733)
+                    : c <= 129753)
+                  : (c <= 129767 || (c >= 129776 && c <= 129782)))))))))))))))));
+}
 
-static TSCharacterRange sym___identifier_char_no_digit_sign_character_set_1[] = {
-  {'!', '!'}, {'#', '\''}, {'*', '*'}, {'.', '.'}, {':', ':'}, {'?', 'Z'}, {'^', '_'}, {'a', 'z'},
-  {'|', '|'}, {'~', '~'}, {0xaa, 0xaa}, {0xb2, 0xb3}, {0xb5, 0xb5}, {0xb9, 0xba}, {0xbc, 0xbe}, {0xc0, 0xd6},
-  {0xd8, 0xf6}, {0xf8, 0x2c1}, {0x2c6, 0x2d1}, {0x2e0, 0x2e4}, {0x2ec, 0x2ec}, {0x2ee, 0x2ee}, {0x300, 0x374}, {0x376, 0x377},
-  {0x37a, 0x37d}, {0x37f, 0x37f}, {0x386, 0x386}, {0x388, 0x38a}, {0x38c, 0x38c}, {0x38e, 0x3a1}, {0x3a3, 0x3f5}, {0x3f7, 0x481},
-  {0x483, 0x52f}, {0x531, 0x556}, {0x559, 0x559}, {0x560, 0x588}, {0x591, 0x5bd}, {0x5bf, 0x5bf}, {0x5c1, 0x5c2}, {0x5c4, 0x5c5},
-  {0x5c7, 0x5c7}, {0x5d0, 0x5ea}, {0x5ef, 0x5f2}, {0x610, 0x61a}, {0x620, 0x669}, {0x66e, 0x6d3}, {0x6d5, 0x6dc}, {0x6df, 0x6e8},
-  {0x6ea, 0x6fc}, {0x6ff, 0x6ff}, {0x710, 0x74a}, {0x74d, 0x7b1}, {0x7c0, 0x7f5}, {0x7fa, 0x7fa}, {0x7fd, 0x7fd}, {0x800, 0x82d},
-  {0x840, 0x85b}, {0x860, 0x86a}, {0x870, 0x887}, {0x889, 0x88e}, {0x898, 0x8e1}, {0x8e3, 0x963}, {0x966, 0x96f}, {0x971, 0x983},
-  {0x985, 0x98c}, {0x98f, 0x990}, {0x993, 0x9a8}, {0x9aa, 0x9b0}, {0x9b2, 0x9b2}, {0x9b6, 0x9b9}, {0x9bc, 0x9c4}, {0x9c7, 0x9c8},
-  {0x9cb, 0x9ce}, {0x9d7, 0x9d7}, {0x9dc, 0x9dd}, {0x9df, 0x9e3}, {0x9e6, 0x9f1}, {0x9f4, 0x9f9}, {0x9fc, 0x9fc}, {0x9fe, 0x9fe},
-  {0xa01, 0xa03}, {0xa05, 0xa0a}, {0xa0f, 0xa10}, {0xa13, 0xa28}, {0xa2a, 0xa30}, {0xa32, 0xa33}, {0xa35, 0xa36}, {0xa38, 0xa39},
-  {0xa3c, 0xa3c}, {0xa3e, 0xa42}, {0xa47, 0xa48}, {0xa4b, 0xa4d}, {0xa51, 0xa51}, {0xa59, 0xa5c}, {0xa5e, 0xa5e}, {0xa66, 0xa75},
-  {0xa81, 0xa83}, {0xa85, 0xa8d}, {0xa8f, 0xa91}, {0xa93, 0xaa8}, {0xaaa, 0xab0}, {0xab2, 0xab3}, {0xab5, 0xab9}, {0xabc, 0xac5},
-  {0xac7, 0xac9}, {0xacb, 0xacd}, {0xad0, 0xad0}, {0xae0, 0xae3}, {0xae6, 0xaef}, {0xaf9, 0xaff}, {0xb01, 0xb03}, {0xb05, 0xb0c},
-  {0xb0f, 0xb10}, {0xb13, 0xb28}, {0xb2a, 0xb30}, {0xb32, 0xb33}, {0xb35, 0xb39}, {0xb3c, 0xb44}, {0xb47, 0xb48}, {0xb4b, 0xb4d},
-  {0xb55, 0xb57}, {0xb5c, 0xb5d}, {0xb5f, 0xb63}, {0xb66, 0xb6f}, {0xb71, 0xb77}, {0xb82, 0xb83}, {0xb85, 0xb8a}, {0xb8e, 0xb90},
-  {0xb92, 0xb95}, {0xb99, 0xb9a}, {0xb9c, 0xb9c}, {0xb9e, 0xb9f}, {0xba3, 0xba4}, {0xba8, 0xbaa}, {0xbae, 0xbb9}, {0xbbe, 0xbc2},
-  {0xbc6, 0xbc8}, {0xbca, 0xbcd}, {0xbd0, 0xbd0}, {0xbd7, 0xbd7}, {0xbe6, 0xbf2}, {0xc00, 0xc0c}, {0xc0e, 0xc10}, {0xc12, 0xc28},
-  {0xc2a, 0xc39}, {0xc3c, 0xc44}, {0xc46, 0xc48}, {0xc4a, 0xc4d}, {0xc55, 0xc56}, {0xc58, 0xc5a}, {0xc5d, 0xc5d}, {0xc60, 0xc63},
-  {0xc66, 0xc6f}, {0xc78, 0xc7e}, {0xc80, 0xc83}, {0xc85, 0xc8c}, {0xc8e, 0xc90}, {0xc92, 0xca8}, {0xcaa, 0xcb3}, {0xcb5, 0xcb9},
-  {0xcbc, 0xcc4}, {0xcc6, 0xcc8}, {0xcca, 0xccd}, {0xcd5, 0xcd6}, {0xcdd, 0xcde}, {0xce0, 0xce3}, {0xce6, 0xcef}, {0xcf1, 0xcf3},
-  {0xd00, 0xd0c}, {0xd0e, 0xd10}, {0xd12, 0xd44}, {0xd46, 0xd48}, {0xd4a, 0xd4e}, {0xd54, 0xd63}, {0xd66, 0xd78}, {0xd7a, 0xd7f},
-  {0xd81, 0xd83}, {0xd85, 0xd96}, {0xd9a, 0xdb1}, {0xdb3, 0xdbb}, {0xdbd, 0xdbd}, {0xdc0, 0xdc6}, {0xdca, 0xdca}, {0xdcf, 0xdd4},
-  {0xdd6, 0xdd6}, {0xdd8, 0xddf}, {0xde6, 0xdef}, {0xdf2, 0xdf3}, {0xe01, 0xe3a}, {0xe40, 0xe4e}, {0xe50, 0xe59}, {0xe81, 0xe82},
-  {0xe84, 0xe84}, {0xe86, 0xe8a}, {0xe8c, 0xea3}, {0xea5, 0xea5}, {0xea7, 0xebd}, {0xec0, 0xec4}, {0xec6, 0xec6}, {0xec8, 0xece},
-  {0xed0, 0xed9}, {0xedc, 0xedf}, {0xf00, 0xf00}, {0xf18, 0xf19}, {0xf20, 0xf33}, {0xf35, 0xf35}, {0xf37, 0xf37}, {0xf39, 0xf39},
-  {0xf3e, 0xf47}, {0xf49, 0xf6c}, {0xf71, 0xf84}, {0xf86, 0xf97}, {0xf99, 0xfbc}, {0xfc6, 0xfc6}, {0x1000, 0x1049}, {0x1050, 0x109d},
-  {0x10a0, 0x10c5}, {0x10c7, 0x10c7}, {0x10cd, 0x10cd}, {0x10d0, 0x10fa}, {0x10fc, 0x1248}, {0x124a, 0x124d}, {0x1250, 0x1256}, {0x1258, 0x1258},
-  {0x125a, 0x125d}, {0x1260, 0x1288}, {0x128a, 0x128d}, {0x1290, 0x12b0}, {0x12b2, 0x12b5}, {0x12b8, 0x12be}, {0x12c0, 0x12c0}, {0x12c2, 0x12c5},
-  {0x12c8, 0x12d6}, {0x12d8, 0x1310}, {0x1312, 0x1315}, {0x1318, 0x135a}, {0x135d, 0x135f}, {0x1369, 0x137c}, {0x1380, 0x138f}, {0x13a0, 0x13f5},
-  {0x13f8, 0x13fd}, {0x1401, 0x166c}, {0x166f, 0x167f}, {0x1681, 0x169a}, {0x16a0, 0x16ea}, {0x16ee, 0x16f8}, {0x1700, 0x1715}, {0x171f, 0x1734},
-  {0x1740, 0x1753}, {0x1760, 0x176c}, {0x176e, 0x1770}, {0x1772, 0x1773}, {0x1780, 0x17d3}, {0x17d7, 0x17d7}, {0x17dc, 0x17dd}, {0x17e0, 0x17e9},
-  {0x17f0, 0x17f9}, {0x180b, 0x180d}, {0x180f, 0x1819}, {0x1820, 0x1878}, {0x1880, 0x18aa}, {0x18b0, 0x18f5}, {0x1900, 0x191e}, {0x1920, 0x192b},
-  {0x1930, 0x193b}, {0x1946, 0x196d}, {0x1970, 0x1974}, {0x1980, 0x19ab}, {0x19b0, 0x19c9}, {0x19d0, 0x19da}, {0x1a00, 0x1a1b}, {0x1a20, 0x1a5e},
-  {0x1a60, 0x1a7c}, {0x1a7f, 0x1a89}, {0x1a90, 0x1a99}, {0x1aa7, 0x1aa7}, {0x1ab0, 0x1ace}, {0x1b00, 0x1b4c}, {0x1b50, 0x1b59}, {0x1b6b, 0x1b73},
-  {0x1b80, 0x1bf3}, {0x1c00, 0x1c37}, {0x1c40, 0x1c49}, {0x1c4d, 0x1c7d}, {0x1c80, 0x1c88}, {0x1c90, 0x1cba}, {0x1cbd, 0x1cbf}, {0x1cd0, 0x1cd2},
-  {0x1cd4, 0x1cfa}, {0x1d00, 0x1f15}, {0x1f18, 0x1f1d}, {0x1f20, 0x1f45}, {0x1f48, 0x1f4d}, {0x1f50, 0x1f57}, {0x1f59, 0x1f59}, {0x1f5b, 0x1f5b},
-  {0x1f5d, 0x1f5d}, {0x1f5f, 0x1f7d}, {0x1f80, 0x1fb4}, {0x1fb6, 0x1fbc}, {0x1fbe, 0x1fbe}, {0x1fc2, 0x1fc4}, {0x1fc6, 0x1fcc}, {0x1fd0, 0x1fd3},
-  {0x1fd6, 0x1fdb}, {0x1fe0, 0x1fec}, {0x1ff2, 0x1ff4}, {0x1ff6, 0x1ffc}, {0x2070, 0x2071}, {0x2074, 0x2079}, {0x207f, 0x2089}, {0x2090, 0x209c},
-  {0x20d0, 0x20f0}, {0x2102, 0x2102}, {0x2107, 0x2107}, {0x210a, 0x2113}, {0x2115, 0x2115}, {0x2119, 0x211d}, {0x2124, 0x2124}, {0x2126, 0x2126},
-  {0x2128, 0x2128}, {0x212a, 0x212d}, {0x212f, 0x2139}, {0x213c, 0x213f}, {0x2145, 0x2149}, {0x214e, 0x214e}, {0x2150, 0x2189}, {0x2460, 0x249b},
-  {0x24ea, 0x24ff}, {0x2776, 0x2793}, {0x2c00, 0x2ce4}, {0x2ceb, 0x2cf3}, {0x2cfd, 0x2cfd}, {0x2d00, 0x2d25}, {0x2d27, 0x2d27}, {0x2d2d, 0x2d2d},
-  {0x2d30, 0x2d67}, {0x2d6f, 0x2d6f}, {0x2d7f, 0x2d96}, {0x2da0, 0x2da6}, {0x2da8, 0x2dae}, {0x2db0, 0x2db6}, {0x2db8, 0x2dbe}, {0x2dc0, 0x2dc6},
-  {0x2dc8, 0x2dce}, {0x2dd0, 0x2dd6}, {0x2dd8, 0x2dde}, {0x2de0, 0x2dff}, {0x2e2f, 0x2e2f}, {0x3005, 0x3007}, {0x3021, 0x302f}, {0x3031, 0x3035},
-  {0x3038, 0x303c}, {0x3041, 0x3096}, {0x3099, 0x309a}, {0x309d, 0x309f}, {0x30a1, 0x30fa}, {0x30fc, 0x30ff}, {0x3105, 0x312f}, {0x3131, 0x318e},
-  {0x3192, 0x3195}, {0x31a0, 0x31bf}, {0x31f0, 0x31ff}, {0x3220, 0x3229}, {0x3248, 0x324f}, {0x3251, 0x325f}, {0x3280, 0x3289}, {0x32b1, 0x32bf},
-  {0x3400, 0x3400}, {0x4dbf, 0x4dbf}, {0x4e00, 0xa48c}, {0xa4d0, 0xa4fd}, {0xa500, 0xa60c}, {0xa610, 0xa62b}, {0xa640, 0xa672}, {0xa674, 0xa67d},
-  {0xa67f, 0xa6f1}, {0xa717, 0xa71f}, {0xa722, 0xa788}, {0xa78b, 0xa7ca}, {0xa7d0, 0xa7d1}, {0xa7d3, 0xa7d3}, {0xa7d5, 0xa7d9}, {0xa7f2, 0xa827},
-  {0xa82c, 0xa82c}, {0xa830, 0xa835}, {0xa840, 0xa873}, {0xa880, 0xa8c5}, {0xa8d0, 0xa8d9}, {0xa8e0, 0xa8f7}, {0xa8fb, 0xa8fb}, {0xa8fd, 0xa92d},
-  {0xa930, 0xa953}, {0xa960, 0xa97c}, {0xa980, 0xa9c0}, {0xa9cf, 0xa9d9}, {0xa9e0, 0xa9fe}, {0xaa00, 0xaa36}, {0xaa40, 0xaa4d}, {0xaa50, 0xaa59},
-  {0xaa60, 0xaa76}, {0xaa7a, 0xaac2}, {0xaadb, 0xaadd}, {0xaae0, 0xaaef}, {0xaaf2, 0xaaf6}, {0xab01, 0xab06}, {0xab09, 0xab0e}, {0xab11, 0xab16},
-  {0xab20, 0xab26}, {0xab28, 0xab2e}, {0xab30, 0xab5a}, {0xab5c, 0xab69}, {0xab70, 0xabea}, {0xabec, 0xabed}, {0xabf0, 0xabf9}, {0xac00, 0xac00},
-  {0xd7a3, 0xd7a3}, {0xd7b0, 0xd7c6}, {0xd7cb, 0xd7fb}, {0xf900, 0xfa6d}, {0xfa70, 0xfad9}, {0xfb00, 0xfb06}, {0xfb13, 0xfb17}, {0xfb1d, 0xfb28},
-  {0xfb2a, 0xfb36}, {0xfb38, 0xfb3c}, {0xfb3e, 0xfb3e}, {0xfb40, 0xfb41}, {0xfb43, 0xfb44}, {0xfb46, 0xfbb1}, {0xfbd3, 0xfd3d}, {0xfd50, 0xfd8f},
-  {0xfd92, 0xfdc7}, {0xfdf0, 0xfdfb}, {0xfe00, 0xfe0f}, {0xfe20, 0xfe2f}, {0xfe70, 0xfe74}, {0xfe76, 0xfefc}, {0xff10, 0xff19}, {0xff21, 0xff3a},
-  {0xff41, 0xff5a}, {0xff66, 0xffbe}, {0xffc2, 0xffc7}, {0xffca, 0xffcf}, {0xffd2, 0xffd7}, {0xffda, 0xffdc}, {0x10000, 0x1000b}, {0x1000d, 0x10026},
-  {0x10028, 0x1003a}, {0x1003c, 0x1003d}, {0x1003f, 0x1004d}, {0x10050, 0x1005d}, {0x10080, 0x100fa}, {0x10107, 0x10133}, {0x10140, 0x10178}, {0x1018a, 0x1018b},
-  {0x101fd, 0x101fd}, {0x10280, 0x1029c}, {0x102a0, 0x102d0}, {0x102e0, 0x102fb}, {0x10300, 0x10323}, {0x1032d, 0x1034a}, {0x10350, 0x1037a}, {0x10380, 0x1039d},
-  {0x103a0, 0x103c3}, {0x103c8, 0x103cf}, {0x103d1, 0x103d5}, {0x10400, 0x1049d}, {0x104a0, 0x104a9}, {0x104b0, 0x104d3}, {0x104d8, 0x104fb}, {0x10500, 0x10527},
-  {0x10530, 0x10563}, {0x10570, 0x1057a}, {0x1057c, 0x1058a}, {0x1058c, 0x10592}, {0x10594, 0x10595}, {0x10597, 0x105a1}, {0x105a3, 0x105b1}, {0x105b3, 0x105b9},
-  {0x105bb, 0x105bc}, {0x10600, 0x10736}, {0x10740, 0x10755}, {0x10760, 0x10767}, {0x10780, 0x10785}, {0x10787, 0x107b0}, {0x107b2, 0x107ba}, {0x10800, 0x10805},
-  {0x10808, 0x10808}, {0x1080a, 0x10835}, {0x10837, 0x10838}, {0x1083c, 0x1083c}, {0x1083f, 0x10855}, {0x10858, 0x10876}, {0x10879, 0x1089e}, {0x108a7, 0x108af},
-  {0x108e0, 0x108f2}, {0x108f4, 0x108f5}, {0x108fb, 0x1091b},
-};
+static inline bool sym__normal_bare_identifier_character_set_4(int32_t c) {
+  return (c < 8490
+    ? (c < 3285
+      ? (c < 2579
+        ? (c < 1552
+          ? (c < 886
+            ? (c < 185
+              ? (c < 'a'
+                ? (c < '?'
+                  ? (c < '.'
+                    ? (c >= '!' && c <= '*')
+                    : c <= ':')
+                  : (c <= 'Z' || (c >= '^' && c <= '_')))
+                : (c <= '~' || (c < 178
+                  ? (c < 174
+                    ? (c >= 169 && c <= 170)
+                    : c <= 174)
+                  : (c <= 179 || c == 181))))
+              : (c <= 186 || (c < 710
+                ? (c < 216
+                  ? (c < 192
+                    ? (c >= 188 && c <= 190)
+                    : c <= 214)
+                  : (c <= 246 || (c >= 248 && c <= 705)))
+                : (c <= 721 || (c < 750
+                  ? (c < 748
+                    ? (c >= 736 && c <= 740)
+                    : c <= 748)
+                  : (c <= 750 || (c >= 768 && c <= 884)))))))
+            : (c <= 887 || (c < 1329
+              ? (c < 908
+                ? (c < 902
+                  ? (c < 895
+                    ? (c >= 890 && c <= 893)
+                    : c <= 895)
+                  : (c <= 902 || (c >= 904 && c <= 906)))
+                : (c <= 908 || (c < 1015
+                  ? (c < 931
+                    ? (c >= 910 && c <= 929)
+                    : c <= 1013)
+                  : (c <= 1153 || (c >= 1155 && c <= 1327)))))
+              : (c <= 1366 || (c < 1473
+                ? (c < 1425
+                  ? (c < 1376
+                    ? c == 1369
+                    : c <= 1416)
+                  : (c <= 1469 || c == 1471))
+                : (c <= 1474 || (c < 1488
+                  ? (c < 1479
+                    ? (c >= 1476 && c <= 1477)
+                    : c <= 1479)
+                  : (c <= 1514 || (c >= 1519 && c <= 1522)))))))))
+          : (c <= 1562 || (c < 2417
+            ? (c < 2042
+              ? (c < 1770
+                ? (c < 1749
+                  ? (c < 1646
+                    ? (c >= 1568 && c <= 1641)
+                    : c <= 1747)
+                  : (c <= 1756 || (c >= 1759 && c <= 1768)))
+                : (c <= 1788 || (c < 1869
+                  ? (c < 1808
+                    ? c == 1791
+                    : c <= 1866)
+                  : (c <= 1969 || (c >= 1984 && c <= 2037)))))
+              : (c <= 2042 || (c < 2160
+                ? (c < 2112
+                  ? (c < 2048
+                    ? c == 2045
+                    : c <= 2093)
+                  : (c <= 2139 || (c >= 2144 && c <= 2154)))
+                : (c <= 2183 || (c < 2275
+                  ? (c < 2200
+                    ? (c >= 2185 && c <= 2190)
+                    : c <= 2273)
+                  : (c <= 2403 || (c >= 2406 && c <= 2415)))))))
+            : (c <= 2435 || (c < 2519
+              ? (c < 2482
+                ? (c < 2451
+                  ? (c < 2447
+                    ? (c >= 2437 && c <= 2444)
+                    : c <= 2448)
+                  : (c <= 2472 || (c >= 2474 && c <= 2480)))
+                : (c <= 2482 || (c < 2503
+                  ? (c < 2492
+                    ? (c >= 2486 && c <= 2489)
+                    : c <= 2500)
+                  : (c <= 2504 || (c >= 2507 && c <= 2510)))))
+              : (c <= 2519 || (c < 2556
+                ? (c < 2534
+                  ? (c < 2527
+                    ? (c >= 2524 && c <= 2525)
+                    : c <= 2531)
+                  : (c <= 2545 || (c >= 2548 && c <= 2553)))
+                : (c <= 2556 || (c < 2565
+                  ? (c < 2561
+                    ? c == 2558
+                    : c <= 2563)
+                  : (c <= 2570 || (c >= 2575 && c <= 2576)))))))))))
+        : (c <= 2600 || (c < 2918
+          ? (c < 2748
+            ? (c < 2649
+              ? (c < 2620
+                ? (c < 2613
+                  ? (c < 2610
+                    ? (c >= 2602 && c <= 2608)
+                    : c <= 2611)
+                  : (c <= 2614 || (c >= 2616 && c <= 2617)))
+                : (c <= 2620 || (c < 2635
+                  ? (c < 2631
+                    ? (c >= 2622 && c <= 2626)
+                    : c <= 2632)
+                  : (c <= 2637 || c == 2641))))
+              : (c <= 2652 || (c < 2703
+                ? (c < 2689
+                  ? (c < 2662
+                    ? c == 2654
+                    : c <= 2677)
+                  : (c <= 2691 || (c >= 2693 && c <= 2701)))
+                : (c <= 2705 || (c < 2738
+                  ? (c < 2730
+                    ? (c >= 2707 && c <= 2728)
+                    : c <= 2736)
+                  : (c <= 2739 || (c >= 2741 && c <= 2745)))))))
+            : (c <= 2757 || (c < 2835
+              ? (c < 2790
+                ? (c < 2768
+                  ? (c < 2763
+                    ? (c >= 2759 && c <= 2761)
+                    : c <= 2765)
+                  : (c <= 2768 || (c >= 2784 && c <= 2787)))
+                : (c <= 2799 || (c < 2821
+                  ? (c < 2817
+                    ? (c >= 2809 && c <= 2815)
+                    : c <= 2819)
+                  : (c <= 2828 || (c >= 2831 && c <= 2832)))))
+              : (c <= 2856 || (c < 2887
+                ? (c < 2869
+                  ? (c < 2866
+                    ? (c >= 2858 && c <= 2864)
+                    : c <= 2867)
+                  : (c <= 2873 || (c >= 2876 && c <= 2884)))
+                : (c <= 2888 || (c < 2908
+                  ? (c < 2901
+                    ? (c >= 2891 && c <= 2893)
+                    : c <= 2903)
+                  : (c <= 2909 || (c >= 2911 && c <= 2915)))))))))
+          : (c <= 2927 || (c < 3090
+            ? (c < 2984
+              ? (c < 2962
+                ? (c < 2949
+                  ? (c < 2946
+                    ? (c >= 2929 && c <= 2935)
+                    : c <= 2947)
+                  : (c <= 2954 || (c >= 2958 && c <= 2960)))
+                : (c <= 2965 || (c < 2974
+                  ? (c < 2972
+                    ? (c >= 2969 && c <= 2970)
+                    : c <= 2972)
+                  : (c <= 2975 || (c >= 2979 && c <= 2980)))))
+              : (c <= 2986 || (c < 3024
+                ? (c < 3014
+                  ? (c < 3006
+                    ? (c >= 2990 && c <= 3001)
+                    : c <= 3010)
+                  : (c <= 3016 || (c >= 3018 && c <= 3021)))
+                : (c <= 3024 || (c < 3072
+                  ? (c < 3046
+                    ? c == 3031
+                    : c <= 3058)
+                  : (c <= 3084 || (c >= 3086 && c <= 3088)))))))
+            : (c <= 3112 || (c < 3192
+              ? (c < 3157
+                ? (c < 3142
+                  ? (c < 3132
+                    ? (c >= 3114 && c <= 3129)
+                    : c <= 3140)
+                  : (c <= 3144 || (c >= 3146 && c <= 3149)))
+                : (c <= 3158 || (c < 3168
+                  ? (c < 3165
+                    ? (c >= 3160 && c <= 3162)
+                    : c <= 3165)
+                  : (c <= 3171 || (c >= 3174 && c <= 3183)))))
+              : (c <= 3198 || (c < 3242
+                ? (c < 3214
+                  ? (c < 3205
+                    ? (c >= 3200 && c <= 3203)
+                    : c <= 3212)
+                  : (c <= 3216 || (c >= 3218 && c <= 3240)))
+                : (c <= 3251 || (c < 3270
+                  ? (c < 3260
+                    ? (c >= 3253 && c <= 3257)
+                    : c <= 3268)
+                  : (c <= 3272 || (c >= 3274 && c <= 3277)))))))))))))
+      : (c <= 3286 || (c < 5792
+        ? (c < 3864
+          ? (c < 3535
+            ? (c < 3412
+              ? (c < 3328
+                ? (c < 3302
+                  ? (c < 3296
+                    ? (c >= 3293 && c <= 3294)
+                    : c <= 3299)
+                  : (c <= 3311 || (c >= 3313 && c <= 3314)))
+                : (c <= 3340 || (c < 3398
+                  ? (c < 3346
+                    ? (c >= 3342 && c <= 3344)
+                    : c <= 3396)
+                  : (c <= 3400 || (c >= 3402 && c <= 3406)))))
+              : (c <= 3427 || (c < 3482
+                ? (c < 3457
+                  ? (c < 3450
+                    ? (c >= 3430 && c <= 3448)
+                    : c <= 3455)
+                  : (c <= 3459 || (c >= 3461 && c <= 3478)))
+                : (c <= 3505 || (c < 3520
+                  ? (c < 3517
+                    ? (c >= 3507 && c <= 3515)
+                    : c <= 3517)
+                  : (c <= 3526 || c == 3530))))))
+            : (c <= 3540 || (c < 3718
+              ? (c < 3585
+                ? (c < 3558
+                  ? (c < 3544
+                    ? c == 3542
+                    : c <= 3551)
+                  : (c <= 3567 || (c >= 3570 && c <= 3571)))
+                : (c <= 3642 || (c < 3713
+                  ? (c < 3664
+                    ? (c >= 3648 && c <= 3662)
+                    : c <= 3673)
+                  : (c <= 3714 || c == 3716))))
+              : (c <= 3722 || (c < 3782
+                ? (c < 3751
+                  ? (c < 3749
+                    ? (c >= 3724 && c <= 3747)
+                    : c <= 3749)
+                  : (c <= 3773 || (c >= 3776 && c <= 3780)))
+                : (c <= 3782 || (c < 3804
+                  ? (c < 3792
+                    ? (c >= 3784 && c <= 3789)
+                    : c <= 3801)
+                  : (c <= 3807 || c == 3840))))))))
+          : (c <= 3865 || (c < 4696
+            ? (c < 4038
+              ? (c < 3902
+                ? (c < 3895
+                  ? (c < 3893
+                    ? (c >= 3872 && c <= 3891)
+                    : c <= 3893)
+                  : (c <= 3895 || c == 3897))
+                : (c <= 3911 || (c < 3974
+                  ? (c < 3953
+                    ? (c >= 3913 && c <= 3948)
+                    : c <= 3972)
+                  : (c <= 3991 || (c >= 3993 && c <= 4028)))))
+              : (c <= 4038 || (c < 4301
+                ? (c < 4256
+                  ? (c < 4176
+                    ? (c >= 4096 && c <= 4169)
+                    : c <= 4253)
+                  : (c <= 4293 || c == 4295))
+                : (c <= 4301 || (c < 4682
+                  ? (c < 4348
+                    ? (c >= 4304 && c <= 4346)
+                    : c <= 4680)
+                  : (c <= 4685 || (c >= 4688 && c <= 4694)))))))
+            : (c <= 4696 || (c < 4824
+              ? (c < 4786
+                ? (c < 4746
+                  ? (c < 4704
+                    ? (c >= 4698 && c <= 4701)
+                    : c <= 4744)
+                  : (c <= 4749 || (c >= 4752 && c <= 4784)))
+                : (c <= 4789 || (c < 4802
+                  ? (c < 4800
+                    ? (c >= 4792 && c <= 4798)
+                    : c <= 4800)
+                  : (c <= 4805 || (c >= 4808 && c <= 4822)))))
+              : (c <= 4880 || (c < 4992
+                ? (c < 4957
+                  ? (c < 4888
+                    ? (c >= 4882 && c <= 4885)
+                    : c <= 4954)
+                  : (c <= 4959 || (c >= 4969 && c <= 4988)))
+                : (c <= 5007 || (c < 5121
+                  ? (c < 5112
+                    ? (c >= 5024 && c <= 5109)
+                    : c <= 5117)
+                  : (c <= 5740 || (c >= 5743 && c <= 5786)))))))))))
+        : (c <= 5866 || (c < 7296
+          ? (c < 6448
+            ? (c < 6108
+              ? (c < 5984
+                ? (c < 5919
+                  ? (c < 5888
+                    ? (c >= 5870 && c <= 5880)
+                    : c <= 5909)
+                  : (c <= 5940 || (c >= 5952 && c <= 5971)))
+                : (c <= 5996 || (c < 6016
+                  ? (c < 6002
+                    ? (c >= 5998 && c <= 6000)
+                    : c <= 6003)
+                  : (c <= 6099 || c == 6103))))
+              : (c <= 6109 || (c < 6176
+                ? (c < 6155
+                  ? (c < 6128
+                    ? (c >= 6112 && c <= 6121)
+                    : c <= 6137)
+                  : (c <= 6157 || (c >= 6159 && c <= 6169)))
+                : (c <= 6264 || (c < 6400
+                  ? (c < 6320
+                    ? (c >= 6272 && c <= 6314)
+                    : c <= 6389)
+                  : (c <= 6430 || (c >= 6432 && c <= 6443)))))))
+            : (c <= 6459 || (c < 6800
+              ? (c < 6608
+                ? (c < 6528
+                  ? (c < 6512
+                    ? (c >= 6470 && c <= 6509)
+                    : c <= 6516)
+                  : (c <= 6571 || (c >= 6576 && c <= 6601)))
+                : (c <= 6618 || (c < 6752
+                  ? (c < 6688
+                    ? (c >= 6656 && c <= 6683)
+                    : c <= 6750)
+                  : (c <= 6780 || (c >= 6783 && c <= 6793)))))
+              : (c <= 6809 || (c < 7019
+                ? (c < 6912
+                  ? (c < 6832
+                    ? c == 6823
+                    : c <= 6862)
+                  : (c <= 6988 || (c >= 6992 && c <= 7001)))
+                : (c <= 7027 || (c < 7232
+                  ? (c < 7168
+                    ? (c >= 7040 && c <= 7155)
+                    : c <= 7223)
+                  : (c <= 7241 || (c >= 7245 && c <= 7293)))))))))
+          : (c <= 7304 || (c < 8150
+            ? (c < 8025
+              ? (c < 7424
+                ? (c < 7376
+                  ? (c < 7357
+                    ? (c >= 7312 && c <= 7354)
+                    : c <= 7359)
+                  : (c <= 7378 || (c >= 7380 && c <= 7418)))
+                : (c <= 7957 || (c < 8008
+                  ? (c < 7968
+                    ? (c >= 7960 && c <= 7965)
+                    : c <= 8005)
+                  : (c <= 8013 || (c >= 8016 && c <= 8023)))))
+              : (c <= 8025 || (c < 8118
+                ? (c < 8031
+                  ? (c < 8029
+                    ? c == 8027
+                    : c <= 8029)
+                  : (c <= 8061 || (c >= 8064 && c <= 8116)))
+                : (c <= 8124 || (c < 8134
+                  ? (c < 8130
+                    ? c == 8126
+                    : c <= 8132)
+                  : (c <= 8140 || (c >= 8144 && c <= 8147)))))))
+            : (c <= 8155 || (c < 8400
+              ? (c < 8265
+                ? (c < 8182
+                  ? (c < 8178
+                    ? (c >= 8160 && c <= 8172)
+                    : c <= 8180)
+                  : (c <= 8188 || c == 8252))
+                : (c <= 8265 || (c < 8319
+                  ? (c < 8308
+                    ? (c >= 8304 && c <= 8305)
+                    : c <= 8313)
+                  : (c <= 8329 || (c >= 8336 && c <= 8348)))))
+              : (c <= 8432 || (c < 8473
+                ? (c < 8458
+                  ? (c < 8455
+                    ? c == 8450
+                    : c <= 8455)
+                  : (c <= 8467 || c == 8469))
+                : (c <= 8477 || (c < 8486
+                  ? (c < 8484
+                    ? c == 8482
+                    : c <= 8484)
+                  : (c <= 8486 || c == 8488))))))))))))))
+    : (c <= 8493 || (c < 43744
+      ? (c < 10175
+        ? (c < 9854
+          ? (c < 9728
+            ? (c < 9167
+              ? (c < 8528
+                ? (c < 8517
+                  ? (c < 8508
+                    ? (c >= 8495 && c <= 8505)
+                    : c <= 8511)
+                  : (c <= 8521 || c == 8526))
+                : (c <= 8585 || (c < 8986
+                  ? (c < 8617
+                    ? (c >= 8596 && c <= 8601)
+                    : c <= 8618)
+                  : (c <= 8987 || c == 9000))))
+              : (c <= 9167 || (c < 9450
+                ? (c < 9312
+                  ? (c < 9208
+                    ? (c >= 9193 && c <= 9203)
+                    : c <= 9210)
+                  : (c <= 9371 || c == 9410))
+                : (c <= 9471 || (c < 9664
+                  ? (c < 9654
+                    ? (c >= 9642 && c <= 9643)
+                    : c <= 9654)
+                  : (c <= 9664 || (c >= 9723 && c <= 9726)))))))
+            : (c <= 9732 || (c < 9774
+              ? (c < 9757
+                ? (c < 9748
+                  ? (c < 9745
+                    ? c == 9742
+                    : c <= 9745)
+                  : (c <= 9749 || c == 9752))
+                : (c <= 9757 || (c < 9766
+                  ? (c < 9762
+                    ? c == 9760
+                    : c <= 9763)
+                  : (c <= 9766 || c == 9770))))
+              : (c <= 9775 || (c < 9823
+                ? (c < 9794
+                  ? (c < 9792
+                    ? (c >= 9784 && c <= 9786)
+                    : c <= 9792)
+                  : (c <= 9794 || (c >= 9800 && c <= 9811)))
+                : (c <= 9824 || (c < 9832
+                  ? (c < 9829
+                    ? c == 9827
+                    : c <= 9830)
+                  : (c <= 9832 || c == 9851))))))))
+          : (c <= 9855 || (c < 9992
+            ? (c < 9928
+              ? (c < 9895
+                ? (c < 9883
+                  ? (c < 9881
+                    ? (c >= 9874 && c <= 9879)
+                    : c <= 9881)
+                  : (c <= 9884 || (c >= 9888 && c <= 9889)))
+                : (c <= 9895 || (c < 9917
+                  ? (c < 9904
+                    ? (c >= 9898 && c <= 9899)
+                    : c <= 9905)
+                  : (c <= 9918 || (c >= 9924 && c <= 9925)))))
+              : (c <= 9928 || (c < 9968
+                ? (c < 9939
+                  ? (c < 9937
+                    ? (c >= 9934 && c <= 9935)
+                    : c <= 9937)
+                  : (c <= 9940 || (c >= 9961 && c <= 9962)))
+                : (c <= 9973 || (c < 9986
+                  ? (c < 9981
+                    ? (c >= 9975 && c <= 9978)
+                    : c <= 9981)
+                  : (c <= 9986 || c == 9989))))))
+            : (c <= 9997 || (c < 10055
+              ? (c < 10013
+                ? (c < 10004
+                  ? (c < 10002
+                    ? c == 9999
+                    : c <= 10002)
+                  : (c <= 10004 || c == 10006))
+                : (c <= 10013 || (c < 10035
+                  ? (c < 10024
+                    ? c == 10017
+                    : c <= 10024)
+                  : (c <= 10036 || c == 10052))))
+              : (c <= 10055 || (c < 10083
+                ? (c < 10067
+                  ? (c < 10062
+                    ? c == 10060
+                    : c <= 10062)
+                  : (c <= 10069 || c == 10071))
+                : (c <= 10084 || (c < 10145
+                  ? (c < 10133
+                    ? (c >= 10102 && c <= 10131)
+                    : c <= 10135)
+                  : (c <= 10145 || c == 10160))))))))))
+        : (c <= 10175 || (c < 12881
+          ? (c < 11720
+            ? (c < 11559
+              ? (c < 11093
+                ? (c < 11035
+                  ? (c < 11013
+                    ? (c >= 10548 && c <= 10549)
+                    : c <= 11015)
+                  : (c <= 11036 || c == 11088))
+                : (c <= 11093 || (c < 11517
+                  ? (c < 11499
+                    ? (c >= 11264 && c <= 11492)
+                    : c <= 11507)
+                  : (c <= 11517 || (c >= 11520 && c <= 11557)))))
+              : (c <= 11559 || (c < 11680
+                ? (c < 11631
+                  ? (c < 11568
+                    ? c == 11565
+                    : c <= 11623)
+                  : (c <= 11631 || (c >= 11647 && c <= 11670)))
+                : (c <= 11686 || (c < 11704
+                  ? (c < 11696
+                    ? (c >= 11688 && c <= 11694)
+                    : c <= 11702)
+                  : (c <= 11710 || (c >= 11712 && c <= 11718)))))))
+            : (c <= 11726 || (c < 12445
+              ? (c < 12293
+                ? (c < 11744
+                  ? (c < 11736
+                    ? (c >= 11728 && c <= 11734)
+                    : c <= 11742)
+                  : (c <= 11775 || c == 11823))
+                : (c <= 12295 || (c < 12353
+                  ? (c < 12344
+                    ? (c >= 12321 && c <= 12341)
+                    : c <= 12349)
+                  : (c <= 12438 || (c >= 12441 && c <= 12442)))))
+              : (c <= 12447 || (c < 12690
+                ? (c < 12549
+                  ? (c < 12540
+                    ? (c >= 12449 && c <= 12538)
+                    : c <= 12543)
+                  : (c <= 12591 || (c >= 12593 && c <= 12686)))
+                : (c <= 12693 || (c < 12832
+                  ? (c < 12784
+                    ? (c >= 12704 && c <= 12735)
+                    : c <= 12799)
+                  : (c <= 12841 || (c >= 12872 && c <= 12879)))))))))
+          : (c <= 12895 || (c < 42994
+            ? (c < 42512
+              ? (c < 13312
+                ? (c < 12953
+                  ? (c < 12951
+                    ? (c >= 12928 && c <= 12937)
+                    : c <= 12951)
+                  : (c <= 12953 || (c >= 12977 && c <= 12991)))
+                : (c <= 13312 || (c < 42192
+                  ? (c < 19968
+                    ? c == 19903
+                    : c <= 42124)
+                  : (c <= 42237 || (c >= 42240 && c <= 42508)))))
+              : (c <= 42539 || (c < 42786
+                ? (c < 42623
+                  ? (c < 42612
+                    ? (c >= 42560 && c <= 42610)
+                    : c <= 42621)
+                  : (c <= 42737 || (c >= 42775 && c <= 42783)))
+                : (c <= 42888 || (c < 42963
+                  ? (c < 42960
+                    ? (c >= 42891 && c <= 42954)
+                    : c <= 42961)
+                  : (c <= 42963 || (c >= 42965 && c <= 42969)))))))
+            : (c <= 43047 || (c < 43360
+              ? (c < 43216
+                ? (c < 43072
+                  ? (c < 43056
+                    ? c == 43052
+                    : c <= 43061)
+                  : (c <= 43123 || (c >= 43136 && c <= 43205)))
+                : (c <= 43225 || (c < 43261
+                  ? (c < 43259
+                    ? (c >= 43232 && c <= 43255)
+                    : c <= 43259)
+                  : (c <= 43309 || (c >= 43312 && c <= 43347)))))
+              : (c <= 43388 || (c < 43584
+                ? (c < 43488
+                  ? (c < 43471
+                    ? (c >= 43392 && c <= 43456)
+                    : c <= 43481)
+                  : (c <= 43518 || (c >= 43520 && c <= 43574)))
+                : (c <= 43597 || (c < 43642
+                  ? (c < 43616
+                    ? (c >= 43600 && c <= 43609)
+                    : c <= 43638)
+                  : (c <= 43714 || (c >= 43739 && c <= 43741)))))))))))))
+      : (c <= 43759 || (c < 67424
+        ? (c < 65482
+          ? (c < 64285
+            ? (c < 44012
+              ? (c < 43808
+                ? (c < 43785
+                  ? (c < 43777
+                    ? (c >= 43762 && c <= 43766)
+                    : c <= 43782)
+                  : (c <= 43790 || (c >= 43793 && c <= 43798)))
+                : (c <= 43814 || (c < 43868
+                  ? (c < 43824
+                    ? (c >= 43816 && c <= 43822)
+                    : c <= 43866)
+                  : (c <= 43881 || (c >= 43888 && c <= 44010)))))
+              : (c <= 44013 || (c < 55243
+                ? (c < 55203
+                  ? (c < 44032
+                    ? (c >= 44016 && c <= 44025)
+                    : c <= 44032)
+                  : (c <= 55203 || (c >= 55216 && c <= 55238)))
+                : (c <= 55291 || (c < 64256
+                  ? (c < 64112
+                    ? (c >= 63744 && c <= 64109)
+                    : c <= 64217)
+                  : (c <= 64262 || (c >= 64275 && c <= 64279)))))))
+            : (c <= 64296 || (c < 65008
+              ? (c < 64323
+                ? (c < 64318
+                  ? (c < 64312
+                    ? (c >= 64298 && c <= 64310)
+                    : c <= 64316)
+                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
+                : (c <= 64324 || (c < 64848
+                  ? (c < 64467
+                    ? (c >= 64326 && c <= 64433)
+                    : c <= 64829)
+                  : (c <= 64911 || (c >= 64914 && c <= 64967)))))
+              : (c <= 65019 || (c < 65296
+                ? (c < 65136
+                  ? (c < 65056
+                    ? (c >= 65024 && c <= 65039)
+                    : c <= 65071)
+                  : (c <= 65140 || (c >= 65142 && c <= 65276)))
+                : (c <= 65305 || (c < 65382
+                  ? (c < 65345
+                    ? (c >= 65313 && c <= 65338)
+                    : c <= 65370)
+                  : (c <= 65470 || (c >= 65474 && c <= 65479)))))))))
+          : (c <= 65487 || (c < 66432
+            ? (c < 65799
+              ? (c < 65576
+                ? (c < 65536
+                  ? (c < 65498
+                    ? (c >= 65490 && c <= 65495)
+                    : c <= 65500)
+                  : (c <= 65547 || (c >= 65549 && c <= 65574)))
+                : (c <= 65594 || (c < 65616
+                  ? (c < 65599
+                    ? (c >= 65596 && c <= 65597)
+                    : c <= 65613)
+                  : (c <= 65629 || (c >= 65664 && c <= 65786)))))
+              : (c <= 65843 || (c < 66208
+                ? (c < 66045
+                  ? (c < 65930
+                    ? (c >= 65856 && c <= 65912)
+                    : c <= 65931)
+                  : (c <= 66045 || (c >= 66176 && c <= 66204)))
+                : (c <= 66256 || (c < 66349
+                  ? (c < 66304
+                    ? (c >= 66272 && c <= 66299)
+                    : c <= 66339)
+                  : (c <= 66378 || (c >= 66384 && c <= 66426)))))))
+            : (c <= 66461 || (c < 66928
+              ? (c < 66720
+                ? (c < 66513
+                  ? (c < 66504
+                    ? (c >= 66464 && c <= 66499)
+                    : c <= 66511)
+                  : (c <= 66517 || (c >= 66560 && c <= 66717)))
+                : (c <= 66729 || (c < 66816
+                  ? (c < 66776
+                    ? (c >= 66736 && c <= 66771)
+                    : c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))))
+              : (c <= 66938 || (c < 66979
+                ? (c < 66964
+                  ? (c < 66956
+                    ? (c >= 66940 && c <= 66954)
+                    : c <= 66962)
+                  : (c <= 66965 || (c >= 66967 && c <= 66977)))
+                : (c <= 66993 || (c < 67072
+                  ? (c < 67003
+                    ? (c >= 66995 && c <= 67001)
+                    : c <= 67004)
+                  : (c <= 67382 || (c >= 67392 && c <= 67413)))))))))))
+        : (c <= 67431 || (c < 128371
+          ? (c < 127358
+            ? (c < 67672
+              ? (c < 67592
+                ? (c < 67506
+                  ? (c < 67463
+                    ? (c >= 67456 && c <= 67461)
+                    : c <= 67504)
+                  : (c <= 67514 || (c >= 67584 && c <= 67589)))
+                : (c <= 67592 || (c < 67644
+                  ? (c < 67639
+                    ? (c >= 67594 && c <= 67637)
+                    : c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67835
+                ? (c < 67808
+                  ? (c < 67751
+                    ? (c >= 67705 && c <= 67742)
+                    : c <= 67759)
+                  : (c <= 67826 || (c >= 67828 && c <= 67829)))
+                : (c <= 67867 || (c < 127183
+                  ? (c < 126980
+                    ? (c >= 67872 && c <= 67883)
+                    : c <= 126980)
+                  : (c <= 127183 || (c >= 127344 && c <= 127345)))))))
+            : (c <= 127359 || (c < 127780
+              ? (c < 127514
+                ? (c < 127462
+                  ? (c < 127377
+                    ? c == 127374
+                    : c <= 127386)
+                  : (c <= 127487 || (c >= 127489 && c <= 127490)))
+                : (c <= 127514 || (c < 127568
+                  ? (c < 127538
+                    ? c == 127535
+                    : c <= 127546)
+                  : (c <= 127569 || (c >= 127744 && c <= 127777)))))
+              : (c <= 127891 || (c < 127991
+                ? (c < 127902
+                  ? (c < 127897
+                    ? (c >= 127894 && c <= 127895)
+                    : c <= 127899)
+                  : (c <= 127984 || (c >= 127987 && c <= 127989)))
+                : (c <= 128253 || (c < 128336
+                  ? (c < 128329
+                    ? (c >= 128255 && c <= 128317)
+                    : c <= 128334)
+                  : (c <= 128359 || (c >= 128367 && c <= 128368)))))))))
+          : (c <= 128378 || (c < 128725
+            ? (c < 128465
+              ? (c < 128420
+                ? (c < 128400
+                  ? (c < 128394
+                    ? c == 128391
+                    : c <= 128397)
+                  : (c <= 128400 || (c >= 128405 && c <= 128406)))
+                : (c <= 128421 || (c < 128444
+                  ? (c < 128433
+                    ? c == 128424
+                    : c <= 128434)
+                  : (c <= 128444 || (c >= 128450 && c <= 128452)))))
+              : (c <= 128467 || (c < 128495
+                ? (c < 128483
+                  ? (c < 128481
+                    ? (c >= 128476 && c <= 128478)
+                    : c <= 128481)
+                  : (c <= 128483 || c == 128488))
+                : (c <= 128495 || (c < 128640
+                  ? (c < 128506
+                    ? c == 128499
+                    : c <= 128591)
+                  : (c <= 128709 || (c >= 128715 && c <= 128722)))))))
+            : (c <= 128727 || (c < 129351
+              ? (c < 128755
+                ? (c < 128747
+                  ? (c < 128745
+                    ? (c >= 128733 && c <= 128741)
+                    : c <= 128745)
+                  : (c <= 128748 || c == 128752))
+                : (c <= 128764 || (c < 129292
+                  ? (c < 129008
+                    ? (c >= 128992 && c <= 129003)
+                    : c <= 129008)
+                  : (c <= 129338 || (c >= 129340 && c <= 129349)))))
+              : (c <= 129535 || (c < 129712
+                ? (c < 129664
+                  ? (c < 129656
+                    ? (c >= 129648 && c <= 129652)
+                    : c <= 129660)
+                  : (c <= 129670 || (c >= 129680 && c <= 129708)))
+                : (c <= 129722 || (c < 129760
+                  ? (c < 129744
+                    ? (c >= 129728 && c <= 129733)
+                    : c <= 129753)
+                  : (c <= 129767 || (c >= 129776 && c <= 129782)))))))))))))))));
+}
+
+static inline bool sym__normal_bare_identifier_character_set_5(int32_t c) {
+  return (c < 8484
+    ? (c < 3260
+      ? (c < 2558
+        ? (c < 1476
+          ? (c < 736
+            ? (c < 169
+              ? (c < '?'
+                ? (c < '*'
+                  ? (c < '#'
+                    ? c == '!'
+                    : c <= '\'')
+                  : (c <= '+' || (c < '0'
+                    ? c == '.'
+                    : c <= ':')))
+                : (c <= 'Z' || (c < '|'
+                  ? (c < 'a'
+                    ? (c >= '^' && c <= '_')
+                    : c <= 'z')
+                  : (c <= '|' || c == '~'))))
+              : (c <= 170 || (c < 188
+                ? (c < 181
+                  ? (c < 178
+                    ? c == 174
+                    : c <= 179)
+                  : (c <= 181 || (c >= 185 && c <= 186)))
+                : (c <= 190 || (c < 248
+                  ? (c < 216
+                    ? (c >= 192 && c <= 214)
+                    : c <= 246)
+                  : (c <= 705 || (c >= 710 && c <= 721)))))))
+            : (c <= 740 || (c < 910
+              ? (c < 890
+                ? (c < 768
+                  ? (c < 750
+                    ? c == 748
+                    : c <= 750)
+                  : (c <= 884 || (c >= 886 && c <= 887)))
+                : (c <= 893 || (c < 904
+                  ? (c < 902
+                    ? c == 895
+                    : c <= 902)
+                  : (c <= 906 || c == 908))))
+              : (c <= 929 || (c < 1369
+                ? (c < 1155
+                  ? (c < 1015
+                    ? (c >= 931 && c <= 1013)
+                    : c <= 1153)
+                  : (c <= 1327 || (c >= 1329 && c <= 1366)))
+                : (c <= 1369 || (c < 1471
+                  ? (c < 1425
+                    ? (c >= 1376 && c <= 1416)
+                    : c <= 1469)
+                  : (c <= 1471 || (c >= 1473 && c <= 1474)))))))))
+          : (c <= 1477 || (c < 2185
+            ? (c < 1791
+              ? (c < 1568
+                ? (c < 1519
+                  ? (c < 1488
+                    ? c == 1479
+                    : c <= 1514)
+                  : (c <= 1522 || (c >= 1552 && c <= 1562)))
+                : (c <= 1641 || (c < 1759
+                  ? (c < 1749
+                    ? (c >= 1646 && c <= 1747)
+                    : c <= 1756)
+                  : (c <= 1768 || (c >= 1770 && c <= 1788)))))
+              : (c <= 1791 || (c < 2045
+                ? (c < 1984
+                  ? (c < 1869
+                    ? (c >= 1808 && c <= 1866)
+                    : c <= 1969)
+                  : (c <= 2037 || c == 2042))
+                : (c <= 2045 || (c < 2144
+                  ? (c < 2112
+                    ? (c >= 2048 && c <= 2093)
+                    : c <= 2139)
+                  : (c <= 2154 || (c >= 2160 && c <= 2183)))))))
+            : (c <= 2190 || (c < 2486
+              ? (c < 2437
+                ? (c < 2406
+                  ? (c < 2275
+                    ? (c >= 2200 && c <= 2273)
+                    : c <= 2403)
+                  : (c <= 2415 || (c >= 2417 && c <= 2435)))
+                : (c <= 2444 || (c < 2474
+                  ? (c < 2451
+                    ? (c >= 2447 && c <= 2448)
+                    : c <= 2472)
+                  : (c <= 2480 || c == 2482))))
+              : (c <= 2489 || (c < 2524
+                ? (c < 2507
+                  ? (c < 2503
+                    ? (c >= 2492 && c <= 2500)
+                    : c <= 2504)
+                  : (c <= 2510 || c == 2519))
+                : (c <= 2525 || (c < 2548
+                  ? (c < 2534
+                    ? (c >= 2527 && c <= 2531)
+                    : c <= 2545)
+                  : (c <= 2553 || c == 2556))))))))))
+        : (c <= 2558 || (c < 2901
+          ? (c < 2730
+            ? (c < 2631
+              ? (c < 2610
+                ? (c < 2575
+                  ? (c < 2565
+                    ? (c >= 2561 && c <= 2563)
+                    : c <= 2570)
+                  : (c <= 2576 || (c < 2602
+                    ? (c >= 2579 && c <= 2600)
+                    : c <= 2608)))
+                : (c <= 2611 || (c < 2620
+                  ? (c < 2616
+                    ? (c >= 2613 && c <= 2614)
+                    : c <= 2617)
+                  : (c <= 2620 || (c >= 2622 && c <= 2626)))))
+              : (c <= 2632 || (c < 2662
+                ? (c < 2649
+                  ? (c < 2641
+                    ? (c >= 2635 && c <= 2637)
+                    : c <= 2641)
+                  : (c <= 2652 || c == 2654))
+                : (c <= 2677 || (c < 2703
+                  ? (c < 2693
+                    ? (c >= 2689 && c <= 2691)
+                    : c <= 2701)
+                  : (c <= 2705 || (c >= 2707 && c <= 2728)))))))
+            : (c <= 2736 || (c < 2817
+              ? (c < 2763
+                ? (c < 2748
+                  ? (c < 2741
+                    ? (c >= 2738 && c <= 2739)
+                    : c <= 2745)
+                  : (c <= 2757 || (c >= 2759 && c <= 2761)))
+                : (c <= 2765 || (c < 2790
+                  ? (c < 2784
+                    ? c == 2768
+                    : c <= 2787)
+                  : (c <= 2799 || (c >= 2809 && c <= 2815)))))
+              : (c <= 2819 || (c < 2866
+                ? (c < 2835
+                  ? (c < 2831
+                    ? (c >= 2821 && c <= 2828)
+                    : c <= 2832)
+                  : (c <= 2856 || (c >= 2858 && c <= 2864)))
+                : (c <= 2867 || (c < 2887
+                  ? (c < 2876
+                    ? (c >= 2869 && c <= 2873)
+                    : c <= 2884)
+                  : (c <= 2888 || (c >= 2891 && c <= 2893)))))))))
+          : (c <= 2903 || (c < 3046
+            ? (c < 2972
+              ? (c < 2946
+                ? (c < 2918
+                  ? (c < 2911
+                    ? (c >= 2908 && c <= 2909)
+                    : c <= 2915)
+                  : (c <= 2927 || (c >= 2929 && c <= 2935)))
+                : (c <= 2947 || (c < 2962
+                  ? (c < 2958
+                    ? (c >= 2949 && c <= 2954)
+                    : c <= 2960)
+                  : (c <= 2965 || (c >= 2969 && c <= 2970)))))
+              : (c <= 2972 || (c < 3006
+                ? (c < 2984
+                  ? (c < 2979
+                    ? (c >= 2974 && c <= 2975)
+                    : c <= 2980)
+                  : (c <= 2986 || (c >= 2990 && c <= 3001)))
+                : (c <= 3010 || (c < 3024
+                  ? (c < 3018
+                    ? (c >= 3014 && c <= 3016)
+                    : c <= 3021)
+                  : (c <= 3024 || c == 3031))))))
+            : (c <= 3058 || (c < 3165
+              ? (c < 3132
+                ? (c < 3090
+                  ? (c < 3086
+                    ? (c >= 3072 && c <= 3084)
+                    : c <= 3088)
+                  : (c <= 3112 || (c >= 3114 && c <= 3129)))
+                : (c <= 3140 || (c < 3157
+                  ? (c < 3146
+                    ? (c >= 3142 && c <= 3144)
+                    : c <= 3149)
+                  : (c <= 3158 || (c >= 3160 && c <= 3162)))))
+              : (c <= 3165 || (c < 3205
+                ? (c < 3192
+                  ? (c < 3174
+                    ? (c >= 3168 && c <= 3171)
+                    : c <= 3183)
+                  : (c <= 3198 || (c >= 3200 && c <= 3203)))
+                : (c <= 3212 || (c < 3242
+                  ? (c < 3218
+                    ? (c >= 3214 && c <= 3216)
+                    : c <= 3240)
+                  : (c <= 3251 || (c >= 3253 && c <= 3257)))))))))))))
+      : (c <= 3268 || (c < 5121
+        ? (c < 3804
+          ? (c < 3520
+            ? (c < 3398
+              ? (c < 3302
+                ? (c < 3285
+                  ? (c < 3274
+                    ? (c >= 3270 && c <= 3272)
+                    : c <= 3277)
+                  : (c <= 3286 || (c < 3296
+                    ? (c >= 3293 && c <= 3294)
+                    : c <= 3299)))
+                : (c <= 3311 || (c < 3342
+                  ? (c < 3328
+                    ? (c >= 3313 && c <= 3314)
+                    : c <= 3340)
+                  : (c <= 3344 || (c >= 3346 && c <= 3396)))))
+              : (c <= 3400 || (c < 3457
+                ? (c < 3430
+                  ? (c < 3412
+                    ? (c >= 3402 && c <= 3406)
+                    : c <= 3427)
+                  : (c <= 3448 || (c >= 3450 && c <= 3455)))
+                : (c <= 3459 || (c < 3507
+                  ? (c < 3482
+                    ? (c >= 3461 && c <= 3478)
+                    : c <= 3505)
+                  : (c <= 3515 || c == 3517))))))
+            : (c <= 3526 || (c < 3713
+              ? (c < 3558
+                ? (c < 3542
+                  ? (c < 3535
+                    ? c == 3530
+                    : c <= 3540)
+                  : (c <= 3542 || (c >= 3544 && c <= 3551)))
+                : (c <= 3567 || (c < 3648
+                  ? (c < 3585
+                    ? (c >= 3570 && c <= 3571)
+                    : c <= 3642)
+                  : (c <= 3662 || (c >= 3664 && c <= 3673)))))
+              : (c <= 3714 || (c < 3751
+                ? (c < 3724
+                  ? (c < 3718
+                    ? c == 3716
+                    : c <= 3722)
+                  : (c <= 3747 || c == 3749))
+                : (c <= 3773 || (c < 3784
+                  ? (c < 3782
+                    ? (c >= 3776 && c <= 3780)
+                    : c <= 3782)
+                  : (c <= 3789 || (c >= 3792 && c <= 3801)))))))))
+          : (c <= 3807 || (c < 4682
+            ? (c < 3974
+              ? (c < 3895
+                ? (c < 3872
+                  ? (c < 3864
+                    ? c == 3840
+                    : c <= 3865)
+                  : (c <= 3891 || c == 3893))
+                : (c <= 3895 || (c < 3913
+                  ? (c < 3902
+                    ? c == 3897
+                    : c <= 3911)
+                  : (c <= 3948 || (c >= 3953 && c <= 3972)))))
+              : (c <= 3991 || (c < 4256
+                ? (c < 4096
+                  ? (c < 4038
+                    ? (c >= 3993 && c <= 4028)
+                    : c <= 4038)
+                  : (c <= 4169 || (c >= 4176 && c <= 4253)))
+                : (c <= 4293 || (c < 4304
+                  ? (c < 4301
+                    ? c == 4295
+                    : c <= 4301)
+                  : (c <= 4346 || (c >= 4348 && c <= 4680)))))))
+            : (c <= 4685 || (c < 4802
+              ? (c < 4746
+                ? (c < 4698
+                  ? (c < 4696
+                    ? (c >= 4688 && c <= 4694)
+                    : c <= 4696)
+                  : (c <= 4701 || (c >= 4704 && c <= 4744)))
+                : (c <= 4749 || (c < 4792
+                  ? (c < 4786
+                    ? (c >= 4752 && c <= 4784)
+                    : c <= 4789)
+                  : (c <= 4798 || c == 4800))))
+              : (c <= 4805 || (c < 4957
+                ? (c < 4882
+                  ? (c < 4824
+                    ? (c >= 4808 && c <= 4822)
+                    : c <= 4880)
+                  : (c <= 4885 || (c >= 4888 && c <= 4954)))
+                : (c <= 4959 || (c < 5024
+                  ? (c < 4992
+                    ? (c >= 4969 && c <= 4988)
+                    : c <= 5007)
+                  : (c <= 5109 || (c >= 5112 && c <= 5117)))))))))))
+        : (c <= 5740 || (c < 7168
+          ? (c < 6320
+            ? (c < 6002
+              ? (c < 5888
+                ? (c < 5792
+                  ? (c < 5761
+                    ? (c >= 5743 && c <= 5759)
+                    : c <= 5786)
+                  : (c <= 5866 || (c >= 5870 && c <= 5880)))
+                : (c <= 5909 || (c < 5984
+                  ? (c < 5952
+                    ? (c >= 5919 && c <= 5940)
+                    : c <= 5971)
+                  : (c <= 5996 || (c >= 5998 && c <= 6000)))))
+              : (c <= 6003 || (c < 6128
+                ? (c < 6108
+                  ? (c < 6103
+                    ? (c >= 6016 && c <= 6099)
+                    : c <= 6103)
+                  : (c <= 6109 || (c >= 6112 && c <= 6121)))
+                : (c <= 6137 || (c < 6176
+                  ? (c < 6159
+                    ? (c >= 6155 && c <= 6157)
+                    : c <= 6169)
+                  : (c <= 6264 || (c >= 6272 && c <= 6314)))))))
+            : (c <= 6389 || (c < 6688
+              ? (c < 6512
+                ? (c < 6448
+                  ? (c < 6432
+                    ? (c >= 6400 && c <= 6430)
+                    : c <= 6443)
+                  : (c <= 6459 || (c >= 6470 && c <= 6509)))
+                : (c <= 6516 || (c < 6608
+                  ? (c < 6576
+                    ? (c >= 6528 && c <= 6571)
+                    : c <= 6601)
+                  : (c <= 6618 || (c >= 6656 && c <= 6683)))))
+              : (c <= 6750 || (c < 6832
+                ? (c < 6800
+                  ? (c < 6783
+                    ? (c >= 6752 && c <= 6780)
+                    : c <= 6793)
+                  : (c <= 6809 || c == 6823))
+                : (c <= 6862 || (c < 7019
+                  ? (c < 6992
+                    ? (c >= 6912 && c <= 6988)
+                    : c <= 7001)
+                  : (c <= 7027 || (c >= 7040 && c <= 7155)))))))))
+          : (c <= 7223 || (c < 8130
+            ? (c < 7968
+              ? (c < 7357
+                ? (c < 7296
+                  ? (c < 7245
+                    ? (c >= 7232 && c <= 7241)
+                    : c <= 7293)
+                  : (c <= 7304 || (c >= 7312 && c <= 7354)))
+                : (c <= 7359 || (c < 7424
+                  ? (c < 7380
+                    ? (c >= 7376 && c <= 7378)
+                    : c <= 7418)
+                  : (c <= 7957 || (c >= 7960 && c <= 7965)))))
+              : (c <= 8005 || (c < 8029
+                ? (c < 8025
+                  ? (c < 8016
+                    ? (c >= 8008 && c <= 8013)
+                    : c <= 8023)
+                  : (c <= 8025 || c == 8027))
+                : (c <= 8029 || (c < 8118
+                  ? (c < 8064
+                    ? (c >= 8031 && c <= 8061)
+                    : c <= 8116)
+                  : (c <= 8124 || c == 8126))))))
+            : (c <= 8132 || (c < 8308
+              ? (c < 8178
+                ? (c < 8150
+                  ? (c < 8144
+                    ? (c >= 8134 && c <= 8140)
+                    : c <= 8147)
+                  : (c <= 8155 || (c >= 8160 && c <= 8172)))
+                : (c <= 8180 || (c < 8265
+                  ? (c < 8252
+                    ? (c >= 8182 && c <= 8188)
+                    : c <= 8252)
+                  : (c <= 8265 || (c >= 8304 && c <= 8305)))))
+              : (c <= 8313 || (c < 8455
+                ? (c < 8400
+                  ? (c < 8336
+                    ? (c >= 8319 && c <= 8329)
+                    : c <= 8348)
+                  : (c <= 8432 || c == 8450))
+                : (c <= 8455 || (c < 8473
+                  ? (c < 8469
+                    ? (c >= 8458 && c <= 8467)
+                    : c <= 8469)
+                  : (c <= 8477 || c == 8482))))))))))))))
+    : (c <= 8484 || (c < 43739
+      ? (c < 10145
+        ? (c < 9832
+          ? (c < 9664
+            ? (c < 8986
+              ? (c < 8517
+                ? (c < 8490
+                  ? (c < 8488
+                    ? c == 8486
+                    : c <= 8488)
+                  : (c <= 8493 || (c < 8508
+                    ? (c >= 8495 && c <= 8505)
+                    : c <= 8511)))
+                : (c <= 8521 || (c < 8596
+                  ? (c < 8528
+                    ? c == 8526
+                    : c <= 8585)
+                  : (c <= 8601 || (c >= 8617 && c <= 8618)))))
+              : (c <= 8987 || (c < 9312
+                ? (c < 9193
+                  ? (c < 9167
+                    ? c == 9000
+                    : c <= 9167)
+                  : (c <= 9203 || (c >= 9208 && c <= 9210)))
+                : (c <= 9371 || (c < 9642
+                  ? (c < 9450
+                    ? c == 9410
+                    : c <= 9471)
+                  : (c <= 9643 || c == 9654))))))
+            : (c <= 9664 || (c < 9766
+              ? (c < 9748
+                ? (c < 9742
+                  ? (c < 9728
+                    ? (c >= 9723 && c <= 9726)
+                    : c <= 9732)
+                  : (c <= 9742 || c == 9745))
+                : (c <= 9749 || (c < 9760
+                  ? (c < 9757
+                    ? c == 9752
+                    : c <= 9757)
+                  : (c <= 9760 || (c >= 9762 && c <= 9763)))))
+              : (c <= 9766 || (c < 9794
+                ? (c < 9784
+                  ? (c < 9774
+                    ? c == 9770
+                    : c <= 9775)
+                  : (c <= 9786 || c == 9792))
+                : (c <= 9794 || (c < 9827
+                  ? (c < 9823
+                    ? (c >= 9800 && c <= 9811)
+                    : c <= 9824)
+                  : (c <= 9827 || (c >= 9829 && c <= 9830)))))))))
+          : (c <= 9832 || (c < 9986
+            ? (c < 9917
+              ? (c < 9883
+                ? (c < 9874
+                  ? (c < 9854
+                    ? c == 9851
+                    : c <= 9855)
+                  : (c <= 9879 || c == 9881))
+                : (c <= 9884 || (c < 9898
+                  ? (c < 9895
+                    ? (c >= 9888 && c <= 9889)
+                    : c <= 9895)
+                  : (c <= 9899 || (c >= 9904 && c <= 9905)))))
+              : (c <= 9918 || (c < 9939
+                ? (c < 9934
+                  ? (c < 9928
+                    ? (c >= 9924 && c <= 9925)
+                    : c <= 9928)
+                  : (c <= 9935 || c == 9937))
+                : (c <= 9940 || (c < 9975
+                  ? (c < 9968
+                    ? (c >= 9961 && c <= 9962)
+                    : c <= 9973)
+                  : (c <= 9978 || c == 9981))))))
+            : (c <= 9986 || (c < 10035
+              ? (c < 10004
+                ? (c < 9999
+                  ? (c < 9992
+                    ? c == 9989
+                    : c <= 9997)
+                  : (c <= 9999 || c == 10002))
+                : (c <= 10004 || (c < 10017
+                  ? (c < 10013
+                    ? c == 10006
+                    : c <= 10013)
+                  : (c <= 10017 || c == 10024))))
+              : (c <= 10036 || (c < 10067
+                ? (c < 10060
+                  ? (c < 10055
+                    ? c == 10052
+                    : c <= 10055)
+                  : (c <= 10060 || c == 10062))
+                : (c <= 10069 || (c < 10102
+                  ? (c < 10083
+                    ? c == 10071
+                    : c <= 10084)
+                  : (c <= 10131 || (c >= 10133 && c <= 10135)))))))))))
+        : (c <= 10145 || (c < 12872
+          ? (c < 11712
+            ? (c < 11520
+              ? (c < 11088
+                ? (c < 10548
+                  ? (c < 10175
+                    ? c == 10160
+                    : c <= 10175)
+                  : (c <= 10549 || (c < 11035
+                    ? (c >= 11013 && c <= 11015)
+                    : c <= 11036)))
+                : (c <= 11088 || (c < 11499
+                  ? (c < 11264
+                    ? c == 11093
+                    : c <= 11492)
+                  : (c <= 11507 || c == 11517))))
+              : (c <= 11557 || (c < 11647
+                ? (c < 11568
+                  ? (c < 11565
+                    ? c == 11559
+                    : c <= 11565)
+                  : (c <= 11623 || c == 11631))
+                : (c <= 11670 || (c < 11696
+                  ? (c < 11688
+                    ? (c >= 11680 && c <= 11686)
+                    : c <= 11694)
+                  : (c <= 11702 || (c >= 11704 && c <= 11710)))))))
+            : (c <= 11718 || (c < 12441
+              ? (c < 11823
+                ? (c < 11736
+                  ? (c < 11728
+                    ? (c >= 11720 && c <= 11726)
+                    : c <= 11734)
+                  : (c <= 11742 || (c >= 11744 && c <= 11775)))
+                : (c <= 11823 || (c < 12344
+                  ? (c < 12321
+                    ? (c >= 12293 && c <= 12295)
+                    : c <= 12341)
+                  : (c <= 12349 || (c >= 12353 && c <= 12438)))))
+              : (c <= 12442 || (c < 12593
+                ? (c < 12540
+                  ? (c < 12449
+                    ? (c >= 12445 && c <= 12447)
+                    : c <= 12538)
+                  : (c <= 12543 || (c >= 12549 && c <= 12591)))
+                : (c <= 12686 || (c < 12784
+                  ? (c < 12704
+                    ? (c >= 12690 && c <= 12693)
+                    : c <= 12735)
+                  : (c <= 12799 || (c >= 12832 && c <= 12841)))))))))
+          : (c <= 12879 || (c < 42965
+            ? (c < 42240
+              ? (c < 12977
+                ? (c < 12951
+                  ? (c < 12928
+                    ? (c >= 12881 && c <= 12895)
+                    : c <= 12937)
+                  : (c <= 12951 || c == 12953))
+                : (c <= 12991 || (c < 19968
+                  ? (c < 19903
+                    ? c == 13312
+                    : c <= 19903)
+                  : (c <= 42124 || (c >= 42192 && c <= 42237)))))
+              : (c <= 42508 || (c < 42775
+                ? (c < 42612
+                  ? (c < 42560
+                    ? (c >= 42512 && c <= 42539)
+                    : c <= 42610)
+                  : (c <= 42621 || (c >= 42623 && c <= 42737)))
+                : (c <= 42783 || (c < 42960
+                  ? (c < 42891
+                    ? (c >= 42786 && c <= 42888)
+                    : c <= 42954)
+                  : (c <= 42961 || c == 42963))))))
+            : (c <= 42969 || (c < 43312
+              ? (c < 43136
+                ? (c < 43056
+                  ? (c < 43052
+                    ? (c >= 42994 && c <= 43047)
+                    : c <= 43052)
+                  : (c <= 43061 || (c >= 43072 && c <= 43123)))
+                : (c <= 43205 || (c < 43259
+                  ? (c < 43232
+                    ? (c >= 43216 && c <= 43225)
+                    : c <= 43255)
+                  : (c <= 43259 || (c >= 43261 && c <= 43309)))))
+              : (c <= 43347 || (c < 43520
+                ? (c < 43471
+                  ? (c < 43392
+                    ? (c >= 43360 && c <= 43388)
+                    : c <= 43456)
+                  : (c <= 43481 || (c >= 43488 && c <= 43518)))
+                : (c <= 43574 || (c < 43616
+                  ? (c < 43600
+                    ? (c >= 43584 && c <= 43597)
+                    : c <= 43609)
+                  : (c <= 43638 || (c >= 43642 && c <= 43714)))))))))))))
+      : (c <= 43741 || (c < 67424
+        ? (c < 65482
+          ? (c < 64285
+            ? (c < 44012
+              ? (c < 43808
+                ? (c < 43777
+                  ? (c < 43762
+                    ? (c >= 43744 && c <= 43759)
+                    : c <= 43766)
+                  : (c <= 43782 || (c < 43793
+                    ? (c >= 43785 && c <= 43790)
+                    : c <= 43798)))
+                : (c <= 43814 || (c < 43868
+                  ? (c < 43824
+                    ? (c >= 43816 && c <= 43822)
+                    : c <= 43866)
+                  : (c <= 43881 || (c >= 43888 && c <= 44010)))))
+              : (c <= 44013 || (c < 55243
+                ? (c < 55203
+                  ? (c < 44032
+                    ? (c >= 44016 && c <= 44025)
+                    : c <= 44032)
+                  : (c <= 55203 || (c >= 55216 && c <= 55238)))
+                : (c <= 55291 || (c < 64256
+                  ? (c < 64112
+                    ? (c >= 63744 && c <= 64109)
+                    : c <= 64217)
+                  : (c <= 64262 || (c >= 64275 && c <= 64279)))))))
+            : (c <= 64296 || (c < 65008
+              ? (c < 64323
+                ? (c < 64318
+                  ? (c < 64312
+                    ? (c >= 64298 && c <= 64310)
+                    : c <= 64316)
+                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
+                : (c <= 64324 || (c < 64848
+                  ? (c < 64467
+                    ? (c >= 64326 && c <= 64433)
+                    : c <= 64829)
+                  : (c <= 64911 || (c >= 64914 && c <= 64967)))))
+              : (c <= 65019 || (c < 65296
+                ? (c < 65136
+                  ? (c < 65056
+                    ? (c >= 65024 && c <= 65039)
+                    : c <= 65071)
+                  : (c <= 65140 || (c >= 65142 && c <= 65276)))
+                : (c <= 65305 || (c < 65382
+                  ? (c < 65345
+                    ? (c >= 65313 && c <= 65338)
+                    : c <= 65370)
+                  : (c <= 65470 || (c >= 65474 && c <= 65479)))))))))
+          : (c <= 65487 || (c < 66432
+            ? (c < 65799
+              ? (c < 65576
+                ? (c < 65536
+                  ? (c < 65498
+                    ? (c >= 65490 && c <= 65495)
+                    : c <= 65500)
+                  : (c <= 65547 || (c >= 65549 && c <= 65574)))
+                : (c <= 65594 || (c < 65616
+                  ? (c < 65599
+                    ? (c >= 65596 && c <= 65597)
+                    : c <= 65613)
+                  : (c <= 65629 || (c >= 65664 && c <= 65786)))))
+              : (c <= 65843 || (c < 66208
+                ? (c < 66045
+                  ? (c < 65930
+                    ? (c >= 65856 && c <= 65912)
+                    : c <= 65931)
+                  : (c <= 66045 || (c >= 66176 && c <= 66204)))
+                : (c <= 66256 || (c < 66349
+                  ? (c < 66304
+                    ? (c >= 66272 && c <= 66299)
+                    : c <= 66339)
+                  : (c <= 66378 || (c >= 66384 && c <= 66426)))))))
+            : (c <= 66461 || (c < 66928
+              ? (c < 66720
+                ? (c < 66513
+                  ? (c < 66504
+                    ? (c >= 66464 && c <= 66499)
+                    : c <= 66511)
+                  : (c <= 66517 || (c >= 66560 && c <= 66717)))
+                : (c <= 66729 || (c < 66816
+                  ? (c < 66776
+                    ? (c >= 66736 && c <= 66771)
+                    : c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))))
+              : (c <= 66938 || (c < 66979
+                ? (c < 66964
+                  ? (c < 66956
+                    ? (c >= 66940 && c <= 66954)
+                    : c <= 66962)
+                  : (c <= 66965 || (c >= 66967 && c <= 66977)))
+                : (c <= 66993 || (c < 67072
+                  ? (c < 67003
+                    ? (c >= 66995 && c <= 67001)
+                    : c <= 67004)
+                  : (c <= 67382 || (c >= 67392 && c <= 67413)))))))))))
+        : (c <= 67431 || (c < 128371
+          ? (c < 127358
+            ? (c < 67672
+              ? (c < 67592
+                ? (c < 67506
+                  ? (c < 67463
+                    ? (c >= 67456 && c <= 67461)
+                    : c <= 67504)
+                  : (c <= 67514 || (c >= 67584 && c <= 67589)))
+                : (c <= 67592 || (c < 67644
+                  ? (c < 67639
+                    ? (c >= 67594 && c <= 67637)
+                    : c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67835
+                ? (c < 67808
+                  ? (c < 67751
+                    ? (c >= 67705 && c <= 67742)
+                    : c <= 67759)
+                  : (c <= 67826 || (c >= 67828 && c <= 67829)))
+                : (c <= 67867 || (c < 127183
+                  ? (c < 126980
+                    ? (c >= 67872 && c <= 67883)
+                    : c <= 126980)
+                  : (c <= 127183 || (c >= 127344 && c <= 127345)))))))
+            : (c <= 127359 || (c < 127780
+              ? (c < 127514
+                ? (c < 127462
+                  ? (c < 127377
+                    ? c == 127374
+                    : c <= 127386)
+                  : (c <= 127487 || (c >= 127489 && c <= 127490)))
+                : (c <= 127514 || (c < 127568
+                  ? (c < 127538
+                    ? c == 127535
+                    : c <= 127546)
+                  : (c <= 127569 || (c >= 127744 && c <= 127777)))))
+              : (c <= 127891 || (c < 127991
+                ? (c < 127902
+                  ? (c < 127897
+                    ? (c >= 127894 && c <= 127895)
+                    : c <= 127899)
+                  : (c <= 127984 || (c >= 127987 && c <= 127989)))
+                : (c <= 128253 || (c < 128336
+                  ? (c < 128329
+                    ? (c >= 128255 && c <= 128317)
+                    : c <= 128334)
+                  : (c <= 128359 || (c >= 128367 && c <= 128368)))))))))
+          : (c <= 128378 || (c < 128725
+            ? (c < 128465
+              ? (c < 128420
+                ? (c < 128400
+                  ? (c < 128394
+                    ? c == 128391
+                    : c <= 128397)
+                  : (c <= 128400 || (c >= 128405 && c <= 128406)))
+                : (c <= 128421 || (c < 128444
+                  ? (c < 128433
+                    ? c == 128424
+                    : c <= 128434)
+                  : (c <= 128444 || (c >= 128450 && c <= 128452)))))
+              : (c <= 128467 || (c < 128495
+                ? (c < 128483
+                  ? (c < 128481
+                    ? (c >= 128476 && c <= 128478)
+                    : c <= 128481)
+                  : (c <= 128483 || c == 128488))
+                : (c <= 128495 || (c < 128640
+                  ? (c < 128506
+                    ? c == 128499
+                    : c <= 128591)
+                  : (c <= 128709 || (c >= 128715 && c <= 128722)))))))
+            : (c <= 128727 || (c < 129351
+              ? (c < 128755
+                ? (c < 128747
+                  ? (c < 128745
+                    ? (c >= 128733 && c <= 128741)
+                    : c <= 128745)
+                  : (c <= 128748 || c == 128752))
+                : (c <= 128764 || (c < 129292
+                  ? (c < 129008
+                    ? (c >= 128992 && c <= 129003)
+                    : c <= 129008)
+                  : (c <= 129338 || (c >= 129340 && c <= 129349)))))
+              : (c <= 129535 || (c < 129712
+                ? (c < 129664
+                  ? (c < 129656
+                    ? (c >= 129648 && c <= 129652)
+                    : c <= 129660)
+                  : (c <= 129670 || (c >= 129680 && c <= 129708)))
+                : (c <= 129722 || (c < 129760
+                  ? (c < 129744
+                    ? (c >= 129728 && c <= 129733)
+                    : c <= 129753)
+                  : (c <= 129767 || (c >= 129776 && c <= 129782)))))))))))))))));
+}
+
+static inline bool sym__normal_bare_identifier_character_set_6(int32_t c) {
+  return (c < 8484
+    ? (c < 3260
+      ? (c < 2558
+        ? (c < 1476
+          ? (c < 736
+            ? (c < 169
+              ? (c < '?'
+                ? (c < '*'
+                  ? (c < '#'
+                    ? c == '!'
+                    : c <= '\'')
+                  : (c <= '+' || (c < '0'
+                    ? (c >= '-' && c <= '.')
+                    : c <= ':')))
+                : (c <= 'Z' || (c < '|'
+                  ? (c < 'b'
+                    ? (c >= '^' && c <= '_')
+                    : c <= 'z')
+                  : (c <= '|' || c == '~'))))
+              : (c <= 170 || (c < 188
+                ? (c < 181
+                  ? (c < 178
+                    ? c == 174
+                    : c <= 179)
+                  : (c <= 181 || (c >= 185 && c <= 186)))
+                : (c <= 190 || (c < 248
+                  ? (c < 216
+                    ? (c >= 192 && c <= 214)
+                    : c <= 246)
+                  : (c <= 705 || (c >= 710 && c <= 721)))))))
+            : (c <= 740 || (c < 910
+              ? (c < 890
+                ? (c < 768
+                  ? (c < 750
+                    ? c == 748
+                    : c <= 750)
+                  : (c <= 884 || (c >= 886 && c <= 887)))
+                : (c <= 893 || (c < 904
+                  ? (c < 902
+                    ? c == 895
+                    : c <= 902)
+                  : (c <= 906 || c == 908))))
+              : (c <= 929 || (c < 1369
+                ? (c < 1155
+                  ? (c < 1015
+                    ? (c >= 931 && c <= 1013)
+                    : c <= 1153)
+                  : (c <= 1327 || (c >= 1329 && c <= 1366)))
+                : (c <= 1369 || (c < 1471
+                  ? (c < 1425
+                    ? (c >= 1376 && c <= 1416)
+                    : c <= 1469)
+                  : (c <= 1471 || (c >= 1473 && c <= 1474)))))))))
+          : (c <= 1477 || (c < 2185
+            ? (c < 1791
+              ? (c < 1568
+                ? (c < 1519
+                  ? (c < 1488
+                    ? c == 1479
+                    : c <= 1514)
+                  : (c <= 1522 || (c >= 1552 && c <= 1562)))
+                : (c <= 1641 || (c < 1759
+                  ? (c < 1749
+                    ? (c >= 1646 && c <= 1747)
+                    : c <= 1756)
+                  : (c <= 1768 || (c >= 1770 && c <= 1788)))))
+              : (c <= 1791 || (c < 2045
+                ? (c < 1984
+                  ? (c < 1869
+                    ? (c >= 1808 && c <= 1866)
+                    : c <= 1969)
+                  : (c <= 2037 || c == 2042))
+                : (c <= 2045 || (c < 2144
+                  ? (c < 2112
+                    ? (c >= 2048 && c <= 2093)
+                    : c <= 2139)
+                  : (c <= 2154 || (c >= 2160 && c <= 2183)))))))
+            : (c <= 2190 || (c < 2486
+              ? (c < 2437
+                ? (c < 2406
+                  ? (c < 2275
+                    ? (c >= 2200 && c <= 2273)
+                    : c <= 2403)
+                  : (c <= 2415 || (c >= 2417 && c <= 2435)))
+                : (c <= 2444 || (c < 2474
+                  ? (c < 2451
+                    ? (c >= 2447 && c <= 2448)
+                    : c <= 2472)
+                  : (c <= 2480 || c == 2482))))
+              : (c <= 2489 || (c < 2524
+                ? (c < 2507
+                  ? (c < 2503
+                    ? (c >= 2492 && c <= 2500)
+                    : c <= 2504)
+                  : (c <= 2510 || c == 2519))
+                : (c <= 2525 || (c < 2548
+                  ? (c < 2534
+                    ? (c >= 2527 && c <= 2531)
+                    : c <= 2545)
+                  : (c <= 2553 || c == 2556))))))))))
+        : (c <= 2558 || (c < 2901
+          ? (c < 2730
+            ? (c < 2631
+              ? (c < 2610
+                ? (c < 2575
+                  ? (c < 2565
+                    ? (c >= 2561 && c <= 2563)
+                    : c <= 2570)
+                  : (c <= 2576 || (c < 2602
+                    ? (c >= 2579 && c <= 2600)
+                    : c <= 2608)))
+                : (c <= 2611 || (c < 2620
+                  ? (c < 2616
+                    ? (c >= 2613 && c <= 2614)
+                    : c <= 2617)
+                  : (c <= 2620 || (c >= 2622 && c <= 2626)))))
+              : (c <= 2632 || (c < 2662
+                ? (c < 2649
+                  ? (c < 2641
+                    ? (c >= 2635 && c <= 2637)
+                    : c <= 2641)
+                  : (c <= 2652 || c == 2654))
+                : (c <= 2677 || (c < 2703
+                  ? (c < 2693
+                    ? (c >= 2689 && c <= 2691)
+                    : c <= 2701)
+                  : (c <= 2705 || (c >= 2707 && c <= 2728)))))))
+            : (c <= 2736 || (c < 2817
+              ? (c < 2763
+                ? (c < 2748
+                  ? (c < 2741
+                    ? (c >= 2738 && c <= 2739)
+                    : c <= 2745)
+                  : (c <= 2757 || (c >= 2759 && c <= 2761)))
+                : (c <= 2765 || (c < 2790
+                  ? (c < 2784
+                    ? c == 2768
+                    : c <= 2787)
+                  : (c <= 2799 || (c >= 2809 && c <= 2815)))))
+              : (c <= 2819 || (c < 2866
+                ? (c < 2835
+                  ? (c < 2831
+                    ? (c >= 2821 && c <= 2828)
+                    : c <= 2832)
+                  : (c <= 2856 || (c >= 2858 && c <= 2864)))
+                : (c <= 2867 || (c < 2887
+                  ? (c < 2876
+                    ? (c >= 2869 && c <= 2873)
+                    : c <= 2884)
+                  : (c <= 2888 || (c >= 2891 && c <= 2893)))))))))
+          : (c <= 2903 || (c < 3046
+            ? (c < 2972
+              ? (c < 2946
+                ? (c < 2918
+                  ? (c < 2911
+                    ? (c >= 2908 && c <= 2909)
+                    : c <= 2915)
+                  : (c <= 2927 || (c >= 2929 && c <= 2935)))
+                : (c <= 2947 || (c < 2962
+                  ? (c < 2958
+                    ? (c >= 2949 && c <= 2954)
+                    : c <= 2960)
+                  : (c <= 2965 || (c >= 2969 && c <= 2970)))))
+              : (c <= 2972 || (c < 3006
+                ? (c < 2984
+                  ? (c < 2979
+                    ? (c >= 2974 && c <= 2975)
+                    : c <= 2980)
+                  : (c <= 2986 || (c >= 2990 && c <= 3001)))
+                : (c <= 3010 || (c < 3024
+                  ? (c < 3018
+                    ? (c >= 3014 && c <= 3016)
+                    : c <= 3021)
+                  : (c <= 3024 || c == 3031))))))
+            : (c <= 3058 || (c < 3165
+              ? (c < 3132
+                ? (c < 3090
+                  ? (c < 3086
+                    ? (c >= 3072 && c <= 3084)
+                    : c <= 3088)
+                  : (c <= 3112 || (c >= 3114 && c <= 3129)))
+                : (c <= 3140 || (c < 3157
+                  ? (c < 3146
+                    ? (c >= 3142 && c <= 3144)
+                    : c <= 3149)
+                  : (c <= 3158 || (c >= 3160 && c <= 3162)))))
+              : (c <= 3165 || (c < 3205
+                ? (c < 3192
+                  ? (c < 3174
+                    ? (c >= 3168 && c <= 3171)
+                    : c <= 3183)
+                  : (c <= 3198 || (c >= 3200 && c <= 3203)))
+                : (c <= 3212 || (c < 3242
+                  ? (c < 3218
+                    ? (c >= 3214 && c <= 3216)
+                    : c <= 3240)
+                  : (c <= 3251 || (c >= 3253 && c <= 3257)))))))))))))
+      : (c <= 3268 || (c < 5121
+        ? (c < 3804
+          ? (c < 3520
+            ? (c < 3398
+              ? (c < 3302
+                ? (c < 3285
+                  ? (c < 3274
+                    ? (c >= 3270 && c <= 3272)
+                    : c <= 3277)
+                  : (c <= 3286 || (c < 3296
+                    ? (c >= 3293 && c <= 3294)
+                    : c <= 3299)))
+                : (c <= 3311 || (c < 3342
+                  ? (c < 3328
+                    ? (c >= 3313 && c <= 3314)
+                    : c <= 3340)
+                  : (c <= 3344 || (c >= 3346 && c <= 3396)))))
+              : (c <= 3400 || (c < 3457
+                ? (c < 3430
+                  ? (c < 3412
+                    ? (c >= 3402 && c <= 3406)
+                    : c <= 3427)
+                  : (c <= 3448 || (c >= 3450 && c <= 3455)))
+                : (c <= 3459 || (c < 3507
+                  ? (c < 3482
+                    ? (c >= 3461 && c <= 3478)
+                    : c <= 3505)
+                  : (c <= 3515 || c == 3517))))))
+            : (c <= 3526 || (c < 3713
+              ? (c < 3558
+                ? (c < 3542
+                  ? (c < 3535
+                    ? c == 3530
+                    : c <= 3540)
+                  : (c <= 3542 || (c >= 3544 && c <= 3551)))
+                : (c <= 3567 || (c < 3648
+                  ? (c < 3585
+                    ? (c >= 3570 && c <= 3571)
+                    : c <= 3642)
+                  : (c <= 3662 || (c >= 3664 && c <= 3673)))))
+              : (c <= 3714 || (c < 3751
+                ? (c < 3724
+                  ? (c < 3718
+                    ? c == 3716
+                    : c <= 3722)
+                  : (c <= 3747 || c == 3749))
+                : (c <= 3773 || (c < 3784
+                  ? (c < 3782
+                    ? (c >= 3776 && c <= 3780)
+                    : c <= 3782)
+                  : (c <= 3789 || (c >= 3792 && c <= 3801)))))))))
+          : (c <= 3807 || (c < 4682
+            ? (c < 3974
+              ? (c < 3895
+                ? (c < 3872
+                  ? (c < 3864
+                    ? c == 3840
+                    : c <= 3865)
+                  : (c <= 3891 || c == 3893))
+                : (c <= 3895 || (c < 3913
+                  ? (c < 3902
+                    ? c == 3897
+                    : c <= 3911)
+                  : (c <= 3948 || (c >= 3953 && c <= 3972)))))
+              : (c <= 3991 || (c < 4256
+                ? (c < 4096
+                  ? (c < 4038
+                    ? (c >= 3993 && c <= 4028)
+                    : c <= 4038)
+                  : (c <= 4169 || (c >= 4176 && c <= 4253)))
+                : (c <= 4293 || (c < 4304
+                  ? (c < 4301
+                    ? c == 4295
+                    : c <= 4301)
+                  : (c <= 4346 || (c >= 4348 && c <= 4680)))))))
+            : (c <= 4685 || (c < 4802
+              ? (c < 4746
+                ? (c < 4698
+                  ? (c < 4696
+                    ? (c >= 4688 && c <= 4694)
+                    : c <= 4696)
+                  : (c <= 4701 || (c >= 4704 && c <= 4744)))
+                : (c <= 4749 || (c < 4792
+                  ? (c < 4786
+                    ? (c >= 4752 && c <= 4784)
+                    : c <= 4789)
+                  : (c <= 4798 || c == 4800))))
+              : (c <= 4805 || (c < 4957
+                ? (c < 4882
+                  ? (c < 4824
+                    ? (c >= 4808 && c <= 4822)
+                    : c <= 4880)
+                  : (c <= 4885 || (c >= 4888 && c <= 4954)))
+                : (c <= 4959 || (c < 5024
+                  ? (c < 4992
+                    ? (c >= 4969 && c <= 4988)
+                    : c <= 5007)
+                  : (c <= 5109 || (c >= 5112 && c <= 5117)))))))))))
+        : (c <= 5740 || (c < 7168
+          ? (c < 6320
+            ? (c < 6002
+              ? (c < 5888
+                ? (c < 5792
+                  ? (c < 5761
+                    ? (c >= 5743 && c <= 5759)
+                    : c <= 5786)
+                  : (c <= 5866 || (c >= 5870 && c <= 5880)))
+                : (c <= 5909 || (c < 5984
+                  ? (c < 5952
+                    ? (c >= 5919 && c <= 5940)
+                    : c <= 5971)
+                  : (c <= 5996 || (c >= 5998 && c <= 6000)))))
+              : (c <= 6003 || (c < 6128
+                ? (c < 6108
+                  ? (c < 6103
+                    ? (c >= 6016 && c <= 6099)
+                    : c <= 6103)
+                  : (c <= 6109 || (c >= 6112 && c <= 6121)))
+                : (c <= 6137 || (c < 6176
+                  ? (c < 6159
+                    ? (c >= 6155 && c <= 6157)
+                    : c <= 6169)
+                  : (c <= 6264 || (c >= 6272 && c <= 6314)))))))
+            : (c <= 6389 || (c < 6688
+              ? (c < 6512
+                ? (c < 6448
+                  ? (c < 6432
+                    ? (c >= 6400 && c <= 6430)
+                    : c <= 6443)
+                  : (c <= 6459 || (c >= 6470 && c <= 6509)))
+                : (c <= 6516 || (c < 6608
+                  ? (c < 6576
+                    ? (c >= 6528 && c <= 6571)
+                    : c <= 6601)
+                  : (c <= 6618 || (c >= 6656 && c <= 6683)))))
+              : (c <= 6750 || (c < 6832
+                ? (c < 6800
+                  ? (c < 6783
+                    ? (c >= 6752 && c <= 6780)
+                    : c <= 6793)
+                  : (c <= 6809 || c == 6823))
+                : (c <= 6862 || (c < 7019
+                  ? (c < 6992
+                    ? (c >= 6912 && c <= 6988)
+                    : c <= 7001)
+                  : (c <= 7027 || (c >= 7040 && c <= 7155)))))))))
+          : (c <= 7223 || (c < 8130
+            ? (c < 7968
+              ? (c < 7357
+                ? (c < 7296
+                  ? (c < 7245
+                    ? (c >= 7232 && c <= 7241)
+                    : c <= 7293)
+                  : (c <= 7304 || (c >= 7312 && c <= 7354)))
+                : (c <= 7359 || (c < 7424
+                  ? (c < 7380
+                    ? (c >= 7376 && c <= 7378)
+                    : c <= 7418)
+                  : (c <= 7957 || (c >= 7960 && c <= 7965)))))
+              : (c <= 8005 || (c < 8029
+                ? (c < 8025
+                  ? (c < 8016
+                    ? (c >= 8008 && c <= 8013)
+                    : c <= 8023)
+                  : (c <= 8025 || c == 8027))
+                : (c <= 8029 || (c < 8118
+                  ? (c < 8064
+                    ? (c >= 8031 && c <= 8061)
+                    : c <= 8116)
+                  : (c <= 8124 || c == 8126))))))
+            : (c <= 8132 || (c < 8308
+              ? (c < 8178
+                ? (c < 8150
+                  ? (c < 8144
+                    ? (c >= 8134 && c <= 8140)
+                    : c <= 8147)
+                  : (c <= 8155 || (c >= 8160 && c <= 8172)))
+                : (c <= 8180 || (c < 8265
+                  ? (c < 8252
+                    ? (c >= 8182 && c <= 8188)
+                    : c <= 8252)
+                  : (c <= 8265 || (c >= 8304 && c <= 8305)))))
+              : (c <= 8313 || (c < 8455
+                ? (c < 8400
+                  ? (c < 8336
+                    ? (c >= 8319 && c <= 8329)
+                    : c <= 8348)
+                  : (c <= 8432 || c == 8450))
+                : (c <= 8455 || (c < 8473
+                  ? (c < 8469
+                    ? (c >= 8458 && c <= 8467)
+                    : c <= 8469)
+                  : (c <= 8477 || c == 8482))))))))))))))
+    : (c <= 8484 || (c < 43739
+      ? (c < 10145
+        ? (c < 9832
+          ? (c < 9664
+            ? (c < 8986
+              ? (c < 8517
+                ? (c < 8490
+                  ? (c < 8488
+                    ? c == 8486
+                    : c <= 8488)
+                  : (c <= 8493 || (c < 8508
+                    ? (c >= 8495 && c <= 8505)
+                    : c <= 8511)))
+                : (c <= 8521 || (c < 8596
+                  ? (c < 8528
+                    ? c == 8526
+                    : c <= 8585)
+                  : (c <= 8601 || (c >= 8617 && c <= 8618)))))
+              : (c <= 8987 || (c < 9312
+                ? (c < 9193
+                  ? (c < 9167
+                    ? c == 9000
+                    : c <= 9167)
+                  : (c <= 9203 || (c >= 9208 && c <= 9210)))
+                : (c <= 9371 || (c < 9642
+                  ? (c < 9450
+                    ? c == 9410
+                    : c <= 9471)
+                  : (c <= 9643 || c == 9654))))))
+            : (c <= 9664 || (c < 9766
+              ? (c < 9748
+                ? (c < 9742
+                  ? (c < 9728
+                    ? (c >= 9723 && c <= 9726)
+                    : c <= 9732)
+                  : (c <= 9742 || c == 9745))
+                : (c <= 9749 || (c < 9760
+                  ? (c < 9757
+                    ? c == 9752
+                    : c <= 9757)
+                  : (c <= 9760 || (c >= 9762 && c <= 9763)))))
+              : (c <= 9766 || (c < 9794
+                ? (c < 9784
+                  ? (c < 9774
+                    ? c == 9770
+                    : c <= 9775)
+                  : (c <= 9786 || c == 9792))
+                : (c <= 9794 || (c < 9827
+                  ? (c < 9823
+                    ? (c >= 9800 && c <= 9811)
+                    : c <= 9824)
+                  : (c <= 9827 || (c >= 9829 && c <= 9830)))))))))
+          : (c <= 9832 || (c < 9986
+            ? (c < 9917
+              ? (c < 9883
+                ? (c < 9874
+                  ? (c < 9854
+                    ? c == 9851
+                    : c <= 9855)
+                  : (c <= 9879 || c == 9881))
+                : (c <= 9884 || (c < 9898
+                  ? (c < 9895
+                    ? (c >= 9888 && c <= 9889)
+                    : c <= 9895)
+                  : (c <= 9899 || (c >= 9904 && c <= 9905)))))
+              : (c <= 9918 || (c < 9939
+                ? (c < 9934
+                  ? (c < 9928
+                    ? (c >= 9924 && c <= 9925)
+                    : c <= 9928)
+                  : (c <= 9935 || c == 9937))
+                : (c <= 9940 || (c < 9975
+                  ? (c < 9968
+                    ? (c >= 9961 && c <= 9962)
+                    : c <= 9973)
+                  : (c <= 9978 || c == 9981))))))
+            : (c <= 9986 || (c < 10035
+              ? (c < 10004
+                ? (c < 9999
+                  ? (c < 9992
+                    ? c == 9989
+                    : c <= 9997)
+                  : (c <= 9999 || c == 10002))
+                : (c <= 10004 || (c < 10017
+                  ? (c < 10013
+                    ? c == 10006
+                    : c <= 10013)
+                  : (c <= 10017 || c == 10024))))
+              : (c <= 10036 || (c < 10067
+                ? (c < 10060
+                  ? (c < 10055
+                    ? c == 10052
+                    : c <= 10055)
+                  : (c <= 10060 || c == 10062))
+                : (c <= 10069 || (c < 10102
+                  ? (c < 10083
+                    ? c == 10071
+                    : c <= 10084)
+                  : (c <= 10131 || (c >= 10133 && c <= 10135)))))))))))
+        : (c <= 10145 || (c < 12872
+          ? (c < 11712
+            ? (c < 11520
+              ? (c < 11088
+                ? (c < 10548
+                  ? (c < 10175
+                    ? c == 10160
+                    : c <= 10175)
+                  : (c <= 10549 || (c < 11035
+                    ? (c >= 11013 && c <= 11015)
+                    : c <= 11036)))
+                : (c <= 11088 || (c < 11499
+                  ? (c < 11264
+                    ? c == 11093
+                    : c <= 11492)
+                  : (c <= 11507 || c == 11517))))
+              : (c <= 11557 || (c < 11647
+                ? (c < 11568
+                  ? (c < 11565
+                    ? c == 11559
+                    : c <= 11565)
+                  : (c <= 11623 || c == 11631))
+                : (c <= 11670 || (c < 11696
+                  ? (c < 11688
+                    ? (c >= 11680 && c <= 11686)
+                    : c <= 11694)
+                  : (c <= 11702 || (c >= 11704 && c <= 11710)))))))
+            : (c <= 11718 || (c < 12441
+              ? (c < 11823
+                ? (c < 11736
+                  ? (c < 11728
+                    ? (c >= 11720 && c <= 11726)
+                    : c <= 11734)
+                  : (c <= 11742 || (c >= 11744 && c <= 11775)))
+                : (c <= 11823 || (c < 12344
+                  ? (c < 12321
+                    ? (c >= 12293 && c <= 12295)
+                    : c <= 12341)
+                  : (c <= 12349 || (c >= 12353 && c <= 12438)))))
+              : (c <= 12442 || (c < 12593
+                ? (c < 12540
+                  ? (c < 12449
+                    ? (c >= 12445 && c <= 12447)
+                    : c <= 12538)
+                  : (c <= 12543 || (c >= 12549 && c <= 12591)))
+                : (c <= 12686 || (c < 12784
+                  ? (c < 12704
+                    ? (c >= 12690 && c <= 12693)
+                    : c <= 12735)
+                  : (c <= 12799 || (c >= 12832 && c <= 12841)))))))))
+          : (c <= 12879 || (c < 42965
+            ? (c < 42240
+              ? (c < 12977
+                ? (c < 12951
+                  ? (c < 12928
+                    ? (c >= 12881 && c <= 12895)
+                    : c <= 12937)
+                  : (c <= 12951 || c == 12953))
+                : (c <= 12991 || (c < 19968
+                  ? (c < 19903
+                    ? c == 13312
+                    : c <= 19903)
+                  : (c <= 42124 || (c >= 42192 && c <= 42237)))))
+              : (c <= 42508 || (c < 42775
+                ? (c < 42612
+                  ? (c < 42560
+                    ? (c >= 42512 && c <= 42539)
+                    : c <= 42610)
+                  : (c <= 42621 || (c >= 42623 && c <= 42737)))
+                : (c <= 42783 || (c < 42960
+                  ? (c < 42891
+                    ? (c >= 42786 && c <= 42888)
+                    : c <= 42954)
+                  : (c <= 42961 || c == 42963))))))
+            : (c <= 42969 || (c < 43312
+              ? (c < 43136
+                ? (c < 43056
+                  ? (c < 43052
+                    ? (c >= 42994 && c <= 43047)
+                    : c <= 43052)
+                  : (c <= 43061 || (c >= 43072 && c <= 43123)))
+                : (c <= 43205 || (c < 43259
+                  ? (c < 43232
+                    ? (c >= 43216 && c <= 43225)
+                    : c <= 43255)
+                  : (c <= 43259 || (c >= 43261 && c <= 43309)))))
+              : (c <= 43347 || (c < 43520
+                ? (c < 43471
+                  ? (c < 43392
+                    ? (c >= 43360 && c <= 43388)
+                    : c <= 43456)
+                  : (c <= 43481 || (c >= 43488 && c <= 43518)))
+                : (c <= 43574 || (c < 43616
+                  ? (c < 43600
+                    ? (c >= 43584 && c <= 43597)
+                    : c <= 43609)
+                  : (c <= 43638 || (c >= 43642 && c <= 43714)))))))))))))
+      : (c <= 43741 || (c < 67424
+        ? (c < 65482
+          ? (c < 64285
+            ? (c < 44012
+              ? (c < 43808
+                ? (c < 43777
+                  ? (c < 43762
+                    ? (c >= 43744 && c <= 43759)
+                    : c <= 43766)
+                  : (c <= 43782 || (c < 43793
+                    ? (c >= 43785 && c <= 43790)
+                    : c <= 43798)))
+                : (c <= 43814 || (c < 43868
+                  ? (c < 43824
+                    ? (c >= 43816 && c <= 43822)
+                    : c <= 43866)
+                  : (c <= 43881 || (c >= 43888 && c <= 44010)))))
+              : (c <= 44013 || (c < 55243
+                ? (c < 55203
+                  ? (c < 44032
+                    ? (c >= 44016 && c <= 44025)
+                    : c <= 44032)
+                  : (c <= 55203 || (c >= 55216 && c <= 55238)))
+                : (c <= 55291 || (c < 64256
+                  ? (c < 64112
+                    ? (c >= 63744 && c <= 64109)
+                    : c <= 64217)
+                  : (c <= 64262 || (c >= 64275 && c <= 64279)))))))
+            : (c <= 64296 || (c < 65008
+              ? (c < 64323
+                ? (c < 64318
+                  ? (c < 64312
+                    ? (c >= 64298 && c <= 64310)
+                    : c <= 64316)
+                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
+                : (c <= 64324 || (c < 64848
+                  ? (c < 64467
+                    ? (c >= 64326 && c <= 64433)
+                    : c <= 64829)
+                  : (c <= 64911 || (c >= 64914 && c <= 64967)))))
+              : (c <= 65019 || (c < 65296
+                ? (c < 65136
+                  ? (c < 65056
+                    ? (c >= 65024 && c <= 65039)
+                    : c <= 65071)
+                  : (c <= 65140 || (c >= 65142 && c <= 65276)))
+                : (c <= 65305 || (c < 65382
+                  ? (c < 65345
+                    ? (c >= 65313 && c <= 65338)
+                    : c <= 65370)
+                  : (c <= 65470 || (c >= 65474 && c <= 65479)))))))))
+          : (c <= 65487 || (c < 66432
+            ? (c < 65799
+              ? (c < 65576
+                ? (c < 65536
+                  ? (c < 65498
+                    ? (c >= 65490 && c <= 65495)
+                    : c <= 65500)
+                  : (c <= 65547 || (c >= 65549 && c <= 65574)))
+                : (c <= 65594 || (c < 65616
+                  ? (c < 65599
+                    ? (c >= 65596 && c <= 65597)
+                    : c <= 65613)
+                  : (c <= 65629 || (c >= 65664 && c <= 65786)))))
+              : (c <= 65843 || (c < 66208
+                ? (c < 66045
+                  ? (c < 65930
+                    ? (c >= 65856 && c <= 65912)
+                    : c <= 65931)
+                  : (c <= 66045 || (c >= 66176 && c <= 66204)))
+                : (c <= 66256 || (c < 66349
+                  ? (c < 66304
+                    ? (c >= 66272 && c <= 66299)
+                    : c <= 66339)
+                  : (c <= 66378 || (c >= 66384 && c <= 66426)))))))
+            : (c <= 66461 || (c < 66928
+              ? (c < 66720
+                ? (c < 66513
+                  ? (c < 66504
+                    ? (c >= 66464 && c <= 66499)
+                    : c <= 66511)
+                  : (c <= 66517 || (c >= 66560 && c <= 66717)))
+                : (c <= 66729 || (c < 66816
+                  ? (c < 66776
+                    ? (c >= 66736 && c <= 66771)
+                    : c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))))
+              : (c <= 66938 || (c < 66979
+                ? (c < 66964
+                  ? (c < 66956
+                    ? (c >= 66940 && c <= 66954)
+                    : c <= 66962)
+                  : (c <= 66965 || (c >= 66967 && c <= 66977)))
+                : (c <= 66993 || (c < 67072
+                  ? (c < 67003
+                    ? (c >= 66995 && c <= 67001)
+                    : c <= 67004)
+                  : (c <= 67382 || (c >= 67392 && c <= 67413)))))))))))
+        : (c <= 67431 || (c < 128371
+          ? (c < 127358
+            ? (c < 67672
+              ? (c < 67592
+                ? (c < 67506
+                  ? (c < 67463
+                    ? (c >= 67456 && c <= 67461)
+                    : c <= 67504)
+                  : (c <= 67514 || (c >= 67584 && c <= 67589)))
+                : (c <= 67592 || (c < 67644
+                  ? (c < 67639
+                    ? (c >= 67594 && c <= 67637)
+                    : c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67835
+                ? (c < 67808
+                  ? (c < 67751
+                    ? (c >= 67705 && c <= 67742)
+                    : c <= 67759)
+                  : (c <= 67826 || (c >= 67828 && c <= 67829)))
+                : (c <= 67867 || (c < 127183
+                  ? (c < 126980
+                    ? (c >= 67872 && c <= 67883)
+                    : c <= 126980)
+                  : (c <= 127183 || (c >= 127344 && c <= 127345)))))))
+            : (c <= 127359 || (c < 127780
+              ? (c < 127514
+                ? (c < 127462
+                  ? (c < 127377
+                    ? c == 127374
+                    : c <= 127386)
+                  : (c <= 127487 || (c >= 127489 && c <= 127490)))
+                : (c <= 127514 || (c < 127568
+                  ? (c < 127538
+                    ? c == 127535
+                    : c <= 127546)
+                  : (c <= 127569 || (c >= 127744 && c <= 127777)))))
+              : (c <= 127891 || (c < 127991
+                ? (c < 127902
+                  ? (c < 127897
+                    ? (c >= 127894 && c <= 127895)
+                    : c <= 127899)
+                  : (c <= 127984 || (c >= 127987 && c <= 127989)))
+                : (c <= 128253 || (c < 128336
+                  ? (c < 128329
+                    ? (c >= 128255 && c <= 128317)
+                    : c <= 128334)
+                  : (c <= 128359 || (c >= 128367 && c <= 128368)))))))))
+          : (c <= 128378 || (c < 128725
+            ? (c < 128465
+              ? (c < 128420
+                ? (c < 128400
+                  ? (c < 128394
+                    ? c == 128391
+                    : c <= 128397)
+                  : (c <= 128400 || (c >= 128405 && c <= 128406)))
+                : (c <= 128421 || (c < 128444
+                  ? (c < 128433
+                    ? c == 128424
+                    : c <= 128434)
+                  : (c <= 128444 || (c >= 128450 && c <= 128452)))))
+              : (c <= 128467 || (c < 128495
+                ? (c < 128483
+                  ? (c < 128481
+                    ? (c >= 128476 && c <= 128478)
+                    : c <= 128481)
+                  : (c <= 128483 || c == 128488))
+                : (c <= 128495 || (c < 128640
+                  ? (c < 128506
+                    ? c == 128499
+                    : c <= 128591)
+                  : (c <= 128709 || (c >= 128715 && c <= 128722)))))))
+            : (c <= 128727 || (c < 129351
+              ? (c < 128755
+                ? (c < 128747
+                  ? (c < 128745
+                    ? (c >= 128733 && c <= 128741)
+                    : c <= 128745)
+                  : (c <= 128748 || c == 128752))
+                : (c <= 128764 || (c < 129292
+                  ? (c < 129008
+                    ? (c >= 128992 && c <= 129003)
+                    : c <= 129008)
+                  : (c <= 129338 || (c >= 129340 && c <= 129349)))))
+              : (c <= 129535 || (c < 129712
+                ? (c < 129664
+                  ? (c < 129656
+                    ? (c >= 129648 && c <= 129652)
+                    : c <= 129660)
+                  : (c <= 129670 || (c >= 129680 && c <= 129708)))
+                : (c <= 129722 || (c < 129760
+                  ? (c < 129744
+                    ? (c >= 129728 && c <= 129733)
+                    : c <= 129753)
+                  : (c <= 129767 || (c >= 129776 && c <= 129782)))))))))))))))));
+}
+
+static inline bool sym__normal_bare_identifier_character_set_7(int32_t c) {
+  return (c < 8484
+    ? (c < 3260
+      ? (c < 2558
+        ? (c < 1476
+          ? (c < 736
+            ? (c < 169
+              ? (c < '?'
+                ? (c < '*'
+                  ? (c < '#'
+                    ? c == '!'
+                    : c <= '\'')
+                  : (c <= '+' || (c < '0'
+                    ? (c >= '-' && c <= '.')
+                    : c <= ':')))
+                : (c <= 'Z' || (c < '|'
+                  ? (c < 'a'
+                    ? (c >= '^' && c <= '_')
+                    : c <= 'z')
+                  : (c <= '|' || c == '~'))))
+              : (c <= 170 || (c < 188
+                ? (c < 181
+                  ? (c < 178
+                    ? c == 174
+                    : c <= 179)
+                  : (c <= 181 || (c >= 185 && c <= 186)))
+                : (c <= 190 || (c < 248
+                  ? (c < 216
+                    ? (c >= 192 && c <= 214)
+                    : c <= 246)
+                  : (c <= 705 || (c >= 710 && c <= 721)))))))
+            : (c <= 740 || (c < 910
+              ? (c < 890
+                ? (c < 768
+                  ? (c < 750
+                    ? c == 748
+                    : c <= 750)
+                  : (c <= 884 || (c >= 886 && c <= 887)))
+                : (c <= 893 || (c < 904
+                  ? (c < 902
+                    ? c == 895
+                    : c <= 902)
+                  : (c <= 906 || c == 908))))
+              : (c <= 929 || (c < 1369
+                ? (c < 1155
+                  ? (c < 1015
+                    ? (c >= 931 && c <= 1013)
+                    : c <= 1153)
+                  : (c <= 1327 || (c >= 1329 && c <= 1366)))
+                : (c <= 1369 || (c < 1471
+                  ? (c < 1425
+                    ? (c >= 1376 && c <= 1416)
+                    : c <= 1469)
+                  : (c <= 1471 || (c >= 1473 && c <= 1474)))))))))
+          : (c <= 1477 || (c < 2185
+            ? (c < 1791
+              ? (c < 1568
+                ? (c < 1519
+                  ? (c < 1488
+                    ? c == 1479
+                    : c <= 1514)
+                  : (c <= 1522 || (c >= 1552 && c <= 1562)))
+                : (c <= 1641 || (c < 1759
+                  ? (c < 1749
+                    ? (c >= 1646 && c <= 1747)
+                    : c <= 1756)
+                  : (c <= 1768 || (c >= 1770 && c <= 1788)))))
+              : (c <= 1791 || (c < 2045
+                ? (c < 1984
+                  ? (c < 1869
+                    ? (c >= 1808 && c <= 1866)
+                    : c <= 1969)
+                  : (c <= 2037 || c == 2042))
+                : (c <= 2045 || (c < 2144
+                  ? (c < 2112
+                    ? (c >= 2048 && c <= 2093)
+                    : c <= 2139)
+                  : (c <= 2154 || (c >= 2160 && c <= 2183)))))))
+            : (c <= 2190 || (c < 2486
+              ? (c < 2437
+                ? (c < 2406
+                  ? (c < 2275
+                    ? (c >= 2200 && c <= 2273)
+                    : c <= 2403)
+                  : (c <= 2415 || (c >= 2417 && c <= 2435)))
+                : (c <= 2444 || (c < 2474
+                  ? (c < 2451
+                    ? (c >= 2447 && c <= 2448)
+                    : c <= 2472)
+                  : (c <= 2480 || c == 2482))))
+              : (c <= 2489 || (c < 2524
+                ? (c < 2507
+                  ? (c < 2503
+                    ? (c >= 2492 && c <= 2500)
+                    : c <= 2504)
+                  : (c <= 2510 || c == 2519))
+                : (c <= 2525 || (c < 2548
+                  ? (c < 2534
+                    ? (c >= 2527 && c <= 2531)
+                    : c <= 2545)
+                  : (c <= 2553 || c == 2556))))))))))
+        : (c <= 2558 || (c < 2901
+          ? (c < 2730
+            ? (c < 2631
+              ? (c < 2610
+                ? (c < 2575
+                  ? (c < 2565
+                    ? (c >= 2561 && c <= 2563)
+                    : c <= 2570)
+                  : (c <= 2576 || (c < 2602
+                    ? (c >= 2579 && c <= 2600)
+                    : c <= 2608)))
+                : (c <= 2611 || (c < 2620
+                  ? (c < 2616
+                    ? (c >= 2613 && c <= 2614)
+                    : c <= 2617)
+                  : (c <= 2620 || (c >= 2622 && c <= 2626)))))
+              : (c <= 2632 || (c < 2662
+                ? (c < 2649
+                  ? (c < 2641
+                    ? (c >= 2635 && c <= 2637)
+                    : c <= 2641)
+                  : (c <= 2652 || c == 2654))
+                : (c <= 2677 || (c < 2703
+                  ? (c < 2693
+                    ? (c >= 2689 && c <= 2691)
+                    : c <= 2701)
+                  : (c <= 2705 || (c >= 2707 && c <= 2728)))))))
+            : (c <= 2736 || (c < 2817
+              ? (c < 2763
+                ? (c < 2748
+                  ? (c < 2741
+                    ? (c >= 2738 && c <= 2739)
+                    : c <= 2745)
+                  : (c <= 2757 || (c >= 2759 && c <= 2761)))
+                : (c <= 2765 || (c < 2790
+                  ? (c < 2784
+                    ? c == 2768
+                    : c <= 2787)
+                  : (c <= 2799 || (c >= 2809 && c <= 2815)))))
+              : (c <= 2819 || (c < 2866
+                ? (c < 2835
+                  ? (c < 2831
+                    ? (c >= 2821 && c <= 2828)
+                    : c <= 2832)
+                  : (c <= 2856 || (c >= 2858 && c <= 2864)))
+                : (c <= 2867 || (c < 2887
+                  ? (c < 2876
+                    ? (c >= 2869 && c <= 2873)
+                    : c <= 2884)
+                  : (c <= 2888 || (c >= 2891 && c <= 2893)))))))))
+          : (c <= 2903 || (c < 3046
+            ? (c < 2972
+              ? (c < 2946
+                ? (c < 2918
+                  ? (c < 2911
+                    ? (c >= 2908 && c <= 2909)
+                    : c <= 2915)
+                  : (c <= 2927 || (c >= 2929 && c <= 2935)))
+                : (c <= 2947 || (c < 2962
+                  ? (c < 2958
+                    ? (c >= 2949 && c <= 2954)
+                    : c <= 2960)
+                  : (c <= 2965 || (c >= 2969 && c <= 2970)))))
+              : (c <= 2972 || (c < 3006
+                ? (c < 2984
+                  ? (c < 2979
+                    ? (c >= 2974 && c <= 2975)
+                    : c <= 2980)
+                  : (c <= 2986 || (c >= 2990 && c <= 3001)))
+                : (c <= 3010 || (c < 3024
+                  ? (c < 3018
+                    ? (c >= 3014 && c <= 3016)
+                    : c <= 3021)
+                  : (c <= 3024 || c == 3031))))))
+            : (c <= 3058 || (c < 3165
+              ? (c < 3132
+                ? (c < 3090
+                  ? (c < 3086
+                    ? (c >= 3072 && c <= 3084)
+                    : c <= 3088)
+                  : (c <= 3112 || (c >= 3114 && c <= 3129)))
+                : (c <= 3140 || (c < 3157
+                  ? (c < 3146
+                    ? (c >= 3142 && c <= 3144)
+                    : c <= 3149)
+                  : (c <= 3158 || (c >= 3160 && c <= 3162)))))
+              : (c <= 3165 || (c < 3205
+                ? (c < 3192
+                  ? (c < 3174
+                    ? (c >= 3168 && c <= 3171)
+                    : c <= 3183)
+                  : (c <= 3198 || (c >= 3200 && c <= 3203)))
+                : (c <= 3212 || (c < 3242
+                  ? (c < 3218
+                    ? (c >= 3214 && c <= 3216)
+                    : c <= 3240)
+                  : (c <= 3251 || (c >= 3253 && c <= 3257)))))))))))))
+      : (c <= 3268 || (c < 5121
+        ? (c < 3804
+          ? (c < 3520
+            ? (c < 3398
+              ? (c < 3302
+                ? (c < 3285
+                  ? (c < 3274
+                    ? (c >= 3270 && c <= 3272)
+                    : c <= 3277)
+                  : (c <= 3286 || (c < 3296
+                    ? (c >= 3293 && c <= 3294)
+                    : c <= 3299)))
+                : (c <= 3311 || (c < 3342
+                  ? (c < 3328
+                    ? (c >= 3313 && c <= 3314)
+                    : c <= 3340)
+                  : (c <= 3344 || (c >= 3346 && c <= 3396)))))
+              : (c <= 3400 || (c < 3457
+                ? (c < 3430
+                  ? (c < 3412
+                    ? (c >= 3402 && c <= 3406)
+                    : c <= 3427)
+                  : (c <= 3448 || (c >= 3450 && c <= 3455)))
+                : (c <= 3459 || (c < 3507
+                  ? (c < 3482
+                    ? (c >= 3461 && c <= 3478)
+                    : c <= 3505)
+                  : (c <= 3515 || c == 3517))))))
+            : (c <= 3526 || (c < 3713
+              ? (c < 3558
+                ? (c < 3542
+                  ? (c < 3535
+                    ? c == 3530
+                    : c <= 3540)
+                  : (c <= 3542 || (c >= 3544 && c <= 3551)))
+                : (c <= 3567 || (c < 3648
+                  ? (c < 3585
+                    ? (c >= 3570 && c <= 3571)
+                    : c <= 3642)
+                  : (c <= 3662 || (c >= 3664 && c <= 3673)))))
+              : (c <= 3714 || (c < 3751
+                ? (c < 3724
+                  ? (c < 3718
+                    ? c == 3716
+                    : c <= 3722)
+                  : (c <= 3747 || c == 3749))
+                : (c <= 3773 || (c < 3784
+                  ? (c < 3782
+                    ? (c >= 3776 && c <= 3780)
+                    : c <= 3782)
+                  : (c <= 3789 || (c >= 3792 && c <= 3801)))))))))
+          : (c <= 3807 || (c < 4682
+            ? (c < 3974
+              ? (c < 3895
+                ? (c < 3872
+                  ? (c < 3864
+                    ? c == 3840
+                    : c <= 3865)
+                  : (c <= 3891 || c == 3893))
+                : (c <= 3895 || (c < 3913
+                  ? (c < 3902
+                    ? c == 3897
+                    : c <= 3911)
+                  : (c <= 3948 || (c >= 3953 && c <= 3972)))))
+              : (c <= 3991 || (c < 4256
+                ? (c < 4096
+                  ? (c < 4038
+                    ? (c >= 3993 && c <= 4028)
+                    : c <= 4038)
+                  : (c <= 4169 || (c >= 4176 && c <= 4253)))
+                : (c <= 4293 || (c < 4304
+                  ? (c < 4301
+                    ? c == 4295
+                    : c <= 4301)
+                  : (c <= 4346 || (c >= 4348 && c <= 4680)))))))
+            : (c <= 4685 || (c < 4802
+              ? (c < 4746
+                ? (c < 4698
+                  ? (c < 4696
+                    ? (c >= 4688 && c <= 4694)
+                    : c <= 4696)
+                  : (c <= 4701 || (c >= 4704 && c <= 4744)))
+                : (c <= 4749 || (c < 4792
+                  ? (c < 4786
+                    ? (c >= 4752 && c <= 4784)
+                    : c <= 4789)
+                  : (c <= 4798 || c == 4800))))
+              : (c <= 4805 || (c < 4957
+                ? (c < 4882
+                  ? (c < 4824
+                    ? (c >= 4808 && c <= 4822)
+                    : c <= 4880)
+                  : (c <= 4885 || (c >= 4888 && c <= 4954)))
+                : (c <= 4959 || (c < 5024
+                  ? (c < 4992
+                    ? (c >= 4969 && c <= 4988)
+                    : c <= 5007)
+                  : (c <= 5109 || (c >= 5112 && c <= 5117)))))))))))
+        : (c <= 5740 || (c < 7168
+          ? (c < 6320
+            ? (c < 6002
+              ? (c < 5888
+                ? (c < 5792
+                  ? (c < 5761
+                    ? (c >= 5743 && c <= 5759)
+                    : c <= 5786)
+                  : (c <= 5866 || (c >= 5870 && c <= 5880)))
+                : (c <= 5909 || (c < 5984
+                  ? (c < 5952
+                    ? (c >= 5919 && c <= 5940)
+                    : c <= 5971)
+                  : (c <= 5996 || (c >= 5998 && c <= 6000)))))
+              : (c <= 6003 || (c < 6128
+                ? (c < 6108
+                  ? (c < 6103
+                    ? (c >= 6016 && c <= 6099)
+                    : c <= 6103)
+                  : (c <= 6109 || (c >= 6112 && c <= 6121)))
+                : (c <= 6137 || (c < 6176
+                  ? (c < 6159
+                    ? (c >= 6155 && c <= 6157)
+                    : c <= 6169)
+                  : (c <= 6264 || (c >= 6272 && c <= 6314)))))))
+            : (c <= 6389 || (c < 6688
+              ? (c < 6512
+                ? (c < 6448
+                  ? (c < 6432
+                    ? (c >= 6400 && c <= 6430)
+                    : c <= 6443)
+                  : (c <= 6459 || (c >= 6470 && c <= 6509)))
+                : (c <= 6516 || (c < 6608
+                  ? (c < 6576
+                    ? (c >= 6528 && c <= 6571)
+                    : c <= 6601)
+                  : (c <= 6618 || (c >= 6656 && c <= 6683)))))
+              : (c <= 6750 || (c < 6832
+                ? (c < 6800
+                  ? (c < 6783
+                    ? (c >= 6752 && c <= 6780)
+                    : c <= 6793)
+                  : (c <= 6809 || c == 6823))
+                : (c <= 6862 || (c < 7019
+                  ? (c < 6992
+                    ? (c >= 6912 && c <= 6988)
+                    : c <= 7001)
+                  : (c <= 7027 || (c >= 7040 && c <= 7155)))))))))
+          : (c <= 7223 || (c < 8130
+            ? (c < 7968
+              ? (c < 7357
+                ? (c < 7296
+                  ? (c < 7245
+                    ? (c >= 7232 && c <= 7241)
+                    : c <= 7293)
+                  : (c <= 7304 || (c >= 7312 && c <= 7354)))
+                : (c <= 7359 || (c < 7424
+                  ? (c < 7380
+                    ? (c >= 7376 && c <= 7378)
+                    : c <= 7418)
+                  : (c <= 7957 || (c >= 7960 && c <= 7965)))))
+              : (c <= 8005 || (c < 8029
+                ? (c < 8025
+                  ? (c < 8016
+                    ? (c >= 8008 && c <= 8013)
+                    : c <= 8023)
+                  : (c <= 8025 || c == 8027))
+                : (c <= 8029 || (c < 8118
+                  ? (c < 8064
+                    ? (c >= 8031 && c <= 8061)
+                    : c <= 8116)
+                  : (c <= 8124 || c == 8126))))))
+            : (c <= 8132 || (c < 8308
+              ? (c < 8178
+                ? (c < 8150
+                  ? (c < 8144
+                    ? (c >= 8134 && c <= 8140)
+                    : c <= 8147)
+                  : (c <= 8155 || (c >= 8160 && c <= 8172)))
+                : (c <= 8180 || (c < 8265
+                  ? (c < 8252
+                    ? (c >= 8182 && c <= 8188)
+                    : c <= 8252)
+                  : (c <= 8265 || (c >= 8304 && c <= 8305)))))
+              : (c <= 8313 || (c < 8455
+                ? (c < 8400
+                  ? (c < 8336
+                    ? (c >= 8319 && c <= 8329)
+                    : c <= 8348)
+                  : (c <= 8432 || c == 8450))
+                : (c <= 8455 || (c < 8473
+                  ? (c < 8469
+                    ? (c >= 8458 && c <= 8467)
+                    : c <= 8469)
+                  : (c <= 8477 || c == 8482))))))))))))))
+    : (c <= 8484 || (c < 43739
+      ? (c < 10145
+        ? (c < 9832
+          ? (c < 9664
+            ? (c < 8986
+              ? (c < 8517
+                ? (c < 8490
+                  ? (c < 8488
+                    ? c == 8486
+                    : c <= 8488)
+                  : (c <= 8493 || (c < 8508
+                    ? (c >= 8495 && c <= 8505)
+                    : c <= 8511)))
+                : (c <= 8521 || (c < 8596
+                  ? (c < 8528
+                    ? c == 8526
+                    : c <= 8585)
+                  : (c <= 8601 || (c >= 8617 && c <= 8618)))))
+              : (c <= 8987 || (c < 9312
+                ? (c < 9193
+                  ? (c < 9167
+                    ? c == 9000
+                    : c <= 9167)
+                  : (c <= 9203 || (c >= 9208 && c <= 9210)))
+                : (c <= 9371 || (c < 9642
+                  ? (c < 9450
+                    ? c == 9410
+                    : c <= 9471)
+                  : (c <= 9643 || c == 9654))))))
+            : (c <= 9664 || (c < 9766
+              ? (c < 9748
+                ? (c < 9742
+                  ? (c < 9728
+                    ? (c >= 9723 && c <= 9726)
+                    : c <= 9732)
+                  : (c <= 9742 || c == 9745))
+                : (c <= 9749 || (c < 9760
+                  ? (c < 9757
+                    ? c == 9752
+                    : c <= 9757)
+                  : (c <= 9760 || (c >= 9762 && c <= 9763)))))
+              : (c <= 9766 || (c < 9794
+                ? (c < 9784
+                  ? (c < 9774
+                    ? c == 9770
+                    : c <= 9775)
+                  : (c <= 9786 || c == 9792))
+                : (c <= 9794 || (c < 9827
+                  ? (c < 9823
+                    ? (c >= 9800 && c <= 9811)
+                    : c <= 9824)
+                  : (c <= 9827 || (c >= 9829 && c <= 9830)))))))))
+          : (c <= 9832 || (c < 9986
+            ? (c < 9917
+              ? (c < 9883
+                ? (c < 9874
+                  ? (c < 9854
+                    ? c == 9851
+                    : c <= 9855)
+                  : (c <= 9879 || c == 9881))
+                : (c <= 9884 || (c < 9898
+                  ? (c < 9895
+                    ? (c >= 9888 && c <= 9889)
+                    : c <= 9895)
+                  : (c <= 9899 || (c >= 9904 && c <= 9905)))))
+              : (c <= 9918 || (c < 9939
+                ? (c < 9934
+                  ? (c < 9928
+                    ? (c >= 9924 && c <= 9925)
+                    : c <= 9928)
+                  : (c <= 9935 || c == 9937))
+                : (c <= 9940 || (c < 9975
+                  ? (c < 9968
+                    ? (c >= 9961 && c <= 9962)
+                    : c <= 9973)
+                  : (c <= 9978 || c == 9981))))))
+            : (c <= 9986 || (c < 10035
+              ? (c < 10004
+                ? (c < 9999
+                  ? (c < 9992
+                    ? c == 9989
+                    : c <= 9997)
+                  : (c <= 9999 || c == 10002))
+                : (c <= 10004 || (c < 10017
+                  ? (c < 10013
+                    ? c == 10006
+                    : c <= 10013)
+                  : (c <= 10017 || c == 10024))))
+              : (c <= 10036 || (c < 10067
+                ? (c < 10060
+                  ? (c < 10055
+                    ? c == 10052
+                    : c <= 10055)
+                  : (c <= 10060 || c == 10062))
+                : (c <= 10069 || (c < 10102
+                  ? (c < 10083
+                    ? c == 10071
+                    : c <= 10084)
+                  : (c <= 10131 || (c >= 10133 && c <= 10135)))))))))))
+        : (c <= 10145 || (c < 12872
+          ? (c < 11712
+            ? (c < 11520
+              ? (c < 11088
+                ? (c < 10548
+                  ? (c < 10175
+                    ? c == 10160
+                    : c <= 10175)
+                  : (c <= 10549 || (c < 11035
+                    ? (c >= 11013 && c <= 11015)
+                    : c <= 11036)))
+                : (c <= 11088 || (c < 11499
+                  ? (c < 11264
+                    ? c == 11093
+                    : c <= 11492)
+                  : (c <= 11507 || c == 11517))))
+              : (c <= 11557 || (c < 11647
+                ? (c < 11568
+                  ? (c < 11565
+                    ? c == 11559
+                    : c <= 11565)
+                  : (c <= 11623 || c == 11631))
+                : (c <= 11670 || (c < 11696
+                  ? (c < 11688
+                    ? (c >= 11680 && c <= 11686)
+                    : c <= 11694)
+                  : (c <= 11702 || (c >= 11704 && c <= 11710)))))))
+            : (c <= 11718 || (c < 12441
+              ? (c < 11823
+                ? (c < 11736
+                  ? (c < 11728
+                    ? (c >= 11720 && c <= 11726)
+                    : c <= 11734)
+                  : (c <= 11742 || (c >= 11744 && c <= 11775)))
+                : (c <= 11823 || (c < 12344
+                  ? (c < 12321
+                    ? (c >= 12293 && c <= 12295)
+                    : c <= 12341)
+                  : (c <= 12349 || (c >= 12353 && c <= 12438)))))
+              : (c <= 12442 || (c < 12593
+                ? (c < 12540
+                  ? (c < 12449
+                    ? (c >= 12445 && c <= 12447)
+                    : c <= 12538)
+                  : (c <= 12543 || (c >= 12549 && c <= 12591)))
+                : (c <= 12686 || (c < 12784
+                  ? (c < 12704
+                    ? (c >= 12690 && c <= 12693)
+                    : c <= 12735)
+                  : (c <= 12799 || (c >= 12832 && c <= 12841)))))))))
+          : (c <= 12879 || (c < 42965
+            ? (c < 42240
+              ? (c < 12977
+                ? (c < 12951
+                  ? (c < 12928
+                    ? (c >= 12881 && c <= 12895)
+                    : c <= 12937)
+                  : (c <= 12951 || c == 12953))
+                : (c <= 12991 || (c < 19968
+                  ? (c < 19903
+                    ? c == 13312
+                    : c <= 19903)
+                  : (c <= 42124 || (c >= 42192 && c <= 42237)))))
+              : (c <= 42508 || (c < 42775
+                ? (c < 42612
+                  ? (c < 42560
+                    ? (c >= 42512 && c <= 42539)
+                    : c <= 42610)
+                  : (c <= 42621 || (c >= 42623 && c <= 42737)))
+                : (c <= 42783 || (c < 42960
+                  ? (c < 42891
+                    ? (c >= 42786 && c <= 42888)
+                    : c <= 42954)
+                  : (c <= 42961 || c == 42963))))))
+            : (c <= 42969 || (c < 43312
+              ? (c < 43136
+                ? (c < 43056
+                  ? (c < 43052
+                    ? (c >= 42994 && c <= 43047)
+                    : c <= 43052)
+                  : (c <= 43061 || (c >= 43072 && c <= 43123)))
+                : (c <= 43205 || (c < 43259
+                  ? (c < 43232
+                    ? (c >= 43216 && c <= 43225)
+                    : c <= 43255)
+                  : (c <= 43259 || (c >= 43261 && c <= 43309)))))
+              : (c <= 43347 || (c < 43520
+                ? (c < 43471
+                  ? (c < 43392
+                    ? (c >= 43360 && c <= 43388)
+                    : c <= 43456)
+                  : (c <= 43481 || (c >= 43488 && c <= 43518)))
+                : (c <= 43574 || (c < 43616
+                  ? (c < 43600
+                    ? (c >= 43584 && c <= 43597)
+                    : c <= 43609)
+                  : (c <= 43638 || (c >= 43642 && c <= 43714)))))))))))))
+      : (c <= 43741 || (c < 67424
+        ? (c < 65482
+          ? (c < 64285
+            ? (c < 44012
+              ? (c < 43808
+                ? (c < 43777
+                  ? (c < 43762
+                    ? (c >= 43744 && c <= 43759)
+                    : c <= 43766)
+                  : (c <= 43782 || (c < 43793
+                    ? (c >= 43785 && c <= 43790)
+                    : c <= 43798)))
+                : (c <= 43814 || (c < 43868
+                  ? (c < 43824
+                    ? (c >= 43816 && c <= 43822)
+                    : c <= 43866)
+                  : (c <= 43881 || (c >= 43888 && c <= 44010)))))
+              : (c <= 44013 || (c < 55243
+                ? (c < 55203
+                  ? (c < 44032
+                    ? (c >= 44016 && c <= 44025)
+                    : c <= 44032)
+                  : (c <= 55203 || (c >= 55216 && c <= 55238)))
+                : (c <= 55291 || (c < 64256
+                  ? (c < 64112
+                    ? (c >= 63744 && c <= 64109)
+                    : c <= 64217)
+                  : (c <= 64262 || (c >= 64275 && c <= 64279)))))))
+            : (c <= 64296 || (c < 65008
+              ? (c < 64323
+                ? (c < 64318
+                  ? (c < 64312
+                    ? (c >= 64298 && c <= 64310)
+                    : c <= 64316)
+                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
+                : (c <= 64324 || (c < 64848
+                  ? (c < 64467
+                    ? (c >= 64326 && c <= 64433)
+                    : c <= 64829)
+                  : (c <= 64911 || (c >= 64914 && c <= 64967)))))
+              : (c <= 65019 || (c < 65296
+                ? (c < 65136
+                  ? (c < 65056
+                    ? (c >= 65024 && c <= 65039)
+                    : c <= 65071)
+                  : (c <= 65140 || (c >= 65142 && c <= 65276)))
+                : (c <= 65305 || (c < 65382
+                  ? (c < 65345
+                    ? (c >= 65313 && c <= 65338)
+                    : c <= 65370)
+                  : (c <= 65470 || (c >= 65474 && c <= 65479)))))))))
+          : (c <= 65487 || (c < 66432
+            ? (c < 65799
+              ? (c < 65576
+                ? (c < 65536
+                  ? (c < 65498
+                    ? (c >= 65490 && c <= 65495)
+                    : c <= 65500)
+                  : (c <= 65547 || (c >= 65549 && c <= 65574)))
+                : (c <= 65594 || (c < 65616
+                  ? (c < 65599
+                    ? (c >= 65596 && c <= 65597)
+                    : c <= 65613)
+                  : (c <= 65629 || (c >= 65664 && c <= 65786)))))
+              : (c <= 65843 || (c < 66208
+                ? (c < 66045
+                  ? (c < 65930
+                    ? (c >= 65856 && c <= 65912)
+                    : c <= 65931)
+                  : (c <= 66045 || (c >= 66176 && c <= 66204)))
+                : (c <= 66256 || (c < 66349
+                  ? (c < 66304
+                    ? (c >= 66272 && c <= 66299)
+                    : c <= 66339)
+                  : (c <= 66378 || (c >= 66384 && c <= 66426)))))))
+            : (c <= 66461 || (c < 66928
+              ? (c < 66720
+                ? (c < 66513
+                  ? (c < 66504
+                    ? (c >= 66464 && c <= 66499)
+                    : c <= 66511)
+                  : (c <= 66517 || (c >= 66560 && c <= 66717)))
+                : (c <= 66729 || (c < 66816
+                  ? (c < 66776
+                    ? (c >= 66736 && c <= 66771)
+                    : c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))))
+              : (c <= 66938 || (c < 66979
+                ? (c < 66964
+                  ? (c < 66956
+                    ? (c >= 66940 && c <= 66954)
+                    : c <= 66962)
+                  : (c <= 66965 || (c >= 66967 && c <= 66977)))
+                : (c <= 66993 || (c < 67072
+                  ? (c < 67003
+                    ? (c >= 66995 && c <= 67001)
+                    : c <= 67004)
+                  : (c <= 67382 || (c >= 67392 && c <= 67413)))))))))))
+        : (c <= 67431 || (c < 128371
+          ? (c < 127358
+            ? (c < 67672
+              ? (c < 67592
+                ? (c < 67506
+                  ? (c < 67463
+                    ? (c >= 67456 && c <= 67461)
+                    : c <= 67504)
+                  : (c <= 67514 || (c >= 67584 && c <= 67589)))
+                : (c <= 67592 || (c < 67644
+                  ? (c < 67639
+                    ? (c >= 67594 && c <= 67637)
+                    : c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67835
+                ? (c < 67808
+                  ? (c < 67751
+                    ? (c >= 67705 && c <= 67742)
+                    : c <= 67759)
+                  : (c <= 67826 || (c >= 67828 && c <= 67829)))
+                : (c <= 67867 || (c < 127183
+                  ? (c < 126980
+                    ? (c >= 67872 && c <= 67883)
+                    : c <= 126980)
+                  : (c <= 127183 || (c >= 127344 && c <= 127345)))))))
+            : (c <= 127359 || (c < 127780
+              ? (c < 127514
+                ? (c < 127462
+                  ? (c < 127377
+                    ? c == 127374
+                    : c <= 127386)
+                  : (c <= 127487 || (c >= 127489 && c <= 127490)))
+                : (c <= 127514 || (c < 127568
+                  ? (c < 127538
+                    ? c == 127535
+                    : c <= 127546)
+                  : (c <= 127569 || (c >= 127744 && c <= 127777)))))
+              : (c <= 127891 || (c < 127991
+                ? (c < 127902
+                  ? (c < 127897
+                    ? (c >= 127894 && c <= 127895)
+                    : c <= 127899)
+                  : (c <= 127984 || (c >= 127987 && c <= 127989)))
+                : (c <= 128253 || (c < 128336
+                  ? (c < 128329
+                    ? (c >= 128255 && c <= 128317)
+                    : c <= 128334)
+                  : (c <= 128359 || (c >= 128367 && c <= 128368)))))))))
+          : (c <= 128378 || (c < 128725
+            ? (c < 128465
+              ? (c < 128420
+                ? (c < 128400
+                  ? (c < 128394
+                    ? c == 128391
+                    : c <= 128397)
+                  : (c <= 128400 || (c >= 128405 && c <= 128406)))
+                : (c <= 128421 || (c < 128444
+                  ? (c < 128433
+                    ? c == 128424
+                    : c <= 128434)
+                  : (c <= 128444 || (c >= 128450 && c <= 128452)))))
+              : (c <= 128467 || (c < 128495
+                ? (c < 128483
+                  ? (c < 128481
+                    ? (c >= 128476 && c <= 128478)
+                    : c <= 128481)
+                  : (c <= 128483 || c == 128488))
+                : (c <= 128495 || (c < 128640
+                  ? (c < 128506
+                    ? c == 128499
+                    : c <= 128591)
+                  : (c <= 128709 || (c >= 128715 && c <= 128722)))))))
+            : (c <= 128727 || (c < 129351
+              ? (c < 128755
+                ? (c < 128747
+                  ? (c < 128745
+                    ? (c >= 128733 && c <= 128741)
+                    : c <= 128745)
+                  : (c <= 128748 || c == 128752))
+                : (c <= 128764 || (c < 129292
+                  ? (c < 129008
+                    ? (c >= 128992 && c <= 129003)
+                    : c <= 129008)
+                  : (c <= 129338 || (c >= 129340 && c <= 129349)))))
+              : (c <= 129535 || (c < 129712
+                ? (c < 129664
+                  ? (c < 129656
+                    ? (c >= 129648 && c <= 129652)
+                    : c <= 129660)
+                  : (c <= 129670 || (c >= 129680 && c <= 129708)))
+                : (c <= 129722 || (c < 129760
+                  ? (c < 129744
+                    ? (c >= 129728 && c <= 129733)
+                    : c <= 129753)
+                  : (c <= 129767 || (c >= 129776 && c <= 129782)))))))))))))))));
+}
+
+static inline bool sym__identifier_char_character_set_1(int32_t c) {
+  return (c < 6002
+    ? (c < 2949
+      ? (c < 2437
+        ? (c < 1329
+          ? (c < 248
+            ? (c < '~'
+              ? (c < '-'
+                ? (c < '#'
+                  ? c == '!'
+                  : (c <= '\'' || (c >= '*' && c <= '+')))
+                : (c <= ':' || (c < '^'
+                  ? (c >= '?' && c <= 'Z')
+                  : (c <= '_' || (c >= 'a' && c <= '|')))))
+              : (c <= '~' || (c < 185
+                ? (c < 178
+                  ? c == 170
+                  : (c <= 179 || c == 181))
+                : (c <= 186 || (c < 192
+                  ? (c >= 188 && c <= 190)
+                  : (c <= 214 || (c >= 216 && c <= 246)))))))
+            : (c <= 705 || (c < 895
+              ? (c < 750
+                ? (c < 736
+                  ? (c >= 710 && c <= 721)
+                  : (c <= 740 || c == 748))
+                : (c <= 750 || (c < 886
+                  ? (c >= 768 && c <= 884)
+                  : (c <= 887 || (c >= 890 && c <= 893)))))
+              : (c <= 895 || (c < 910
+                ? (c < 904
+                  ? c == 902
+                  : (c <= 906 || c == 908))
+                : (c <= 929 || (c < 1015
+                  ? (c >= 931 && c <= 1013)
+                  : (c <= 1153 || (c >= 1155 && c <= 1327)))))))))
+          : (c <= 1366 || (c < 1791
+            ? (c < 1488
+              ? (c < 1471
+                ? (c < 1376
+                  ? c == 1369
+                  : (c <= 1416 || (c >= 1425 && c <= 1469)))
+                : (c <= 1471 || (c < 1476
+                  ? (c >= 1473 && c <= 1474)
+                  : (c <= 1477 || c == 1479))))
+              : (c <= 1514 || (c < 1646
+                ? (c < 1552
+                  ? (c >= 1519 && c <= 1522)
+                  : (c <= 1562 || (c >= 1568 && c <= 1641)))
+                : (c <= 1747 || (c < 1759
+                  ? (c >= 1749 && c <= 1756)
+                  : (c <= 1768 || (c >= 1770 && c <= 1788)))))))
+            : (c <= 1791 || (c < 2144
+              ? (c < 2042
+                ? (c < 1869
+                  ? (c >= 1808 && c <= 1866)
+                  : (c <= 1969 || (c >= 1984 && c <= 2037)))
+                : (c <= 2042 || (c < 2048
+                  ? c == 2045
+                  : (c <= 2093 || (c >= 2112 && c <= 2139)))))
+              : (c <= 2154 || (c < 2275
+                ? (c < 2185
+                  ? (c >= 2160 && c <= 2183)
+                  : (c <= 2190 || (c >= 2200 && c <= 2273)))
+                : (c <= 2403 || (c < 2417
+                  ? (c >= 2406 && c <= 2415)
+                  : c <= 2435)))))))))
+        : (c <= 2444 || (c < 2662
+          ? (c < 2561
+            ? (c < 2507
+              ? (c < 2482
+                ? (c < 2451
+                  ? (c >= 2447 && c <= 2448)
+                  : (c <= 2472 || (c >= 2474 && c <= 2480)))
+                : (c <= 2482 || (c < 2492
+                  ? (c >= 2486 && c <= 2489)
+                  : (c <= 2500 || (c >= 2503 && c <= 2504)))))
+              : (c <= 2510 || (c < 2534
+                ? (c < 2524
+                  ? c == 2519
+                  : (c <= 2525 || (c >= 2527 && c <= 2531)))
+                : (c <= 2545 || (c < 2556
+                  ? (c >= 2548 && c <= 2553)
+                  : (c <= 2556 || c == 2558))))))
+            : (c <= 2563 || (c < 2620
+              ? (c < 2602
+                ? (c < 2575
+                  ? (c >= 2565 && c <= 2570)
+                  : (c <= 2576 || (c >= 2579 && c <= 2600)))
+                : (c <= 2608 || (c < 2613
+                  ? (c >= 2610 && c <= 2611)
+                  : (c <= 2614 || (c >= 2616 && c <= 2617)))))
+              : (c <= 2620 || (c < 2641
+                ? (c < 2631
+                  ? (c >= 2622 && c <= 2626)
+                  : (c <= 2632 || (c >= 2635 && c <= 2637)))
+                : (c <= 2641 || (c < 2654
+                  ? (c >= 2649 && c <= 2652)
+                  : c <= 2654)))))))
+          : (c <= 2677 || (c < 2821
+            ? (c < 2748
+              ? (c < 2707
+                ? (c < 2693
+                  ? (c >= 2689 && c <= 2691)
+                  : (c <= 2701 || (c >= 2703 && c <= 2705)))
+                : (c <= 2728 || (c < 2738
+                  ? (c >= 2730 && c <= 2736)
+                  : (c <= 2739 || (c >= 2741 && c <= 2745)))))
+              : (c <= 2757 || (c < 2784
+                ? (c < 2763
+                  ? (c >= 2759 && c <= 2761)
+                  : (c <= 2765 || c == 2768))
+                : (c <= 2787 || (c < 2809
+                  ? (c >= 2790 && c <= 2799)
+                  : (c <= 2815 || (c >= 2817 && c <= 2819)))))))
+            : (c <= 2828 || (c < 2891
+              ? (c < 2866
+                ? (c < 2835
+                  ? (c >= 2831 && c <= 2832)
+                  : (c <= 2856 || (c >= 2858 && c <= 2864)))
+                : (c <= 2867 || (c < 2876
+                  ? (c >= 2869 && c <= 2873)
+                  : (c <= 2884 || (c >= 2887 && c <= 2888)))))
+              : (c <= 2893 || (c < 2918
+                ? (c < 2908
+                  ? (c >= 2901 && c <= 2903)
+                  : (c <= 2909 || (c >= 2911 && c <= 2915)))
+                : (c <= 2927 || (c < 2946
+                  ? (c >= 2929 && c <= 2935)
+                  : c <= 2947)))))))))))
+      : (c <= 2954 || (c < 3585
+        ? (c < 3218
+          ? (c < 3086
+            ? (c < 2990
+              ? (c < 2972
+                ? (c < 2962
+                  ? (c >= 2958 && c <= 2960)
+                  : (c <= 2965 || (c >= 2969 && c <= 2970)))
+                : (c <= 2972 || (c < 2979
+                  ? (c >= 2974 && c <= 2975)
+                  : (c <= 2980 || (c >= 2984 && c <= 2986)))))
+              : (c <= 3001 || (c < 3024
+                ? (c < 3014
+                  ? (c >= 3006 && c <= 3010)
+                  : (c <= 3016 || (c >= 3018 && c <= 3021)))
+                : (c <= 3024 || (c < 3046
+                  ? c == 3031
+                  : (c <= 3058 || (c >= 3072 && c <= 3084)))))))
+            : (c <= 3088 || (c < 3165
+              ? (c < 3142
+                ? (c < 3114
+                  ? (c >= 3090 && c <= 3112)
+                  : (c <= 3129 || (c >= 3132 && c <= 3140)))
+                : (c <= 3144 || (c < 3157
+                  ? (c >= 3146 && c <= 3149)
+                  : (c <= 3158 || (c >= 3160 && c <= 3162)))))
+              : (c <= 3165 || (c < 3200
+                ? (c < 3174
+                  ? (c >= 3168 && c <= 3171)
+                  : (c <= 3183 || (c >= 3192 && c <= 3198)))
+                : (c <= 3203 || (c < 3214
+                  ? (c >= 3205 && c <= 3212)
+                  : c <= 3216)))))))
+          : (c <= 3240 || (c < 3412
+            ? (c < 3296
+              ? (c < 3270
+                ? (c < 3253
+                  ? (c >= 3242 && c <= 3251)
+                  : (c <= 3257 || (c >= 3260 && c <= 3268)))
+                : (c <= 3272 || (c < 3285
+                  ? (c >= 3274 && c <= 3277)
+                  : (c <= 3286 || (c >= 3293 && c <= 3294)))))
+              : (c <= 3299 || (c < 3342
+                ? (c < 3313
+                  ? (c >= 3302 && c <= 3311)
+                  : (c <= 3314 || (c >= 3328 && c <= 3340)))
+                : (c <= 3344 || (c < 3398
+                  ? (c >= 3346 && c <= 3396)
+                  : (c <= 3400 || (c >= 3402 && c <= 3406)))))))
+            : (c <= 3427 || (c < 3520
+              ? (c < 3461
+                ? (c < 3450
+                  ? (c >= 3430 && c <= 3448)
+                  : (c <= 3455 || (c >= 3457 && c <= 3459)))
+                : (c <= 3478 || (c < 3507
+                  ? (c >= 3482 && c <= 3505)
+                  : (c <= 3515 || c == 3517))))
+              : (c <= 3526 || (c < 3544
+                ? (c < 3535
+                  ? c == 3530
+                  : (c <= 3540 || c == 3542))
+                : (c <= 3551 || (c < 3570
+                  ? (c >= 3558 && c <= 3567)
+                  : c <= 3571)))))))))
+        : (c <= 3642 || (c < 4304
+          ? (c < 3872
+            ? (c < 3751
+              ? (c < 3716
+                ? (c < 3664
+                  ? (c >= 3648 && c <= 3662)
+                  : (c <= 3673 || (c >= 3713 && c <= 3714)))
+                : (c <= 3716 || (c < 3724
+                  ? (c >= 3718 && c <= 3722)
+                  : (c <= 3747 || c == 3749))))
+              : (c <= 3773 || (c < 3792
+                ? (c < 3782
+                  ? (c >= 3776 && c <= 3780)
+                  : (c <= 3782 || (c >= 3784 && c <= 3789)))
+                : (c <= 3801 || (c < 3840
+                  ? (c >= 3804 && c <= 3807)
+                  : (c <= 3840 || (c >= 3864 && c <= 3865)))))))
+            : (c <= 3891 || (c < 3993
+              ? (c < 3902
+                ? (c < 3895
+                  ? c == 3893
+                  : (c <= 3895 || c == 3897))
+                : (c <= 3911 || (c < 3953
+                  ? (c >= 3913 && c <= 3948)
+                  : (c <= 3972 || (c >= 3974 && c <= 3991)))))
+              : (c <= 4028 || (c < 4256
+                ? (c < 4096
+                  ? c == 4038
+                  : (c <= 4169 || (c >= 4176 && c <= 4253)))
+                : (c <= 4293 || (c < 4301
+                  ? c == 4295
+                  : c <= 4301)))))))
+          : (c <= 4346 || (c < 4888
+            ? (c < 4752
+              ? (c < 4696
+                ? (c < 4682
+                  ? (c >= 4348 && c <= 4680)
+                  : (c <= 4685 || (c >= 4688 && c <= 4694)))
+                : (c <= 4696 || (c < 4704
+                  ? (c >= 4698 && c <= 4701)
+                  : (c <= 4744 || (c >= 4746 && c <= 4749)))))
+              : (c <= 4784 || (c < 4802
+                ? (c < 4792
+                  ? (c >= 4786 && c <= 4789)
+                  : (c <= 4798 || c == 4800))
+                : (c <= 4805 || (c < 4824
+                  ? (c >= 4808 && c <= 4822)
+                  : (c <= 4880 || (c >= 4882 && c <= 4885)))))))
+            : (c <= 4954 || (c < 5792
+              ? (c < 5024
+                ? (c < 4969
+                  ? (c >= 4957 && c <= 4959)
+                  : (c <= 4988 || (c >= 4992 && c <= 5007)))
+                : (c <= 5109 || (c < 5121
+                  ? (c >= 5112 && c <= 5117)
+                  : (c <= 5740 || (c >= 5743 && c <= 5786)))))
+              : (c <= 5866 || (c < 5952
+                ? (c < 5888
+                  ? (c >= 5870 && c <= 5880)
+                  : (c <= 5909 || (c >= 5919 && c <= 5940)))
+                : (c <= 5971 || (c < 5998
+                  ? (c >= 5984 && c <= 5996)
+                  : c <= 6000)))))))))))))
+    : (c <= 6003 || (c < 42623
+      ? (c < 8455
+        ? (c < 7245
+          ? (c < 6528
+            ? (c < 6176
+              ? (c < 6112
+                ? (c < 6103
+                  ? (c >= 6016 && c <= 6099)
+                  : (c <= 6103 || (c >= 6108 && c <= 6109)))
+                : (c <= 6121 || (c < 6155
+                  ? (c >= 6128 && c <= 6137)
+                  : (c <= 6157 || (c >= 6159 && c <= 6169)))))
+              : (c <= 6264 || (c < 6432
+                ? (c < 6320
+                  ? (c >= 6272 && c <= 6314)
+                  : (c <= 6389 || (c >= 6400 && c <= 6430)))
+                : (c <= 6443 || (c < 6470
+                  ? (c >= 6448 && c <= 6459)
+                  : (c <= 6509 || (c >= 6512 && c <= 6516)))))))
+            : (c <= 6571 || (c < 6823
+              ? (c < 6688
+                ? (c < 6608
+                  ? (c >= 6576 && c <= 6601)
+                  : (c <= 6618 || (c >= 6656 && c <= 6683)))
+                : (c <= 6750 || (c < 6783
+                  ? (c >= 6752 && c <= 6780)
+                  : (c <= 6793 || (c >= 6800 && c <= 6809)))))
+              : (c <= 6823 || (c < 7019
+                ? (c < 6912
+                  ? (c >= 6832 && c <= 6862)
+                  : (c <= 6988 || (c >= 6992 && c <= 7001)))
+                : (c <= 7027 || (c < 7168
+                  ? (c >= 7040 && c <= 7155)
+                  : (c <= 7223 || (c >= 7232 && c <= 7241)))))))))
+          : (c <= 7293 || (c < 8118
+            ? (c < 7968
+              ? (c < 7376
+                ? (c < 7312
+                  ? (c >= 7296 && c <= 7304)
+                  : (c <= 7354 || (c >= 7357 && c <= 7359)))
+                : (c <= 7378 || (c < 7424
+                  ? (c >= 7380 && c <= 7418)
+                  : (c <= 7957 || (c >= 7960 && c <= 7965)))))
+              : (c <= 8005 || (c < 8027
+                ? (c < 8016
+                  ? (c >= 8008 && c <= 8013)
+                  : (c <= 8023 || c == 8025))
+                : (c <= 8027 || (c < 8031
+                  ? c == 8029
+                  : (c <= 8061 || (c >= 8064 && c <= 8116)))))))
+            : (c <= 8124 || (c < 8182
+              ? (c < 8144
+                ? (c < 8130
+                  ? c == 8126
+                  : (c <= 8132 || (c >= 8134 && c <= 8140)))
+                : (c <= 8147 || (c < 8160
+                  ? (c >= 8150 && c <= 8155)
+                  : (c <= 8172 || (c >= 8178 && c <= 8180)))))
+              : (c <= 8188 || (c < 8336
+                ? (c < 8308
+                  ? (c >= 8304 && c <= 8305)
+                  : (c <= 8313 || (c >= 8319 && c <= 8329)))
+                : (c <= 8348 || (c < 8450
+                  ? (c >= 8400 && c <= 8432)
+                  : c <= 8450)))))))))
+        : (c <= 8455 || (c < 11728
+          ? (c < 11264
+            ? (c < 8495
+              ? (c < 8484
+                ? (c < 8469
+                  ? (c >= 8458 && c <= 8467)
+                  : (c <= 8469 || (c >= 8473 && c <= 8477)))
+                : (c <= 8484 || (c < 8488
+                  ? c == 8486
+                  : (c <= 8488 || (c >= 8490 && c <= 8493)))))
+              : (c <= 8505 || (c < 8528
+                ? (c < 8517
+                  ? (c >= 8508 && c <= 8511)
+                  : (c <= 8521 || c == 8526))
+                : (c <= 8585 || (c < 9450
+                  ? (c >= 9312 && c <= 9371)
+                  : (c <= 9471 || (c >= 10102 && c <= 10131)))))))
+            : (c <= 11492 || (c < 11647
+              ? (c < 11559
+                ? (c < 11517
+                  ? (c >= 11499 && c <= 11507)
+                  : (c <= 11517 || (c >= 11520 && c <= 11557)))
+                : (c <= 11559 || (c < 11568
+                  ? c == 11565
+                  : (c <= 11623 || c == 11631))))
+              : (c <= 11670 || (c < 11704
+                ? (c < 11688
+                  ? (c >= 11680 && c <= 11686)
+                  : (c <= 11694 || (c >= 11696 && c <= 11702)))
+                : (c <= 11710 || (c < 11720
+                  ? (c >= 11712 && c <= 11718)
+                  : c <= 11726)))))))
+          : (c <= 11734 || (c < 12704
+            ? (c < 12353
+              ? (c < 12293
+                ? (c < 11744
+                  ? (c >= 11736 && c <= 11742)
+                  : (c <= 11775 || c == 11823))
+                : (c <= 12295 || (c < 12337
+                  ? (c >= 12321 && c <= 12335)
+                  : (c <= 12341 || (c >= 12344 && c <= 12348)))))
+              : (c <= 12438 || (c < 12540
+                ? (c < 12445
+                  ? (c >= 12441 && c <= 12442)
+                  : (c <= 12447 || (c >= 12449 && c <= 12538)))
+                : (c <= 12543 || (c < 12593
+                  ? (c >= 12549 && c <= 12591)
+                  : (c <= 12686 || (c >= 12690 && c <= 12693)))))))
+            : (c <= 12735 || (c < 19903
+              ? (c < 12881
+                ? (c < 12832
+                  ? (c >= 12784 && c <= 12799)
+                  : (c <= 12841 || (c >= 12872 && c <= 12879)))
+                : (c <= 12895 || (c < 12977
+                  ? (c >= 12928 && c <= 12937)
+                  : (c <= 12991 || c == 13312))))
+              : (c <= 19903 || (c < 42512
+                ? (c < 42192
+                  ? (c >= 19968 && c <= 42124)
+                  : (c <= 42237 || (c >= 42240 && c <= 42508)))
+                : (c <= 42539 || (c < 42612
+                  ? (c >= 42560 && c <= 42610)
+                  : c <= 42621)))))))))))
+      : (c <= 42737 || (c < 65296
+        ? (c < 43793
+          ? (c < 43312
+            ? (c < 43052
+              ? (c < 42960
+                ? (c < 42786
+                  ? (c >= 42775 && c <= 42783)
+                  : (c <= 42888 || (c >= 42891 && c <= 42954)))
+                : (c <= 42961 || (c < 42965
+                  ? c == 42963
+                  : (c <= 42969 || (c >= 42994 && c <= 43047)))))
+              : (c <= 43052 || (c < 43216
+                ? (c < 43072
+                  ? (c >= 43056 && c <= 43061)
+                  : (c <= 43123 || (c >= 43136 && c <= 43205)))
+                : (c <= 43225 || (c < 43259
+                  ? (c >= 43232 && c <= 43255)
+                  : (c <= 43259 || (c >= 43261 && c <= 43309)))))))
+            : (c <= 43347 || (c < 43616
+              ? (c < 43488
+                ? (c < 43392
+                  ? (c >= 43360 && c <= 43388)
+                  : (c <= 43456 || (c >= 43471 && c <= 43481)))
+                : (c <= 43518 || (c < 43584
+                  ? (c >= 43520 && c <= 43574)
+                  : (c <= 43597 || (c >= 43600 && c <= 43609)))))
+              : (c <= 43638 || (c < 43762
+                ? (c < 43739
+                  ? (c >= 43642 && c <= 43714)
+                  : (c <= 43741 || (c >= 43744 && c <= 43759)))
+                : (c <= 43766 || (c < 43785
+                  ? (c >= 43777 && c <= 43782)
+                  : c <= 43790)))))))
+          : (c <= 43798 || (c < 64285
+            ? (c < 44032
+              ? (c < 43868
+                ? (c < 43816
+                  ? (c >= 43808 && c <= 43814)
+                  : (c <= 43822 || (c >= 43824 && c <= 43866)))
+                : (c <= 43881 || (c < 44012
+                  ? (c >= 43888 && c <= 44010)
+                  : (c <= 44013 || (c >= 44016 && c <= 44025)))))
+              : (c <= 44032 || (c < 63744
+                ? (c < 55216
+                  ? c == 55203
+                  : (c <= 55238 || (c >= 55243 && c <= 55291)))
+                : (c <= 64109 || (c < 64256
+                  ? (c >= 64112 && c <= 64217)
+                  : (c <= 64262 || (c >= 64275 && c <= 64279)))))))
+            : (c <= 64296 || (c < 64848
+              ? (c < 64320
+                ? (c < 64312
+                  ? (c >= 64298 && c <= 64310)
+                  : (c <= 64316 || c == 64318))
+                : (c <= 64321 || (c < 64326
+                  ? (c >= 64323 && c <= 64324)
+                  : (c <= 64433 || (c >= 64467 && c <= 64829)))))
+              : (c <= 64911 || (c < 65056
+                ? (c < 65008
+                  ? (c >= 64914 && c <= 64967)
+                  : (c <= 65019 || (c >= 65024 && c <= 65039)))
+                : (c <= 65071 || (c < 65142
+                  ? (c >= 65136 && c <= 65140)
+                  : c <= 65276)))))))))
+        : (c <= 65305 || (c < 66736
+          ? (c < 65856
+            ? (c < 65536
+              ? (c < 65474
+                ? (c < 65345
+                  ? (c >= 65313 && c <= 65338)
+                  : (c <= 65370 || (c >= 65382 && c <= 65470)))
+                : (c <= 65479 || (c < 65490
+                  ? (c >= 65482 && c <= 65487)
+                  : (c <= 65495 || (c >= 65498 && c <= 65500)))))
+              : (c <= 65547 || (c < 65599
+                ? (c < 65576
+                  ? (c >= 65549 && c <= 65574)
+                  : (c <= 65594 || (c >= 65596 && c <= 65597)))
+                : (c <= 65613 || (c < 65664
+                  ? (c >= 65616 && c <= 65629)
+                  : (c <= 65786 || (c >= 65799 && c <= 65843)))))))
+            : (c <= 65912 || (c < 66384
+              ? (c < 66208
+                ? (c < 66045
+                  ? (c >= 65930 && c <= 65931)
+                  : (c <= 66045 || (c >= 66176 && c <= 66204)))
+                : (c <= 66256 || (c < 66304
+                  ? (c >= 66272 && c <= 66299)
+                  : (c <= 66339 || (c >= 66349 && c <= 66378)))))
+              : (c <= 66426 || (c < 66513
+                ? (c < 66464
+                  ? (c >= 66432 && c <= 66461)
+                  : (c <= 66499 || (c >= 66504 && c <= 66511)))
+                : (c <= 66517 || (c < 66720
+                  ? (c >= 66560 && c <= 66717)
+                  : c <= 66729)))))))
+          : (c <= 66771 || (c < 67463
+            ? (c < 66967
+              ? (c < 66928
+                ? (c < 66816
+                  ? (c >= 66776 && c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))
+                : (c <= 66938 || (c < 66956
+                  ? (c >= 66940 && c <= 66954)
+                  : (c <= 66962 || (c >= 66964 && c <= 66965)))))
+              : (c <= 66977 || (c < 67072
+                ? (c < 66995
+                  ? (c >= 66979 && c <= 66993)
+                  : (c <= 67001 || (c >= 67003 && c <= 67004)))
+                : (c <= 67382 || (c < 67424
+                  ? (c >= 67392 && c <= 67413)
+                  : (c <= 67431 || (c >= 67456 && c <= 67461)))))))
+            : (c <= 67504 || (c < 67672
+              ? (c < 67594
+                ? (c < 67584
+                  ? (c >= 67506 && c <= 67514)
+                  : (c <= 67589 || c == 67592))
+                : (c <= 67637 || (c < 67644
+                  ? (c >= 67639 && c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67828
+                ? (c < 67751
+                  ? (c >= 67705 && c <= 67742)
+                  : (c <= 67759 || (c >= 67808 && c <= 67826)))
+                : (c <= 67829 || (c < 67872
+                  ? (c >= 67835 && c <= 67867)
+                  : c <= 67883)))))))))))))));
+}
+
+static inline bool sym___identifier_char_no_digit_character_set_1(int32_t c) {
+  return (c < 6002
+    ? (c < 2949
+      ? (c < 2437
+        ? (c < 1329
+          ? (c < 248
+            ? (c < '~'
+              ? (c < '-'
+                ? (c < '$'
+                  ? c == '!'
+                  : (c <= '\'' || (c >= '*' && c <= '+')))
+                : (c <= ':' || (c < '^'
+                  ? (c >= '?' && c <= 'Z')
+                  : (c <= '_' || (c >= 'a' && c <= '|')))))
+              : (c <= '~' || (c < 185
+                ? (c < 178
+                  ? c == 170
+                  : (c <= 179 || c == 181))
+                : (c <= 186 || (c < 192
+                  ? (c >= 188 && c <= 190)
+                  : (c <= 214 || (c >= 216 && c <= 246)))))))
+            : (c <= 705 || (c < 895
+              ? (c < 750
+                ? (c < 736
+                  ? (c >= 710 && c <= 721)
+                  : (c <= 740 || c == 748))
+                : (c <= 750 || (c < 886
+                  ? (c >= 768 && c <= 884)
+                  : (c <= 887 || (c >= 890 && c <= 893)))))
+              : (c <= 895 || (c < 910
+                ? (c < 904
+                  ? c == 902
+                  : (c <= 906 || c == 908))
+                : (c <= 929 || (c < 1015
+                  ? (c >= 931 && c <= 1013)
+                  : (c <= 1153 || (c >= 1155 && c <= 1327)))))))))
+          : (c <= 1366 || (c < 1791
+            ? (c < 1488
+              ? (c < 1471
+                ? (c < 1376
+                  ? c == 1369
+                  : (c <= 1416 || (c >= 1425 && c <= 1469)))
+                : (c <= 1471 || (c < 1476
+                  ? (c >= 1473 && c <= 1474)
+                  : (c <= 1477 || c == 1479))))
+              : (c <= 1514 || (c < 1646
+                ? (c < 1552
+                  ? (c >= 1519 && c <= 1522)
+                  : (c <= 1562 || (c >= 1568 && c <= 1641)))
+                : (c <= 1747 || (c < 1759
+                  ? (c >= 1749 && c <= 1756)
+                  : (c <= 1768 || (c >= 1770 && c <= 1788)))))))
+            : (c <= 1791 || (c < 2144
+              ? (c < 2042
+                ? (c < 1869
+                  ? (c >= 1808 && c <= 1866)
+                  : (c <= 1969 || (c >= 1984 && c <= 2037)))
+                : (c <= 2042 || (c < 2048
+                  ? c == 2045
+                  : (c <= 2093 || (c >= 2112 && c <= 2139)))))
+              : (c <= 2154 || (c < 2275
+                ? (c < 2185
+                  ? (c >= 2160 && c <= 2183)
+                  : (c <= 2190 || (c >= 2200 && c <= 2273)))
+                : (c <= 2403 || (c < 2417
+                  ? (c >= 2406 && c <= 2415)
+                  : c <= 2435)))))))))
+        : (c <= 2444 || (c < 2662
+          ? (c < 2561
+            ? (c < 2507
+              ? (c < 2482
+                ? (c < 2451
+                  ? (c >= 2447 && c <= 2448)
+                  : (c <= 2472 || (c >= 2474 && c <= 2480)))
+                : (c <= 2482 || (c < 2492
+                  ? (c >= 2486 && c <= 2489)
+                  : (c <= 2500 || (c >= 2503 && c <= 2504)))))
+              : (c <= 2510 || (c < 2534
+                ? (c < 2524
+                  ? c == 2519
+                  : (c <= 2525 || (c >= 2527 && c <= 2531)))
+                : (c <= 2545 || (c < 2556
+                  ? (c >= 2548 && c <= 2553)
+                  : (c <= 2556 || c == 2558))))))
+            : (c <= 2563 || (c < 2620
+              ? (c < 2602
+                ? (c < 2575
+                  ? (c >= 2565 && c <= 2570)
+                  : (c <= 2576 || (c >= 2579 && c <= 2600)))
+                : (c <= 2608 || (c < 2613
+                  ? (c >= 2610 && c <= 2611)
+                  : (c <= 2614 || (c >= 2616 && c <= 2617)))))
+              : (c <= 2620 || (c < 2641
+                ? (c < 2631
+                  ? (c >= 2622 && c <= 2626)
+                  : (c <= 2632 || (c >= 2635 && c <= 2637)))
+                : (c <= 2641 || (c < 2654
+                  ? (c >= 2649 && c <= 2652)
+                  : c <= 2654)))))))
+          : (c <= 2677 || (c < 2821
+            ? (c < 2748
+              ? (c < 2707
+                ? (c < 2693
+                  ? (c >= 2689 && c <= 2691)
+                  : (c <= 2701 || (c >= 2703 && c <= 2705)))
+                : (c <= 2728 || (c < 2738
+                  ? (c >= 2730 && c <= 2736)
+                  : (c <= 2739 || (c >= 2741 && c <= 2745)))))
+              : (c <= 2757 || (c < 2784
+                ? (c < 2763
+                  ? (c >= 2759 && c <= 2761)
+                  : (c <= 2765 || c == 2768))
+                : (c <= 2787 || (c < 2809
+                  ? (c >= 2790 && c <= 2799)
+                  : (c <= 2815 || (c >= 2817 && c <= 2819)))))))
+            : (c <= 2828 || (c < 2891
+              ? (c < 2866
+                ? (c < 2835
+                  ? (c >= 2831 && c <= 2832)
+                  : (c <= 2856 || (c >= 2858 && c <= 2864)))
+                : (c <= 2867 || (c < 2876
+                  ? (c >= 2869 && c <= 2873)
+                  : (c <= 2884 || (c >= 2887 && c <= 2888)))))
+              : (c <= 2893 || (c < 2918
+                ? (c < 2908
+                  ? (c >= 2901 && c <= 2903)
+                  : (c <= 2909 || (c >= 2911 && c <= 2915)))
+                : (c <= 2927 || (c < 2946
+                  ? (c >= 2929 && c <= 2935)
+                  : c <= 2947)))))))))))
+      : (c <= 2954 || (c < 3585
+        ? (c < 3218
+          ? (c < 3086
+            ? (c < 2990
+              ? (c < 2972
+                ? (c < 2962
+                  ? (c >= 2958 && c <= 2960)
+                  : (c <= 2965 || (c >= 2969 && c <= 2970)))
+                : (c <= 2972 || (c < 2979
+                  ? (c >= 2974 && c <= 2975)
+                  : (c <= 2980 || (c >= 2984 && c <= 2986)))))
+              : (c <= 3001 || (c < 3024
+                ? (c < 3014
+                  ? (c >= 3006 && c <= 3010)
+                  : (c <= 3016 || (c >= 3018 && c <= 3021)))
+                : (c <= 3024 || (c < 3046
+                  ? c == 3031
+                  : (c <= 3058 || (c >= 3072 && c <= 3084)))))))
+            : (c <= 3088 || (c < 3165
+              ? (c < 3142
+                ? (c < 3114
+                  ? (c >= 3090 && c <= 3112)
+                  : (c <= 3129 || (c >= 3132 && c <= 3140)))
+                : (c <= 3144 || (c < 3157
+                  ? (c >= 3146 && c <= 3149)
+                  : (c <= 3158 || (c >= 3160 && c <= 3162)))))
+              : (c <= 3165 || (c < 3200
+                ? (c < 3174
+                  ? (c >= 3168 && c <= 3171)
+                  : (c <= 3183 || (c >= 3192 && c <= 3198)))
+                : (c <= 3203 || (c < 3214
+                  ? (c >= 3205 && c <= 3212)
+                  : c <= 3216)))))))
+          : (c <= 3240 || (c < 3412
+            ? (c < 3296
+              ? (c < 3270
+                ? (c < 3253
+                  ? (c >= 3242 && c <= 3251)
+                  : (c <= 3257 || (c >= 3260 && c <= 3268)))
+                : (c <= 3272 || (c < 3285
+                  ? (c >= 3274 && c <= 3277)
+                  : (c <= 3286 || (c >= 3293 && c <= 3294)))))
+              : (c <= 3299 || (c < 3342
+                ? (c < 3313
+                  ? (c >= 3302 && c <= 3311)
+                  : (c <= 3314 || (c >= 3328 && c <= 3340)))
+                : (c <= 3344 || (c < 3398
+                  ? (c >= 3346 && c <= 3396)
+                  : (c <= 3400 || (c >= 3402 && c <= 3406)))))))
+            : (c <= 3427 || (c < 3520
+              ? (c < 3461
+                ? (c < 3450
+                  ? (c >= 3430 && c <= 3448)
+                  : (c <= 3455 || (c >= 3457 && c <= 3459)))
+                : (c <= 3478 || (c < 3507
+                  ? (c >= 3482 && c <= 3505)
+                  : (c <= 3515 || c == 3517))))
+              : (c <= 3526 || (c < 3544
+                ? (c < 3535
+                  ? c == 3530
+                  : (c <= 3540 || c == 3542))
+                : (c <= 3551 || (c < 3570
+                  ? (c >= 3558 && c <= 3567)
+                  : c <= 3571)))))))))
+        : (c <= 3642 || (c < 4304
+          ? (c < 3872
+            ? (c < 3751
+              ? (c < 3716
+                ? (c < 3664
+                  ? (c >= 3648 && c <= 3662)
+                  : (c <= 3673 || (c >= 3713 && c <= 3714)))
+                : (c <= 3716 || (c < 3724
+                  ? (c >= 3718 && c <= 3722)
+                  : (c <= 3747 || c == 3749))))
+              : (c <= 3773 || (c < 3792
+                ? (c < 3782
+                  ? (c >= 3776 && c <= 3780)
+                  : (c <= 3782 || (c >= 3784 && c <= 3789)))
+                : (c <= 3801 || (c < 3840
+                  ? (c >= 3804 && c <= 3807)
+                  : (c <= 3840 || (c >= 3864 && c <= 3865)))))))
+            : (c <= 3891 || (c < 3993
+              ? (c < 3902
+                ? (c < 3895
+                  ? c == 3893
+                  : (c <= 3895 || c == 3897))
+                : (c <= 3911 || (c < 3953
+                  ? (c >= 3913 && c <= 3948)
+                  : (c <= 3972 || (c >= 3974 && c <= 3991)))))
+              : (c <= 4028 || (c < 4256
+                ? (c < 4096
+                  ? c == 4038
+                  : (c <= 4169 || (c >= 4176 && c <= 4253)))
+                : (c <= 4293 || (c < 4301
+                  ? c == 4295
+                  : c <= 4301)))))))
+          : (c <= 4346 || (c < 4888
+            ? (c < 4752
+              ? (c < 4696
+                ? (c < 4682
+                  ? (c >= 4348 && c <= 4680)
+                  : (c <= 4685 || (c >= 4688 && c <= 4694)))
+                : (c <= 4696 || (c < 4704
+                  ? (c >= 4698 && c <= 4701)
+                  : (c <= 4744 || (c >= 4746 && c <= 4749)))))
+              : (c <= 4784 || (c < 4802
+                ? (c < 4792
+                  ? (c >= 4786 && c <= 4789)
+                  : (c <= 4798 || c == 4800))
+                : (c <= 4805 || (c < 4824
+                  ? (c >= 4808 && c <= 4822)
+                  : (c <= 4880 || (c >= 4882 && c <= 4885)))))))
+            : (c <= 4954 || (c < 5792
+              ? (c < 5024
+                ? (c < 4969
+                  ? (c >= 4957 && c <= 4959)
+                  : (c <= 4988 || (c >= 4992 && c <= 5007)))
+                : (c <= 5109 || (c < 5121
+                  ? (c >= 5112 && c <= 5117)
+                  : (c <= 5740 || (c >= 5743 && c <= 5786)))))
+              : (c <= 5866 || (c < 5952
+                ? (c < 5888
+                  ? (c >= 5870 && c <= 5880)
+                  : (c <= 5909 || (c >= 5919 && c <= 5940)))
+                : (c <= 5971 || (c < 5998
+                  ? (c >= 5984 && c <= 5996)
+                  : c <= 6000)))))))))))))
+    : (c <= 6003 || (c < 42623
+      ? (c < 8455
+        ? (c < 7245
+          ? (c < 6528
+            ? (c < 6176
+              ? (c < 6112
+                ? (c < 6103
+                  ? (c >= 6016 && c <= 6099)
+                  : (c <= 6103 || (c >= 6108 && c <= 6109)))
+                : (c <= 6121 || (c < 6155
+                  ? (c >= 6128 && c <= 6137)
+                  : (c <= 6157 || (c >= 6159 && c <= 6169)))))
+              : (c <= 6264 || (c < 6432
+                ? (c < 6320
+                  ? (c >= 6272 && c <= 6314)
+                  : (c <= 6389 || (c >= 6400 && c <= 6430)))
+                : (c <= 6443 || (c < 6470
+                  ? (c >= 6448 && c <= 6459)
+                  : (c <= 6509 || (c >= 6512 && c <= 6516)))))))
+            : (c <= 6571 || (c < 6823
+              ? (c < 6688
+                ? (c < 6608
+                  ? (c >= 6576 && c <= 6601)
+                  : (c <= 6618 || (c >= 6656 && c <= 6683)))
+                : (c <= 6750 || (c < 6783
+                  ? (c >= 6752 && c <= 6780)
+                  : (c <= 6793 || (c >= 6800 && c <= 6809)))))
+              : (c <= 6823 || (c < 7019
+                ? (c < 6912
+                  ? (c >= 6832 && c <= 6862)
+                  : (c <= 6988 || (c >= 6992 && c <= 7001)))
+                : (c <= 7027 || (c < 7168
+                  ? (c >= 7040 && c <= 7155)
+                  : (c <= 7223 || (c >= 7232 && c <= 7241)))))))))
+          : (c <= 7293 || (c < 8118
+            ? (c < 7968
+              ? (c < 7376
+                ? (c < 7312
+                  ? (c >= 7296 && c <= 7304)
+                  : (c <= 7354 || (c >= 7357 && c <= 7359)))
+                : (c <= 7378 || (c < 7424
+                  ? (c >= 7380 && c <= 7418)
+                  : (c <= 7957 || (c >= 7960 && c <= 7965)))))
+              : (c <= 8005 || (c < 8027
+                ? (c < 8016
+                  ? (c >= 8008 && c <= 8013)
+                  : (c <= 8023 || c == 8025))
+                : (c <= 8027 || (c < 8031
+                  ? c == 8029
+                  : (c <= 8061 || (c >= 8064 && c <= 8116)))))))
+            : (c <= 8124 || (c < 8182
+              ? (c < 8144
+                ? (c < 8130
+                  ? c == 8126
+                  : (c <= 8132 || (c >= 8134 && c <= 8140)))
+                : (c <= 8147 || (c < 8160
+                  ? (c >= 8150 && c <= 8155)
+                  : (c <= 8172 || (c >= 8178 && c <= 8180)))))
+              : (c <= 8188 || (c < 8336
+                ? (c < 8308
+                  ? (c >= 8304 && c <= 8305)
+                  : (c <= 8313 || (c >= 8319 && c <= 8329)))
+                : (c <= 8348 || (c < 8450
+                  ? (c >= 8400 && c <= 8432)
+                  : c <= 8450)))))))))
+        : (c <= 8455 || (c < 11728
+          ? (c < 11264
+            ? (c < 8495
+              ? (c < 8484
+                ? (c < 8469
+                  ? (c >= 8458 && c <= 8467)
+                  : (c <= 8469 || (c >= 8473 && c <= 8477)))
+                : (c <= 8484 || (c < 8488
+                  ? c == 8486
+                  : (c <= 8488 || (c >= 8490 && c <= 8493)))))
+              : (c <= 8505 || (c < 8528
+                ? (c < 8517
+                  ? (c >= 8508 && c <= 8511)
+                  : (c <= 8521 || c == 8526))
+                : (c <= 8585 || (c < 9450
+                  ? (c >= 9312 && c <= 9371)
+                  : (c <= 9471 || (c >= 10102 && c <= 10131)))))))
+            : (c <= 11492 || (c < 11647
+              ? (c < 11559
+                ? (c < 11517
+                  ? (c >= 11499 && c <= 11507)
+                  : (c <= 11517 || (c >= 11520 && c <= 11557)))
+                : (c <= 11559 || (c < 11568
+                  ? c == 11565
+                  : (c <= 11623 || c == 11631))))
+              : (c <= 11670 || (c < 11704
+                ? (c < 11688
+                  ? (c >= 11680 && c <= 11686)
+                  : (c <= 11694 || (c >= 11696 && c <= 11702)))
+                : (c <= 11710 || (c < 11720
+                  ? (c >= 11712 && c <= 11718)
+                  : c <= 11726)))))))
+          : (c <= 11734 || (c < 12704
+            ? (c < 12353
+              ? (c < 12293
+                ? (c < 11744
+                  ? (c >= 11736 && c <= 11742)
+                  : (c <= 11775 || c == 11823))
+                : (c <= 12295 || (c < 12337
+                  ? (c >= 12321 && c <= 12335)
+                  : (c <= 12341 || (c >= 12344 && c <= 12348)))))
+              : (c <= 12438 || (c < 12540
+                ? (c < 12445
+                  ? (c >= 12441 && c <= 12442)
+                  : (c <= 12447 || (c >= 12449 && c <= 12538)))
+                : (c <= 12543 || (c < 12593
+                  ? (c >= 12549 && c <= 12591)
+                  : (c <= 12686 || (c >= 12690 && c <= 12693)))))))
+            : (c <= 12735 || (c < 19903
+              ? (c < 12881
+                ? (c < 12832
+                  ? (c >= 12784 && c <= 12799)
+                  : (c <= 12841 || (c >= 12872 && c <= 12879)))
+                : (c <= 12895 || (c < 12977
+                  ? (c >= 12928 && c <= 12937)
+                  : (c <= 12991 || c == 13312))))
+              : (c <= 19903 || (c < 42512
+                ? (c < 42192
+                  ? (c >= 19968 && c <= 42124)
+                  : (c <= 42237 || (c >= 42240 && c <= 42508)))
+                : (c <= 42539 || (c < 42612
+                  ? (c >= 42560 && c <= 42610)
+                  : c <= 42621)))))))))))
+      : (c <= 42737 || (c < 65296
+        ? (c < 43793
+          ? (c < 43312
+            ? (c < 43052
+              ? (c < 42960
+                ? (c < 42786
+                  ? (c >= 42775 && c <= 42783)
+                  : (c <= 42888 || (c >= 42891 && c <= 42954)))
+                : (c <= 42961 || (c < 42965
+                  ? c == 42963
+                  : (c <= 42969 || (c >= 42994 && c <= 43047)))))
+              : (c <= 43052 || (c < 43216
+                ? (c < 43072
+                  ? (c >= 43056 && c <= 43061)
+                  : (c <= 43123 || (c >= 43136 && c <= 43205)))
+                : (c <= 43225 || (c < 43259
+                  ? (c >= 43232 && c <= 43255)
+                  : (c <= 43259 || (c >= 43261 && c <= 43309)))))))
+            : (c <= 43347 || (c < 43616
+              ? (c < 43488
+                ? (c < 43392
+                  ? (c >= 43360 && c <= 43388)
+                  : (c <= 43456 || (c >= 43471 && c <= 43481)))
+                : (c <= 43518 || (c < 43584
+                  ? (c >= 43520 && c <= 43574)
+                  : (c <= 43597 || (c >= 43600 && c <= 43609)))))
+              : (c <= 43638 || (c < 43762
+                ? (c < 43739
+                  ? (c >= 43642 && c <= 43714)
+                  : (c <= 43741 || (c >= 43744 && c <= 43759)))
+                : (c <= 43766 || (c < 43785
+                  ? (c >= 43777 && c <= 43782)
+                  : c <= 43790)))))))
+          : (c <= 43798 || (c < 64285
+            ? (c < 44032
+              ? (c < 43868
+                ? (c < 43816
+                  ? (c >= 43808 && c <= 43814)
+                  : (c <= 43822 || (c >= 43824 && c <= 43866)))
+                : (c <= 43881 || (c < 44012
+                  ? (c >= 43888 && c <= 44010)
+                  : (c <= 44013 || (c >= 44016 && c <= 44025)))))
+              : (c <= 44032 || (c < 63744
+                ? (c < 55216
+                  ? c == 55203
+                  : (c <= 55238 || (c >= 55243 && c <= 55291)))
+                : (c <= 64109 || (c < 64256
+                  ? (c >= 64112 && c <= 64217)
+                  : (c <= 64262 || (c >= 64275 && c <= 64279)))))))
+            : (c <= 64296 || (c < 64848
+              ? (c < 64320
+                ? (c < 64312
+                  ? (c >= 64298 && c <= 64310)
+                  : (c <= 64316 || c == 64318))
+                : (c <= 64321 || (c < 64326
+                  ? (c >= 64323 && c <= 64324)
+                  : (c <= 64433 || (c >= 64467 && c <= 64829)))))
+              : (c <= 64911 || (c < 65056
+                ? (c < 65008
+                  ? (c >= 64914 && c <= 64967)
+                  : (c <= 65019 || (c >= 65024 && c <= 65039)))
+                : (c <= 65071 || (c < 65142
+                  ? (c >= 65136 && c <= 65140)
+                  : c <= 65276)))))))))
+        : (c <= 65305 || (c < 66736
+          ? (c < 65856
+            ? (c < 65536
+              ? (c < 65474
+                ? (c < 65345
+                  ? (c >= 65313 && c <= 65338)
+                  : (c <= 65370 || (c >= 65382 && c <= 65470)))
+                : (c <= 65479 || (c < 65490
+                  ? (c >= 65482 && c <= 65487)
+                  : (c <= 65495 || (c >= 65498 && c <= 65500)))))
+              : (c <= 65547 || (c < 65599
+                ? (c < 65576
+                  ? (c >= 65549 && c <= 65574)
+                  : (c <= 65594 || (c >= 65596 && c <= 65597)))
+                : (c <= 65613 || (c < 65664
+                  ? (c >= 65616 && c <= 65629)
+                  : (c <= 65786 || (c >= 65799 && c <= 65843)))))))
+            : (c <= 65912 || (c < 66384
+              ? (c < 66208
+                ? (c < 66045
+                  ? (c >= 65930 && c <= 65931)
+                  : (c <= 66045 || (c >= 66176 && c <= 66204)))
+                : (c <= 66256 || (c < 66304
+                  ? (c >= 66272 && c <= 66299)
+                  : (c <= 66339 || (c >= 66349 && c <= 66378)))))
+              : (c <= 66426 || (c < 66513
+                ? (c < 66464
+                  ? (c >= 66432 && c <= 66461)
+                  : (c <= 66499 || (c >= 66504 && c <= 66511)))
+                : (c <= 66517 || (c < 66720
+                  ? (c >= 66560 && c <= 66717)
+                  : c <= 66729)))))))
+          : (c <= 66771 || (c < 67463
+            ? (c < 66967
+              ? (c < 66928
+                ? (c < 66816
+                  ? (c >= 66776 && c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))
+                : (c <= 66938 || (c < 66956
+                  ? (c >= 66940 && c <= 66954)
+                  : (c <= 66962 || (c >= 66964 && c <= 66965)))))
+              : (c <= 66977 || (c < 67072
+                ? (c < 66995
+                  ? (c >= 66979 && c <= 66993)
+                  : (c <= 67001 || (c >= 67003 && c <= 67004)))
+                : (c <= 67382 || (c < 67424
+                  ? (c >= 67392 && c <= 67413)
+                  : (c <= 67431 || (c >= 67456 && c <= 67461)))))))
+            : (c <= 67504 || (c < 67672
+              ? (c < 67594
+                ? (c < 67584
+                  ? (c >= 67506 && c <= 67514)
+                  : (c <= 67589 || c == 67592))
+                : (c <= 67637 || (c < 67644
+                  ? (c >= 67639 && c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67828
+                ? (c < 67751
+                  ? (c >= 67705 && c <= 67742)
+                  : (c <= 67759 || (c >= 67808 && c <= 67826)))
+                : (c <= 67829 || (c < 67872
+                  ? (c >= 67835 && c <= 67867)
+                  : c <= 67883)))))))))))))));
+}
+
+static inline bool sym_escaped_whitespace_character_set_1(int32_t c) {
+  return (c < 8192
+    ? (c < 133
+      ? (c < ' '
+        ? (c >= '\t' && c <= '\f')
+        : c <= ' ')
+      : (c <= 133 || (c < 5760
+        ? c == 160
+        : c <= 5760)))
+    : (c <= 8202 || (c < 8287
+      ? (c < 8239
+        ? (c >= 8232 && c <= 8233)
+        : c <= 8239)
+      : (c <= 8287 || c == 12288))));
+}
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
@@ -1631,440 +7114,286 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(20);
-      ADVANCE_MAP(
-        '\n', 32,
-        '\f', 32,
-        '\r', 32,
-        '"', 31,
-        '(', 29,
-        ')', 30,
-        '+', 46,
-        '-', 47,
-        '.', 37,
-        '0', 52,
-        '1', 53,
-        ';', 24,
-        '=', 28,
-        'E', 41,
-        '\\', 54,
-        '_', 43,
-        'e', 39,
-        '{', 22,
-        '}', 23,
-        0x85, 32,
-        0x2028, 32,
-        0x2029, 32,
-        0xfeff, 32,
-        '8', 26,
-        '9', 26,
-      );
-      if (('2' <= lookahead && lookahead <= '7')) ADVANCE(26);
+      if (lookahead == '\n') ADVANCE(61);
+      if (lookahead == 11) ADVANCE(61);
+      if (lookahead == '\f') ADVANCE(61);
+      if (lookahead == '\r') ADVANCE(61);
+      if (lookahead == '"') ADVANCE(60);
+      if (lookahead == '#') ADVANCE(52);
+      if (lookahead == '(') ADVANCE(58);
+      if (lookahead == ')') ADVANCE(59);
+      if (lookahead == '+') ADVANCE(77);
+      if (lookahead == '-') ADVANCE(78);
+      if (lookahead == '.') ADVANCE(68);
+      if (lookahead == '0') ADVANCE(83);
+      if (lookahead == '1') ADVANCE(84);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '=') ADVANCE(57);
+      if (lookahead == 'E') ADVANCE(72);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '_') ADVANCE(74);
+      if (lookahead == 'e') ADVANCE(70);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == '}') ADVANCE(23);
+      if (lookahead == 133) ADVANCE(61);
+      if (lookahead == 8232) ADVANCE(61);
+      if (lookahead == 8233) ADVANCE(61);
+      if (lookahead == 65279) ADVANCE(61);
+      if (lookahead == '8' ||
+          lookahead == '9') ADVANCE(53);
+      if (('2' <= lookahead && lookahead <= '7')) ADVANCE(53);
       if (('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(25);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(52);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(32);
-      if (lookahead == 0xa9 ||
-          lookahead == 0xae ||
-          lookahead == 0x203c ||
-          lookahead == 0x2049 ||
-          lookahead == 0x2122 ||
-          (0x2194 <= lookahead && lookahead <= 0x2199) ||
-          lookahead == 0x21a9 ||
-          lookahead == 0x21aa ||
-          lookahead == 0x231a ||
-          lookahead == 0x231b ||
-          lookahead == 0x2328 ||
-          lookahead == 0x23cf ||
-          (0x23e9 <= lookahead && lookahead <= 0x23f3) ||
-          (0x23f8 <= lookahead && lookahead <= 0x23fa) ||
-          lookahead == 0x24c2 ||
-          lookahead == 0x25aa ||
-          lookahead == 0x25ab ||
-          lookahead == 0x25b6 ||
-          lookahead == 0x25c0 ||
-          (0x25fb <= lookahead && lookahead <= 0x25fe) ||
-          (0x2600 <= lookahead && lookahead <= 0x2604) ||
-          lookahead == 0x260e ||
-          lookahead == 0x2611 ||
-          lookahead == 0x2614 ||
-          lookahead == 0x2615 ||
-          lookahead == 0x2618 ||
-          lookahead == 0x261d ||
-          lookahead == 0x2620 ||
-          lookahead == 0x2622 ||
-          lookahead == 0x2623 ||
-          lookahead == 0x2626 ||
-          lookahead == 0x262a ||
-          lookahead == 0x262e ||
-          lookahead == 0x262f ||
-          (0x2638 <= lookahead && lookahead <= 0x263a) ||
-          lookahead == 0x2640 ||
-          lookahead == 0x2642 ||
-          (0x2648 <= lookahead && lookahead <= 0x2653) ||
-          lookahead == 0x265f ||
-          lookahead == 0x2660 ||
-          lookahead == 0x2663 ||
-          lookahead == 0x2665 ||
-          lookahead == 0x2666 ||
-          lookahead == 0x2668 ||
-          lookahead == 0x267b ||
-          lookahead == 0x267e ||
-          lookahead == 0x267f ||
-          (0x2692 <= lookahead && lookahead <= 0x2697) ||
-          lookahead == 0x2699 ||
-          lookahead == 0x269b ||
-          lookahead == 0x269c ||
-          lookahead == 0x26a0 ||
-          lookahead == 0x26a1 ||
-          lookahead == 0x26a7 ||
-          lookahead == 0x26aa ||
-          lookahead == 0x26ab ||
-          lookahead == 0x26b0 ||
-          lookahead == 0x26b1 ||
-          lookahead == 0x26bd ||
-          lookahead == 0x26be ||
-          lookahead == 0x26c4 ||
-          lookahead == 0x26c5 ||
-          lookahead == 0x26c8 ||
-          lookahead == 0x26ce ||
-          lookahead == 0x26cf ||
-          lookahead == 0x26d1 ||
-          lookahead == 0x26d3 ||
-          lookahead == 0x26d4 ||
-          lookahead == 0x26e9 ||
-          lookahead == 0x26ea ||
-          (0x26f0 <= lookahead && lookahead <= 0x26f5) ||
-          (0x26f7 <= lookahead && lookahead <= 0x26fa) ||
-          lookahead == 0x26fd ||
-          lookahead == 0x2702 ||
-          lookahead == 0x2705 ||
-          (0x2708 <= lookahead && lookahead <= 0x270d) ||
-          lookahead == 0x270f ||
-          lookahead == 0x2712 ||
-          lookahead == 0x2714 ||
-          lookahead == 0x2716 ||
-          lookahead == 0x271d ||
-          lookahead == 0x2721 ||
-          lookahead == 0x2728 ||
-          lookahead == 0x2733 ||
-          lookahead == 0x2734 ||
-          lookahead == 0x2744 ||
-          lookahead == 0x2747 ||
-          lookahead == 0x274c ||
-          lookahead == 0x274e ||
-          (0x2753 <= lookahead && lookahead <= 0x2755) ||
-          lookahead == 0x2757 ||
-          lookahead == 0x2763 ||
-          lookahead == 0x2764 ||
-          (0x2795 <= lookahead && lookahead <= 0x2797) ||
-          lookahead == 0x27a1 ||
-          lookahead == 0x27b0 ||
-          lookahead == 0x27bf ||
-          lookahead == 0x2934 ||
-          lookahead == 0x2935 ||
-          (0x2b05 <= lookahead && lookahead <= 0x2b07) ||
-          lookahead == 0x2b1b ||
-          lookahead == 0x2b1c ||
-          lookahead == 0x2b50 ||
-          lookahead == 0x2b55 ||
-          lookahead == 0x3030 ||
-          lookahead == 0x303d ||
-          lookahead == 0x3297 ||
-          lookahead == 0x3299 ||
-          lookahead == 0x1f004 ||
-          lookahead == 0x1f0cf ||
-          lookahead == 0x1f170 ||
-          lookahead == 0x1f171 ||
-          lookahead == 0x1f17e ||
-          lookahead == 0x1f17f ||
-          lookahead == 0x1f18e ||
-          (0x1f191 <= lookahead && lookahead <= 0x1f19a) ||
-          (0x1f1e6 <= lookahead && lookahead <= 0x1f1ff) ||
-          lookahead == 0x1f201 ||
-          lookahead == 0x1f202 ||
-          lookahead == 0x1f21a ||
-          lookahead == 0x1f22f ||
-          (0x1f232 <= lookahead && lookahead <= 0x1f23a) ||
-          lookahead == 0x1f250 ||
-          lookahead == 0x1f251 ||
-          (0x1f300 <= lookahead && lookahead <= 0x1f321) ||
-          (0x1f324 <= lookahead && lookahead <= 0x1f393) ||
-          lookahead == 0x1f396 ||
-          lookahead == 0x1f397 ||
-          (0x1f399 <= lookahead && lookahead <= 0x1f39b) ||
-          (0x1f39e <= lookahead && lookahead <= 0x1f3f0) ||
-          (0x1f3f3 <= lookahead && lookahead <= 0x1f3f5) ||
-          (0x1f3f7 <= lookahead && lookahead <= 0x1f4fd) ||
-          (0x1f4ff <= lookahead && lookahead <= 0x1f53d) ||
-          (0x1f549 <= lookahead && lookahead <= 0x1f54e) ||
-          (0x1f550 <= lookahead && lookahead <= 0x1f567) ||
-          lookahead == 0x1f56f ||
-          lookahead == 0x1f570 ||
-          (0x1f573 <= lookahead && lookahead <= 0x1f57a) ||
-          lookahead == 0x1f587 ||
-          (0x1f58a <= lookahead && lookahead <= 0x1f58d) ||
-          lookahead == 0x1f590 ||
-          lookahead == 0x1f595 ||
-          lookahead == 0x1f596 ||
-          lookahead == 0x1f5a4 ||
-          lookahead == 0x1f5a5 ||
-          lookahead == 0x1f5a8 ||
-          lookahead == 0x1f5b1 ||
-          lookahead == 0x1f5b2 ||
-          lookahead == 0x1f5bc ||
-          (0x1f5c2 <= lookahead && lookahead <= 0x1f5c4) ||
-          (0x1f5d1 <= lookahead && lookahead <= 0x1f5d3) ||
-          (0x1f5dc <= lookahead && lookahead <= 0x1f5de) ||
-          lookahead == 0x1f5e1 ||
-          lookahead == 0x1f5e3 ||
-          lookahead == 0x1f5e8 ||
-          lookahead == 0x1f5ef ||
-          lookahead == 0x1f5f3 ||
-          (0x1f5fa <= lookahead && lookahead <= 0x1f64f) ||
-          (0x1f680 <= lookahead && lookahead <= 0x1f6c5) ||
-          (0x1f6cb <= lookahead && lookahead <= 0x1f6d2) ||
-          (0x1f6d5 <= lookahead && lookahead <= 0x1f6d7) ||
-          (0x1f6dc <= lookahead && lookahead <= 0x1f6e5) ||
-          lookahead == 0x1f6e9 ||
-          lookahead == 0x1f6eb ||
-          lookahead == 0x1f6ec ||
-          lookahead == 0x1f6f0 ||
-          (0x1f6f3 <= lookahead && lookahead <= 0x1f6fc) ||
-          (0x1f7e0 <= lookahead && lookahead <= 0x1f7eb) ||
-          lookahead == 0x1f7f0 ||
-          (0x1f90c <= lookahead && lookahead <= 0x1f93a) ||
-          (0x1f93c <= lookahead && lookahead <= 0x1f945) ||
-          (0x1f947 <= lookahead && lookahead <= 0x1f9ff) ||
-          (0x1fa70 <= lookahead && lookahead <= 0x1fa7c) ||
-          (0x1fa80 <= lookahead && lookahead <= 0x1fa88) ||
-          (0x1fa90 <= lookahead && lookahead <= 0x1fabd) ||
-          (0x1fabf <= lookahead && lookahead <= 0x1fac5) ||
-          (0x1face <= lookahead && lookahead <= 0x1fadb) ||
-          (0x1fae0 <= lookahead && lookahead <= 0x1fae8) ||
-          (0x1faf0 <= lookahead && lookahead <= 0x1faf8)) ADVANCE(25);
-      if (set_contains(sym___identifier_char_no_digit_sign_character_set_1, 499, lookahead)) ADVANCE(25);
-      if (lookahead != 0) ADVANCE(32);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(61);
+      if (sym__normal_bare_identifier_character_set_1(lookahead)) ADVANCE(52);
+      if (sym__normal_bare_identifier_character_set_2(lookahead)) ADVANCE(52);
+      if (lookahead != 0) ADVANCE(61);
       END_STATE();
     case 1:
-      ADVANCE_MAP(
-        '\n', 56,
-        '\f', 59,
-        '\r', 8,
-        ')', 30,
-        '/', 10,
-        '0', 45,
-        ';', 24,
-        '=', 28,
-        '\\', 54,
-        '{', 22,
-        0x85, 58,
-        0x2028, 60,
-        0x2029, 61,
-        0xfeff, 62,
-      );
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(44);
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == '"') ADVANCE(60);
+      if (lookahead == '#') ADVANCE(25);
+      if (lookahead == '(') ADVANCE(58);
+      if (lookahead == '+') ADVANCE(77);
+      if (lookahead == '-') ADVANCE(78);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(76);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == 'f') ADVANCE(26);
+      if (lookahead == 'n') ADVANCE(50);
+      if (lookahead == 't') ADVANCE(45);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(75);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(63);
-      if (set_contains(sym___identifier_char_no_digit_character_set_1, 499, lookahead)) ADVANCE(27);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
+      if (sym__normal_bare_identifier_character_set_3(lookahead)) ADVANCE(52);
       END_STATE();
     case 2:
-      ADVANCE_MAP(
-        '\n', 56,
-        '\f', 59,
-        '\r', 8,
-        ')', 30,
-        '/', 10,
-        ';', 24,
-        '=', 28,
-        '\\', 54,
-        '{', 22,
-        0x85, 58,
-        0x2028, 60,
-        0x2029, 61,
-        0xfeff, 62,
-      );
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == ')') ADVANCE(59);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(76);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '=') ADVANCE(57);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(75);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(63);
-      if (set_contains(sym__identifier_char_character_set_1, 499, lookahead)) ADVANCE(26);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
+      if (sym___identifier_char_no_digit_character_set_1(lookahead)) ADVANCE(54);
       END_STATE();
     case 3:
-      ADVANCE_MAP(
-        '\n', 56,
-        '\f', 59,
-        '\r', 8,
-        '.', 36,
-        '/', 10,
-        ';', 24,
-        'E', 40,
-        '\\', 54,
-        '_', 42,
-        'e', 38,
-        '{', 22,
-        0x85, 58,
-        0x2028, 60,
-        0x2029, 61,
-        0xfeff, 62,
-      );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(44);
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == ')') ADVANCE(59);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '=') ADVANCE(57);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(63);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
+      if (sym__identifier_char_character_set_1(lookahead)) ADVANCE(53);
       END_STATE();
     case 4:
-      ADVANCE_MAP(
-        '\n', 56,
-        '\f', 59,
-        '\r', 8,
-        '/', 10,
-        '0', 52,
-        '1', 53,
-        ';', 24,
-        '\\', 54,
-        '_', 42,
-        '{', 22,
-        0x85, 58,
-        0x2028, 60,
-        0x2029, 61,
-        0xfeff, 62,
-      );
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == '.') ADVANCE(67);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == 'E') ADVANCE(71);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '_') ADVANCE(73);
+      if (lookahead == 'e') ADVANCE(69);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(75);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(63);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
       END_STATE();
     case 5:
-      ADVANCE_MAP(
-        '\n', 56,
-        '\f', 59,
-        '\r', 8,
-        '/', 10,
-        ';', 24,
-        '\\', 54,
-        '_', 42,
-        '{', 22,
-        0x85, 58,
-        0x2028, 60,
-        0x2029, 61,
-        0xfeff, 62,
-      );
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(50);
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(83);
+      if (lookahead == '1') ADVANCE(84);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '_') ADVANCE(73);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(63);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
       END_STATE();
     case 6:
-      ADVANCE_MAP(
-        '\n', 56,
-        '\f', 59,
-        '\r', 8,
-        '/', 10,
-        ';', 24,
-        '\\', 54,
-        '_', 42,
-        '{', 22,
-        0x85, 58,
-        0x2028, 60,
-        0x2029, 61,
-        0xfeff, 62,
-      );
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '_') ADVANCE(73);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(81);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(63);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(35);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(56);
-      if (lookahead == '\f') ADVANCE(59);
-      if (lookahead == '\r') ADVANCE(8);
-      if (lookahead == 0x85) ADVANCE(58);
-      if (lookahead == 0x2028) ADVANCE(60);
-      if (lookahead == 0x2029) ADVANCE(61);
-      if (lookahead != 0) ADVANCE(65);
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '_') ADVANCE(73);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
+      if (lookahead == '\t' ||
+          lookahead == ' ' ||
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(66);
       END_STATE();
     case 8:
-      if (lookahead == '\n') ADVANCE(57);
-      if (lookahead == '\'') ADVANCE(55);
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead != 0) ADVANCE(104);
       END_STATE();
     case 9:
-      if (lookahead == '"') ADVANCE(31);
-      if (lookahead == '\\') ADVANCE(33);
-      if (lookahead != 0) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(60);
+      if (lookahead == '\\') ADVANCE(62);
+      if (lookahead != 0) ADVANCE(61);
       END_STATE();
     case 10:
       if (lookahead == '-') ADVANCE(21);
-      if (lookahead == '/') ADVANCE(64);
+      if (lookahead == '/') ADVANCE(103);
       END_STATE();
     case 11:
       if (lookahead == '{') ADVANCE(18);
       END_STATE();
     case 12:
-      if (lookahead == '}') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(63);
       END_STATE();
     case 13:
-      if (lookahead == '}') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(12);
       END_STATE();
     case 14:
-      if (lookahead == '}') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(13);
       END_STATE();
     case 15:
-      if (lookahead == '}') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(14);
       END_STATE();
     case 16:
-      if (lookahead == '}') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(15);
       END_STATE();
     case 17:
-      if (lookahead == '}') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(16);
@@ -2076,37 +7405,36 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 19:
       if (eof) ADVANCE(20);
-      ADVANCE_MAP(
-        '\n', 56,
-        '\f', 59,
-        '\r', 8,
-        '"', 31,
-        '(', 29,
-        ')', 30,
-        '+', 46,
-        '-', 47,
-        '/', 10,
-        '0', 45,
-        ';', 24,
-        '=', 28,
-        '\\', 54,
-        '{', 22,
-        '}', 23,
-        0x85, 58,
-        0x2028, 60,
-        0x2029, 61,
-        0xfeff, 62,
-      );
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(44);
+      if (lookahead == '\n') ADVANCE(95);
+      if (lookahead == 11) ADVANCE(97);
+      if (lookahead == '\f') ADVANCE(98);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == '"') ADVANCE(60);
+      if (lookahead == '(') ADVANCE(58);
+      if (lookahead == ')') ADVANCE(59);
+      if (lookahead == '+') ADVANCE(77);
+      if (lookahead == '-') ADVANCE(78);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(76);
+      if (lookahead == ';') ADVANCE(24);
+      if (lookahead == '=') ADVANCE(57);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == '}') ADVANCE(23);
+      if (lookahead == 133) ADVANCE(96);
+      if (lookahead == 8232) ADVANCE(99);
+      if (lookahead == 8233) ADVANCE(100);
+      if (lookahead == 65279) ADVANCE(101);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(75);
       if (lookahead == '\t' ||
           lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(63);
-      if (set_contains(sym__normal_bare_identifier_character_set_2, 642, lookahead)) ADVANCE(25);
+          lookahead == 160 ||
+          lookahead == 5760 ||
+          (8192 <= lookahead && lookahead <= 8202) ||
+          lookahead == 8239 ||
+          lookahead == 8287 ||
+          lookahead == 12288) ADVANCE(102);
+      if (sym__normal_bare_identifier_character_set_4(lookahead)) ADVANCE(52);
       END_STATE();
     case 20:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -2125,144 +7453,333 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 25:
       ACCEPT_TOKEN(sym__normal_bare_identifier);
-      if (set_contains(sym__normal_bare_identifier_character_set_2, 642, lookahead)) ADVANCE(25);
+      if (lookahead == '-') ADVANCE(35);
+      if (lookahead == 'f') ADVANCE(28);
+      if (lookahead == 'i') ADVANCE(42);
+      if (lookahead == 'n') ADVANCE(27);
+      if (lookahead == 't') ADVANCE(46);
+      if (sym__normal_bare_identifier_character_set_5(lookahead)) ADVANCE(52);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(sym__identifier_char);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'a') ADVANCE(36);
+      if (sym__normal_bare_identifier_character_set_6(lookahead)) ADVANCE(52);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(sym___identifier_char_no_digit);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'a') ADVANCE(43);
+      if (lookahead == 'u') ADVANCE(40);
+      if (sym__normal_bare_identifier_character_set_6(lookahead)) ADVANCE(52);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'a') ADVANCE(41);
+      if (sym__normal_bare_identifier_character_set_6(lookahead)) ADVANCE(52);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'e') ADVANCE(88);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 30:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'e') ADVANCE(90);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'e') ADVANCE(89);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(aux_sym__escaped_string_token1);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'e') ADVANCE(91);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(aux_sym__escaped_string_token1);
-      ADVANCE_MAP(
-        'u', 11,
-        '"', 34,
-        '/', 34,
-        '\\', 34,
-        'b', 34,
-        'f', 34,
-        'n', 34,
-        'r', 34,
-        't', 34,
-      );
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'f') ADVANCE(85);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(sym_escape);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'f') ADVANCE(86);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 35:
-      ACCEPT_TOKEN(sym__hex_digit);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'i') ADVANCE(44);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(anon_sym_DOT);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'l') ADVANCE(47);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 37:
-      ACCEPT_TOKEN(anon_sym_DOT);
-      if (set_contains(sym__normal_bare_identifier_character_set_2, 642, lookahead)) ADVANCE(25);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'l') ADVANCE(55);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(anon_sym_e);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'l') ADVANCE(56);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 39:
-      ACCEPT_TOKEN(anon_sym_e);
-      if (set_contains(sym__normal_bare_identifier_character_set_2, 642, lookahead)) ADVANCE(25);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'l') ADVANCE(37);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(anon_sym_E);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'l') ADVANCE(38);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 41:
-      ACCEPT_TOKEN(anon_sym_E);
-      if (set_contains(sym__normal_bare_identifier_character_set_2, 642, lookahead)) ADVANCE(25);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'l') ADVANCE(48);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(anon_sym__);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'n') ADVANCE(33);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 43:
-      ACCEPT_TOKEN(anon_sym__);
-      if (set_contains(sym__normal_bare_identifier_character_set_2, 642, lookahead)) ADVANCE(25);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'n') ADVANCE(87);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 44:
-      ACCEPT_TOKEN(sym__digit);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'n') ADVANCE(34);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 45:
-      ACCEPT_TOKEN(sym__digit);
-      if (lookahead == 'b') ADVANCE(51);
-      if (lookahead == 'o') ADVANCE(49);
-      if (lookahead == 'x') ADVANCE(48);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'r') ADVANCE(49);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 46:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'r') ADVANCE(51);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 47:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 's') ADVANCE(31);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(anon_sym_0x);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 's') ADVANCE(32);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 49:
-      ACCEPT_TOKEN(anon_sym_0o);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'u') ADVANCE(29);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 50:
-      ACCEPT_TOKEN(aux_sym__octal_token1);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'u') ADVANCE(39);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(anon_sym_0b);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (lookahead == 'u') ADVANCE(30);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(anon_sym_0);
+      ACCEPT_TOKEN(sym__normal_bare_identifier);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(anon_sym_1);
+      ACCEPT_TOKEN(sym__identifier_char);
       END_STATE();
     case 54:
-      ACCEPT_TOKEN(anon_sym_BSLASH);
+      ACCEPT_TOKEN(sym___identifier_char_no_digit);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(aux_sym__newline_token1);
+      ACCEPT_TOKEN(anon_sym_null);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(aux_sym__newline_token2);
+      ACCEPT_TOKEN(anon_sym_POUNDnull);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
       END_STATE();
     case 57:
-      ACCEPT_TOKEN(aux_sym__newline_token3);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 58:
-      ACCEPT_TOKEN(aux_sym__newline_token4);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 59:
-      ACCEPT_TOKEN(aux_sym__newline_token5);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 60:
-      ACCEPT_TOKEN(aux_sym__newline_token6);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 61:
-      ACCEPT_TOKEN(aux_sym__newline_token7);
+      ACCEPT_TOKEN(aux_sym__escaped_string_token1);
       END_STATE();
     case 62:
-      ACCEPT_TOKEN(sym__bom);
+      ACCEPT_TOKEN(aux_sym__escaped_string_token1);
+      if (lookahead == '\r') ADVANCE(65);
+      if (lookahead == '"' ||
+          lookahead == '/' ||
+          lookahead == '\\' ||
+          lookahead == 'b' ||
+          lookahead == 'f' ||
+          lookahead == 'n' ||
+          ('r' <= lookahead && lookahead <= 't')) ADVANCE(63);
+      if (lookahead == 'u') ADVANCE(11);
+      if (sym_escaped_whitespace_character_set_1(lookahead)) ADVANCE(64);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(sym__unicode_space);
+      ACCEPT_TOKEN(sym_escape);
       END_STATE();
     case 64:
-      ACCEPT_TOKEN(anon_sym_SLASH_SLASH);
+      ACCEPT_TOKEN(sym_escaped_whitespace);
+      if (lookahead == '\r') ADVANCE(65);
+      if (sym_escaped_whitespace_character_set_1(lookahead)) ADVANCE(64);
       END_STATE();
     case 65:
+      ACCEPT_TOKEN(sym_escaped_whitespace);
+      if (sym_escaped_whitespace_character_set_1(lookahead)) ADVANCE(64);
+      if (lookahead == '\r') ADVANCE(65);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(sym__hex_digit);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(anon_sym_DOT);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(anon_sym_DOT);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(anon_sym_e);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(anon_sym_e);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(anon_sym_E);
+      END_STATE();
+    case 72:
+      ACCEPT_TOKEN(anon_sym_E);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 73:
+      ACCEPT_TOKEN(anon_sym__);
+      END_STATE();
+    case 74:
+      ACCEPT_TOKEN(anon_sym__);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 75:
+      ACCEPT_TOKEN(sym__digit);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(sym__digit);
+      if (lookahead == 'b') ADVANCE(82);
+      if (lookahead == 'o') ADVANCE(80);
+      if (lookahead == 'x') ADVANCE(79);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(anon_sym_0x);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(anon_sym_0o);
+      END_STATE();
+    case 81:
+      ACCEPT_TOKEN(aux_sym__octal_token1);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(anon_sym_0b);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(anon_sym_0);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(anon_sym_1);
+      END_STATE();
+    case 85:
+      ACCEPT_TOKEN(anon_sym_POUNDinf);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 86:
+      ACCEPT_TOKEN(anon_sym_POUND_DASHinf);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(anon_sym_POUNDnan);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(anon_sym_true);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(anon_sym_false);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(anon_sym_POUNDtrue);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(anon_sym_POUNDfalse);
+      if (sym__normal_bare_identifier_character_set_7(lookahead)) ADVANCE(52);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(anon_sym_BSLASH);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(aux_sym__newline_token1);
+      END_STATE();
+    case 94:
+      ACCEPT_TOKEN(aux_sym__newline_token2);
+      if (lookahead == '\n') ADVANCE(93);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(aux_sym__newline_token3);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(aux_sym__newline_token4);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(aux_sym__newline_token5);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(aux_sym__newline_token6);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(aux_sym__newline_token7);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(aux_sym__newline_token8);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(sym__bom);
+      END_STATE();
+    case 102:
+      ACCEPT_TOKEN(sym__unicode_space);
+      END_STATE();
+    case 103:
+      ACCEPT_TOKEN(anon_sym_SLASH_SLASH);
+      END_STATE();
+    case 104:
       ACCEPT_TOKEN(aux_sym_single_line_comment_token1);
       END_STATE();
     default:
@@ -2275,586 +7792,546 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      ADVANCE_MAP(
-        'b', 1,
-        'c', 2,
-        'd', 3,
-        'e', 4,
-        'f', 5,
-        'h', 6,
-        'i', 7,
-        'n', 8,
-        'r', 9,
-        't', 10,
-        'u', 11,
-      );
+      if (lookahead == 'b') ADVANCE(1);
+      if (lookahead == 'c') ADVANCE(2);
+      if (lookahead == 'd') ADVANCE(3);
+      if (lookahead == 'e') ADVANCE(4);
+      if (lookahead == 'f') ADVANCE(5);
+      if (lookahead == 'h') ADVANCE(6);
+      if (lookahead == 'i') ADVANCE(7);
+      if (lookahead == 'r') ADVANCE(8);
+      if (lookahead == 't') ADVANCE(9);
+      if (lookahead == 'u') ADVANCE(10);
       END_STATE();
     case 1:
-      if (lookahead == 'a') ADVANCE(12);
+      if (lookahead == 'a') ADVANCE(11);
       END_STATE();
     case 2:
-      if (lookahead == 'o') ADVANCE(13);
-      if (lookahead == 'u') ADVANCE(14);
+      if (lookahead == 'o') ADVANCE(12);
+      if (lookahead == 'u') ADVANCE(13);
       END_STATE();
     case 3:
-      if (lookahead == 'a') ADVANCE(15);
-      if (lookahead == 'e') ADVANCE(16);
-      if (lookahead == 'u') ADVANCE(17);
+      if (lookahead == 'a') ADVANCE(14);
+      if (lookahead == 'e') ADVANCE(15);
+      if (lookahead == 'u') ADVANCE(16);
       END_STATE();
     case 4:
-      if (lookahead == 'm') ADVANCE(18);
+      if (lookahead == 'm') ADVANCE(17);
       END_STATE();
     case 5:
-      if (lookahead == '3') ADVANCE(19);
-      if (lookahead == '6') ADVANCE(20);
-      if (lookahead == 'a') ADVANCE(21);
+      if (lookahead == '3') ADVANCE(18);
+      if (lookahead == '6') ADVANCE(19);
       END_STATE();
     case 6:
-      if (lookahead == 'o') ADVANCE(22);
+      if (lookahead == 'o') ADVANCE(20);
       END_STATE();
     case 7:
-      ADVANCE_MAP(
-        '1', 23,
-        '3', 24,
-        '6', 25,
-        '8', 26,
-        'd', 27,
-        'p', 28,
-        'r', 29,
-        's', 30,
-      );
+      if (lookahead == '1') ADVANCE(21);
+      if (lookahead == '3') ADVANCE(22);
+      if (lookahead == '6') ADVANCE(23);
+      if (lookahead == '8') ADVANCE(24);
+      if (lookahead == 'd') ADVANCE(25);
+      if (lookahead == 'p') ADVANCE(26);
+      if (lookahead == 'r') ADVANCE(27);
+      if (lookahead == 's') ADVANCE(28);
       END_STATE();
     case 8:
-      if (lookahead == 'u') ADVANCE(31);
+      if (lookahead == 'e') ADVANCE(29);
       END_STATE();
     case 9:
-      if (lookahead == 'e') ADVANCE(32);
+      if (lookahead == 'i') ADVANCE(30);
       END_STATE();
     case 10:
-      if (lookahead == 'i') ADVANCE(33);
-      if (lookahead == 'r') ADVANCE(34);
+      if (lookahead == '1') ADVANCE(31);
+      if (lookahead == '3') ADVANCE(32);
+      if (lookahead == '6') ADVANCE(33);
+      if (lookahead == '8') ADVANCE(34);
+      if (lookahead == 'r') ADVANCE(35);
+      if (lookahead == 's') ADVANCE(36);
+      if (lookahead == 'u') ADVANCE(37);
       END_STATE();
     case 11:
-      if (lookahead == '1') ADVANCE(35);
-      if (lookahead == '3') ADVANCE(36);
-      if (lookahead == '6') ADVANCE(37);
-      if (lookahead == '8') ADVANCE(38);
-      if (lookahead == 'r') ADVANCE(39);
-      if (lookahead == 's') ADVANCE(40);
-      if (lookahead == 'u') ADVANCE(41);
+      if (lookahead == 's') ADVANCE(38);
       END_STATE();
     case 12:
-      if (lookahead == 's') ADVANCE(42);
+      if (lookahead == 'u') ADVANCE(39);
       END_STATE();
     case 13:
-      if (lookahead == 'u') ADVANCE(43);
+      if (lookahead == 'r') ADVANCE(40);
       END_STATE();
     case 14:
-      if (lookahead == 'r') ADVANCE(44);
+      if (lookahead == 't') ADVANCE(41);
       END_STATE();
     case 15:
-      if (lookahead == 't') ADVANCE(45);
+      if (lookahead == 'c') ADVANCE(42);
       END_STATE();
     case 16:
-      if (lookahead == 'c') ADVANCE(46);
+      if (lookahead == 'r') ADVANCE(43);
       END_STATE();
     case 17:
-      if (lookahead == 'r') ADVANCE(47);
+      if (lookahead == 'a') ADVANCE(44);
       END_STATE();
     case 18:
-      if (lookahead == 'a') ADVANCE(48);
+      if (lookahead == '2') ADVANCE(45);
       END_STATE();
     case 19:
-      if (lookahead == '2') ADVANCE(49);
+      if (lookahead == '4') ADVANCE(46);
       END_STATE();
     case 20:
-      if (lookahead == '4') ADVANCE(50);
+      if (lookahead == 's') ADVANCE(47);
       END_STATE();
     case 21:
-      if (lookahead == 'l') ADVANCE(51);
+      if (lookahead == '6') ADVANCE(48);
       END_STATE();
     case 22:
-      if (lookahead == 's') ADVANCE(52);
+      if (lookahead == '2') ADVANCE(49);
       END_STATE();
     case 23:
-      if (lookahead == '6') ADVANCE(53);
+      if (lookahead == '4') ADVANCE(50);
       END_STATE();
     case 24:
-      if (lookahead == '2') ADVANCE(54);
-      END_STATE();
-    case 25:
-      if (lookahead == '4') ADVANCE(55);
-      END_STATE();
-    case 26:
       ACCEPT_TOKEN(anon_sym_i8);
       END_STATE();
+    case 25:
+      if (lookahead == 'n') ADVANCE(51);
+      END_STATE();
+    case 26:
+      if (lookahead == 'v') ADVANCE(52);
+      END_STATE();
     case 27:
-      if (lookahead == 'n') ADVANCE(56);
+      if (lookahead == 'i') ADVANCE(53);
+      if (lookahead == 'l') ADVANCE(54);
       END_STATE();
     case 28:
-      if (lookahead == 'v') ADVANCE(57);
+      if (lookahead == 'i') ADVANCE(55);
       END_STATE();
     case 29:
-      if (lookahead == 'i') ADVANCE(58);
-      if (lookahead == 'l') ADVANCE(59);
+      if (lookahead == 'g') ADVANCE(56);
       END_STATE();
     case 30:
-      if (lookahead == 'i') ADVANCE(60);
+      if (lookahead == 'm') ADVANCE(57);
       END_STATE();
     case 31:
-      if (lookahead == 'l') ADVANCE(61);
+      if (lookahead == '6') ADVANCE(58);
       END_STATE();
     case 32:
-      if (lookahead == 'g') ADVANCE(62);
+      if (lookahead == '2') ADVANCE(59);
       END_STATE();
     case 33:
-      if (lookahead == 'm') ADVANCE(63);
+      if (lookahead == '4') ADVANCE(60);
       END_STATE();
     case 34:
-      if (lookahead == 'u') ADVANCE(64);
-      END_STATE();
-    case 35:
-      if (lookahead == '6') ADVANCE(65);
-      END_STATE();
-    case 36:
-      if (lookahead == '2') ADVANCE(66);
-      END_STATE();
-    case 37:
-      if (lookahead == '4') ADVANCE(67);
-      END_STATE();
-    case 38:
       ACCEPT_TOKEN(anon_sym_u8);
       END_STATE();
+    case 35:
+      if (lookahead == 'l') ADVANCE(61);
+      END_STATE();
+    case 36:
+      if (lookahead == 'i') ADVANCE(62);
+      END_STATE();
+    case 37:
+      if (lookahead == 'i') ADVANCE(63);
+      END_STATE();
+    case 38:
+      if (lookahead == 'e') ADVANCE(64);
+      END_STATE();
     case 39:
-      if (lookahead == 'l') ADVANCE(68);
+      if (lookahead == 'n') ADVANCE(65);
       END_STATE();
     case 40:
-      if (lookahead == 'i') ADVANCE(69);
+      if (lookahead == 'r') ADVANCE(66);
       END_STATE();
     case 41:
-      if (lookahead == 'i') ADVANCE(70);
+      if (lookahead == 'e') ADVANCE(67);
       END_STATE();
     case 42:
-      if (lookahead == 'e') ADVANCE(71);
+      if (lookahead == 'i') ADVANCE(68);
       END_STATE();
     case 43:
-      if (lookahead == 'n') ADVANCE(72);
+      if (lookahead == 'a') ADVANCE(69);
       END_STATE();
     case 44:
-      if (lookahead == 'r') ADVANCE(73);
+      if (lookahead == 'i') ADVANCE(70);
       END_STATE();
     case 45:
-      if (lookahead == 'e') ADVANCE(74);
-      END_STATE();
-    case 46:
-      if (lookahead == 'i') ADVANCE(75);
-      END_STATE();
-    case 47:
-      if (lookahead == 'a') ADVANCE(76);
-      END_STATE();
-    case 48:
-      if (lookahead == 'i') ADVANCE(77);
-      END_STATE();
-    case 49:
       ACCEPT_TOKEN(anon_sym_f32);
       END_STATE();
-    case 50:
+    case 46:
       ACCEPT_TOKEN(anon_sym_f64);
       END_STATE();
-    case 51:
-      if (lookahead == 's') ADVANCE(78);
+    case 47:
+      if (lookahead == 't') ADVANCE(71);
       END_STATE();
-    case 52:
-      if (lookahead == 't') ADVANCE(79);
-      END_STATE();
-    case 53:
+    case 48:
       ACCEPT_TOKEN(anon_sym_i16);
       END_STATE();
-    case 54:
+    case 49:
       ACCEPT_TOKEN(anon_sym_i32);
       END_STATE();
-    case 55:
+    case 50:
       ACCEPT_TOKEN(anon_sym_i64);
       END_STATE();
-    case 56:
-      if (lookahead == '-') ADVANCE(80);
+    case 51:
+      if (lookahead == '-') ADVANCE(72);
       END_STATE();
-    case 57:
-      if (lookahead == '4') ADVANCE(81);
-      if (lookahead == '6') ADVANCE(82);
+    case 52:
+      if (lookahead == '4') ADVANCE(73);
+      if (lookahead == '6') ADVANCE(74);
       END_STATE();
-    case 58:
-      if (lookahead == '-') ADVANCE(83);
+    case 53:
+      if (lookahead == '-') ADVANCE(75);
       END_STATE();
-    case 59:
+    case 54:
       ACCEPT_TOKEN(anon_sym_irl);
       END_STATE();
-    case 60:
-      if (lookahead == 'z') ADVANCE(84);
+    case 55:
+      if (lookahead == 'z') ADVANCE(76);
       END_STATE();
-    case 61:
-      if (lookahead == 'l') ADVANCE(85);
+    case 56:
+      if (lookahead == 'e') ADVANCE(77);
       END_STATE();
-    case 62:
-      if (lookahead == 'e') ADVANCE(86);
+    case 57:
+      if (lookahead == 'e') ADVANCE(78);
       END_STATE();
-    case 63:
-      if (lookahead == 'e') ADVANCE(87);
-      END_STATE();
-    case 64:
-      if (lookahead == 'e') ADVANCE(88);
-      END_STATE();
-    case 65:
+    case 58:
       ACCEPT_TOKEN(anon_sym_u16);
       END_STATE();
-    case 66:
+    case 59:
       ACCEPT_TOKEN(anon_sym_u32);
       END_STATE();
-    case 67:
+    case 60:
       ACCEPT_TOKEN(anon_sym_u64);
       END_STATE();
-    case 68:
+    case 61:
       ACCEPT_TOKEN(anon_sym_url);
-      if (lookahead == '-') ADVANCE(89);
+      if (lookahead == '-') ADVANCE(79);
+      END_STATE();
+    case 62:
+      if (lookahead == 'z') ADVANCE(80);
+      END_STATE();
+    case 63:
+      if (lookahead == 'd') ADVANCE(81);
+      END_STATE();
+    case 64:
+      if (lookahead == '6') ADVANCE(82);
+      END_STATE();
+    case 65:
+      if (lookahead == 't') ADVANCE(83);
+      END_STATE();
+    case 66:
+      if (lookahead == 'e') ADVANCE(84);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(anon_sym_date);
+      if (lookahead == '-') ADVANCE(85);
+      END_STATE();
+    case 68:
+      if (lookahead == 'm') ADVANCE(86);
       END_STATE();
     case 69:
-      if (lookahead == 'z') ADVANCE(90);
+      if (lookahead == 't') ADVANCE(87);
       END_STATE();
     case 70:
-      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == 'l') ADVANCE(88);
       END_STATE();
     case 71:
-      if (lookahead == '6') ADVANCE(92);
+      if (lookahead == 'n') ADVANCE(89);
       END_STATE();
     case 72:
-      if (lookahead == 't') ADVANCE(93);
+      if (lookahead == 'e') ADVANCE(90);
+      if (lookahead == 'h') ADVANCE(91);
       END_STATE();
     case 73:
-      if (lookahead == 'e') ADVANCE(94);
-      END_STATE();
-    case 74:
-      ACCEPT_TOKEN(anon_sym_date);
-      if (lookahead == '-') ADVANCE(95);
-      END_STATE();
-    case 75:
-      if (lookahead == 'm') ADVANCE(96);
-      END_STATE();
-    case 76:
-      if (lookahead == 't') ADVANCE(97);
-      END_STATE();
-    case 77:
-      if (lookahead == 'l') ADVANCE(98);
-      END_STATE();
-    case 78:
-      if (lookahead == 'e') ADVANCE(99);
-      END_STATE();
-    case 79:
-      if (lookahead == 'n') ADVANCE(100);
-      END_STATE();
-    case 80:
-      if (lookahead == 'e') ADVANCE(101);
-      if (lookahead == 'h') ADVANCE(102);
-      END_STATE();
-    case 81:
       ACCEPT_TOKEN(anon_sym_ipv4);
       END_STATE();
-    case 82:
+    case 74:
       ACCEPT_TOKEN(anon_sym_ipv6);
       END_STATE();
-    case 83:
-      if (lookahead == 'r') ADVANCE(103);
+    case 75:
+      if (lookahead == 'r') ADVANCE(92);
       END_STATE();
-    case 84:
-      if (lookahead == 'e') ADVANCE(104);
+    case 76:
+      if (lookahead == 'e') ADVANCE(93);
       END_STATE();
-    case 85:
-      ACCEPT_TOKEN(anon_sym_null);
+    case 77:
+      if (lookahead == 'x') ADVANCE(94);
       END_STATE();
-    case 86:
-      if (lookahead == 'x') ADVANCE(105);
-      END_STATE();
-    case 87:
+    case 78:
       ACCEPT_TOKEN(anon_sym_time);
       END_STATE();
-    case 88:
-      ACCEPT_TOKEN(anon_sym_true);
+    case 79:
+      if (lookahead == 'r') ADVANCE(95);
+      if (lookahead == 't') ADVANCE(96);
       END_STATE();
-    case 89:
-      if (lookahead == 'r') ADVANCE(106);
-      if (lookahead == 't') ADVANCE(107);
+    case 80:
+      if (lookahead == 'e') ADVANCE(97);
       END_STATE();
-    case 90:
-      if (lookahead == 'e') ADVANCE(108);
-      END_STATE();
-    case 91:
+    case 81:
       ACCEPT_TOKEN(anon_sym_uuid);
       END_STATE();
-    case 92:
-      if (lookahead == '4') ADVANCE(109);
+    case 82:
+      if (lookahead == '4') ADVANCE(98);
       END_STATE();
-    case 93:
-      if (lookahead == 'r') ADVANCE(110);
+    case 83:
+      if (lookahead == 'r') ADVANCE(99);
       END_STATE();
-    case 94:
-      if (lookahead == 'n') ADVANCE(111);
+    case 84:
+      if (lookahead == 'n') ADVANCE(100);
       END_STATE();
-    case 95:
-      if (lookahead == 't') ADVANCE(112);
+    case 85:
+      if (lookahead == 't') ADVANCE(101);
       END_STATE();
-    case 96:
-      if (lookahead == 'a') ADVANCE(113);
+    case 86:
+      if (lookahead == 'a') ADVANCE(102);
       END_STATE();
-    case 97:
-      if (lookahead == 'i') ADVANCE(114);
+    case 87:
+      if (lookahead == 'i') ADVANCE(103);
       END_STATE();
-    case 98:
+    case 88:
       ACCEPT_TOKEN(anon_sym_email);
       END_STATE();
-    case 99:
-      ACCEPT_TOKEN(anon_sym_false);
+    case 89:
+      if (lookahead == 'a') ADVANCE(104);
       END_STATE();
-    case 100:
-      if (lookahead == 'a') ADVANCE(115);
+    case 90:
+      if (lookahead == 'm') ADVANCE(105);
       END_STATE();
-    case 101:
-      if (lookahead == 'm') ADVANCE(116);
+    case 91:
+      if (lookahead == 'o') ADVANCE(106);
       END_STATE();
-    case 102:
-      if (lookahead == 'o') ADVANCE(117);
+    case 92:
+      if (lookahead == 'e') ADVANCE(107);
       END_STATE();
-    case 103:
-      if (lookahead == 'e') ADVANCE(118);
-      END_STATE();
-    case 104:
+    case 93:
       ACCEPT_TOKEN(anon_sym_isize);
       END_STATE();
-    case 105:
+    case 94:
       ACCEPT_TOKEN(anon_sym_regex);
       END_STATE();
-    case 106:
-      if (lookahead == 'e') ADVANCE(119);
+    case 95:
+      if (lookahead == 'e') ADVANCE(108);
       END_STATE();
-    case 107:
-      if (lookahead == 'e') ADVANCE(120);
+    case 96:
+      if (lookahead == 'e') ADVANCE(109);
       END_STATE();
-    case 108:
+    case 97:
       ACCEPT_TOKEN(anon_sym_usize);
       END_STATE();
-    case 109:
+    case 98:
       ACCEPT_TOKEN(anon_sym_base64);
       END_STATE();
+    case 99:
+      if (lookahead == 'y') ADVANCE(110);
+      END_STATE();
+    case 100:
+      if (lookahead == 'c') ADVANCE(111);
+      END_STATE();
+    case 101:
+      if (lookahead == 'i') ADVANCE(112);
+      END_STATE();
+    case 102:
+      if (lookahead == 'l') ADVANCE(113);
+      END_STATE();
+    case 103:
+      if (lookahead == 'o') ADVANCE(114);
+      END_STATE();
+    case 104:
+      if (lookahead == 'm') ADVANCE(115);
+      END_STATE();
+    case 105:
+      if (lookahead == 'a') ADVANCE(116);
+      END_STATE();
+    case 106:
+      if (lookahead == 's') ADVANCE(117);
+      END_STATE();
+    case 107:
+      if (lookahead == 'f') ADVANCE(118);
+      END_STATE();
+    case 108:
+      if (lookahead == 'f') ADVANCE(119);
+      END_STATE();
+    case 109:
+      if (lookahead == 'm') ADVANCE(120);
+      END_STATE();
     case 110:
-      if (lookahead == 'y') ADVANCE(121);
+      if (lookahead == '-') ADVANCE(121);
       END_STATE();
     case 111:
-      if (lookahead == 'c') ADVANCE(122);
+      if (lookahead == 'y') ADVANCE(122);
       END_STATE();
     case 112:
-      if (lookahead == 'i') ADVANCE(123);
+      if (lookahead == 'm') ADVANCE(123);
       END_STATE();
     case 113:
-      if (lookahead == 'l') ADVANCE(124);
+      ACCEPT_TOKEN(anon_sym_decimal);
+      if (lookahead == '1') ADVANCE(124);
+      if (lookahead == '6') ADVANCE(125);
       END_STATE();
     case 114:
-      if (lookahead == 'o') ADVANCE(125);
+      if (lookahead == 'n') ADVANCE(126);
       END_STATE();
     case 115:
-      if (lookahead == 'm') ADVANCE(126);
+      if (lookahead == 'e') ADVANCE(127);
       END_STATE();
     case 116:
-      if (lookahead == 'a') ADVANCE(127);
+      if (lookahead == 'i') ADVANCE(128);
       END_STATE();
     case 117:
-      if (lookahead == 's') ADVANCE(128);
+      if (lookahead == 't') ADVANCE(129);
       END_STATE();
     case 118:
-      if (lookahead == 'f') ADVANCE(129);
+      if (lookahead == 'e') ADVANCE(130);
       END_STATE();
     case 119:
-      if (lookahead == 'f') ADVANCE(130);
+      if (lookahead == 'e') ADVANCE(131);
       END_STATE();
     case 120:
-      if (lookahead == 'm') ADVANCE(131);
+      if (lookahead == 'p') ADVANCE(132);
       END_STATE();
     case 121:
-      if (lookahead == '-') ADVANCE(132);
+      if (lookahead == '2') ADVANCE(133);
+      if (lookahead == '3') ADVANCE(134);
+      if (lookahead == 's') ADVANCE(135);
       END_STATE();
     case 122:
-      if (lookahead == 'y') ADVANCE(133);
-      END_STATE();
-    case 123:
-      if (lookahead == 'm') ADVANCE(134);
-      END_STATE();
-    case 124:
-      ACCEPT_TOKEN(anon_sym_decimal);
-      if (lookahead == '1') ADVANCE(135);
-      if (lookahead == '6') ADVANCE(136);
-      END_STATE();
-    case 125:
-      if (lookahead == 'n') ADVANCE(137);
-      END_STATE();
-    case 126:
-      if (lookahead == 'e') ADVANCE(138);
-      END_STATE();
-    case 127:
-      if (lookahead == 'i') ADVANCE(139);
-      END_STATE();
-    case 128:
-      if (lookahead == 't') ADVANCE(140);
-      END_STATE();
-    case 129:
-      if (lookahead == 'e') ADVANCE(141);
-      END_STATE();
-    case 130:
-      if (lookahead == 'e') ADVANCE(142);
-      END_STATE();
-    case 131:
-      if (lookahead == 'p') ADVANCE(143);
-      END_STATE();
-    case 132:
-      if (lookahead == '2') ADVANCE(144);
-      if (lookahead == '3') ADVANCE(145);
-      if (lookahead == 's') ADVANCE(146);
-      END_STATE();
-    case 133:
       ACCEPT_TOKEN(anon_sym_currency);
       END_STATE();
-    case 134:
-      if (lookahead == 'e') ADVANCE(147);
+    case 123:
+      if (lookahead == 'e') ADVANCE(136);
       END_STATE();
-    case 135:
-      if (lookahead == '2') ADVANCE(148);
+    case 124:
+      if (lookahead == '2') ADVANCE(137);
       END_STATE();
-    case 136:
-      if (lookahead == '4') ADVANCE(149);
+    case 125:
+      if (lookahead == '4') ADVANCE(138);
       END_STATE();
-    case 137:
+    case 126:
       ACCEPT_TOKEN(anon_sym_duration);
       END_STATE();
-    case 138:
+    case 127:
       ACCEPT_TOKEN(anon_sym_hostname);
       END_STATE();
-    case 139:
-      if (lookahead == 'l') ADVANCE(150);
+    case 128:
+      if (lookahead == 'l') ADVANCE(139);
       END_STATE();
-    case 140:
-      if (lookahead == 'n') ADVANCE(151);
+    case 129:
+      if (lookahead == 'n') ADVANCE(140);
       END_STATE();
-    case 141:
-      if (lookahead == 'r') ADVANCE(152);
+    case 130:
+      if (lookahead == 'r') ADVANCE(141);
       END_STATE();
-    case 142:
-      if (lookahead == 'r') ADVANCE(153);
+    case 131:
+      if (lookahead == 'r') ADVANCE(142);
       END_STATE();
-    case 143:
-      if (lookahead == 'l') ADVANCE(154);
+    case 132:
+      if (lookahead == 'l') ADVANCE(143);
       END_STATE();
-    case 144:
+    case 133:
       ACCEPT_TOKEN(anon_sym_country_DASH2);
       END_STATE();
-    case 145:
+    case 134:
       ACCEPT_TOKEN(anon_sym_country_DASH3);
       END_STATE();
-    case 146:
-      if (lookahead == 'u') ADVANCE(155);
+    case 135:
+      if (lookahead == 'u') ADVANCE(144);
       END_STATE();
-    case 147:
+    case 136:
       ACCEPT_TOKEN(anon_sym_date_DASHtime);
       END_STATE();
-    case 148:
-      if (lookahead == '8') ADVANCE(156);
+    case 137:
+      if (lookahead == '8') ADVANCE(145);
       END_STATE();
-    case 149:
+    case 138:
       ACCEPT_TOKEN(anon_sym_decimal64);
       END_STATE();
-    case 150:
+    case 139:
       ACCEPT_TOKEN(anon_sym_idn_DASHemail);
       END_STATE();
-    case 151:
-      if (lookahead == 'a') ADVANCE(157);
+    case 140:
+      if (lookahead == 'a') ADVANCE(146);
       END_STATE();
-    case 152:
-      if (lookahead == 'e') ADVANCE(158);
+    case 141:
+      if (lookahead == 'e') ADVANCE(147);
       END_STATE();
-    case 153:
-      if (lookahead == 'e') ADVANCE(159);
+    case 142:
+      if (lookahead == 'e') ADVANCE(148);
       END_STATE();
-    case 154:
-      if (lookahead == 'a') ADVANCE(160);
+    case 143:
+      if (lookahead == 'a') ADVANCE(149);
       END_STATE();
-    case 155:
-      if (lookahead == 'b') ADVANCE(161);
+    case 144:
+      if (lookahead == 'b') ADVANCE(150);
       END_STATE();
-    case 156:
+    case 145:
       ACCEPT_TOKEN(anon_sym_decimal128);
       END_STATE();
-    case 157:
-      if (lookahead == 'm') ADVANCE(162);
+    case 146:
+      if (lookahead == 'm') ADVANCE(151);
       END_STATE();
-    case 158:
-      if (lookahead == 'n') ADVANCE(163);
+    case 147:
+      if (lookahead == 'n') ADVANCE(152);
       END_STATE();
-    case 159:
-      if (lookahead == 'n') ADVANCE(164);
+    case 148:
+      if (lookahead == 'n') ADVANCE(153);
       END_STATE();
-    case 160:
-      if (lookahead == 't') ADVANCE(165);
+    case 149:
+      if (lookahead == 't') ADVANCE(154);
       END_STATE();
-    case 161:
-      if (lookahead == 'd') ADVANCE(166);
+    case 150:
+      if (lookahead == 'd') ADVANCE(155);
       END_STATE();
-    case 162:
-      if (lookahead == 'e') ADVANCE(167);
+    case 151:
+      if (lookahead == 'e') ADVANCE(156);
       END_STATE();
-    case 163:
-      if (lookahead == 'c') ADVANCE(168);
+    case 152:
+      if (lookahead == 'c') ADVANCE(157);
       END_STATE();
-    case 164:
-      if (lookahead == 'c') ADVANCE(169);
+    case 153:
+      if (lookahead == 'c') ADVANCE(158);
       END_STATE();
-    case 165:
-      if (lookahead == 'e') ADVANCE(170);
+    case 154:
+      if (lookahead == 'e') ADVANCE(159);
       END_STATE();
-    case 166:
-      if (lookahead == 'i') ADVANCE(171);
+    case 155:
+      if (lookahead == 'i') ADVANCE(160);
       END_STATE();
-    case 167:
+    case 156:
       ACCEPT_TOKEN(anon_sym_idn_DASHhostname);
       END_STATE();
-    case 168:
-      if (lookahead == 'e') ADVANCE(172);
+    case 157:
+      if (lookahead == 'e') ADVANCE(161);
       END_STATE();
-    case 169:
-      if (lookahead == 'e') ADVANCE(173);
+    case 158:
+      if (lookahead == 'e') ADVANCE(162);
       END_STATE();
-    case 170:
+    case 159:
       ACCEPT_TOKEN(anon_sym_url_DASHtemplate);
       END_STATE();
-    case 171:
-      if (lookahead == 'v') ADVANCE(174);
+    case 160:
+      if (lookahead == 'v') ADVANCE(163);
       END_STATE();
-    case 172:
+    case 161:
       ACCEPT_TOKEN(anon_sym_iri_DASHreference);
       END_STATE();
-    case 173:
+    case 162:
       ACCEPT_TOKEN(anon_sym_url_DASHreference);
       END_STATE();
-    case 174:
-      if (lookahead == 'i') ADVANCE(175);
+    case 163:
+      if (lookahead == 'i') ADVANCE(164);
       END_STATE();
-    case 175:
-      if (lookahead == 's') ADVANCE(176);
+    case 164:
+      if (lookahead == 's') ADVANCE(165);
       END_STATE();
-    case 176:
-      if (lookahead == 'i') ADVANCE(177);
+    case 165:
+      if (lookahead == 'i') ADVANCE(166);
       END_STATE();
-    case 177:
-      if (lookahead == 'o') ADVANCE(178);
+    case 166:
+      if (lookahead == 'o') ADVANCE(167);
       END_STATE();
-    case 178:
-      if (lookahead == 'n') ADVANCE(179);
+    case 167:
+      if (lookahead == 'n') ADVANCE(168);
       END_STATE();
-    case 179:
+    case 168:
       ACCEPT_TOKEN(anon_sym_country_DASHsubdivision);
       END_STATE();
     default:
@@ -2865,77 +8342,77 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
   [1] = {.lex_state = 19, .external_lex_state = 2},
-  [2] = {.lex_state = 19, .external_lex_state = 1},
-  [3] = {.lex_state = 19, .external_lex_state = 1},
-  [4] = {.lex_state = 19, .external_lex_state = 1},
-  [5] = {.lex_state = 19, .external_lex_state = 1},
-  [6] = {.lex_state = 19, .external_lex_state = 1},
-  [7] = {.lex_state = 19, .external_lex_state = 1},
-  [8] = {.lex_state = 19, .external_lex_state = 1},
-  [9] = {.lex_state = 19, .external_lex_state = 2},
-  [10] = {.lex_state = 19, .external_lex_state = 2},
+  [2] = {.lex_state = 1, .external_lex_state = 1},
+  [3] = {.lex_state = 1, .external_lex_state = 1},
+  [4] = {.lex_state = 1, .external_lex_state = 1},
+  [5] = {.lex_state = 1, .external_lex_state = 1},
+  [6] = {.lex_state = 1, .external_lex_state = 1},
+  [7] = {.lex_state = 1, .external_lex_state = 1},
+  [8] = {.lex_state = 1, .external_lex_state = 1},
+  [9] = {.lex_state = 1, .external_lex_state = 1},
+  [10] = {.lex_state = 1, .external_lex_state = 1},
   [11] = {.lex_state = 19, .external_lex_state = 2},
   [12] = {.lex_state = 19, .external_lex_state = 2},
   [13] = {.lex_state = 19, .external_lex_state = 2},
   [14] = {.lex_state = 19, .external_lex_state = 2},
-  [15] = {.lex_state = 19, .external_lex_state = 1},
+  [15] = {.lex_state = 19, .external_lex_state = 2},
   [16] = {.lex_state = 19, .external_lex_state = 2},
   [17] = {.lex_state = 19, .external_lex_state = 2},
   [18] = {.lex_state = 19, .external_lex_state = 2},
   [19] = {.lex_state = 19, .external_lex_state = 2},
   [20] = {.lex_state = 19, .external_lex_state = 2},
   [21] = {.lex_state = 19, .external_lex_state = 2},
-  [22] = {.lex_state = 19, .external_lex_state = 2},
+  [22] = {.lex_state = 1, .external_lex_state = 2},
   [23] = {.lex_state = 19, .external_lex_state = 2},
   [24] = {.lex_state = 19, .external_lex_state = 2},
-  [25] = {.lex_state = 19, .external_lex_state = 2},
+  [25] = {.lex_state = 1, .external_lex_state = 2},
   [26] = {.lex_state = 19, .external_lex_state = 2},
-  [27] = {.lex_state = 19, .external_lex_state = 1},
+  [27] = {.lex_state = 1, .external_lex_state = 2},
   [28] = {.lex_state = 19, .external_lex_state = 2},
   [29] = {.lex_state = 19, .external_lex_state = 2},
-  [30] = {.lex_state = 19, .external_lex_state = 2},
-  [31] = {.lex_state = 19, .external_lex_state = 2},
-  [32] = {.lex_state = 19, .external_lex_state = 2},
-  [33] = {.lex_state = 19, .external_lex_state = 2},
-  [34] = {.lex_state = 19, .external_lex_state = 1},
-  [35] = {.lex_state = 19, .external_lex_state = 2},
-  [36] = {.lex_state = 19, .external_lex_state = 2},
-  [37] = {.lex_state = 19, .external_lex_state = 2},
-  [38] = {.lex_state = 19, .external_lex_state = 1},
-  [39] = {.lex_state = 19, .external_lex_state = 1},
-  [40] = {.lex_state = 19, .external_lex_state = 2},
-  [41] = {.lex_state = 19, .external_lex_state = 2},
-  [42] = {.lex_state = 19, .external_lex_state = 2},
-  [43] = {.lex_state = 19, .external_lex_state = 2},
-  [44] = {.lex_state = 19, .external_lex_state = 2},
-  [45] = {.lex_state = 19, .external_lex_state = 2},
-  [46] = {.lex_state = 19, .external_lex_state = 2},
-  [47] = {.lex_state = 19, .external_lex_state = 2},
-  [48] = {.lex_state = 19, .external_lex_state = 2},
-  [49] = {.lex_state = 19, .external_lex_state = 1},
+  [30] = {.lex_state = 1, .external_lex_state = 2},
+  [31] = {.lex_state = 1, .external_lex_state = 2},
+  [32] = {.lex_state = 1, .external_lex_state = 1},
+  [33] = {.lex_state = 1, .external_lex_state = 2},
+  [34] = {.lex_state = 1, .external_lex_state = 2},
+  [35] = {.lex_state = 1, .external_lex_state = 2},
+  [36] = {.lex_state = 1, .external_lex_state = 2},
+  [37] = {.lex_state = 1, .external_lex_state = 1},
+  [38] = {.lex_state = 1, .external_lex_state = 1},
+  [39] = {.lex_state = 1, .external_lex_state = 2},
+  [40] = {.lex_state = 1, .external_lex_state = 1},
+  [41] = {.lex_state = 1, .external_lex_state = 1},
+  [42] = {.lex_state = 1, .external_lex_state = 1},
+  [43] = {.lex_state = 1, .external_lex_state = 1},
+  [44] = {.lex_state = 1, .external_lex_state = 2},
+  [45] = {.lex_state = 1, .external_lex_state = 1},
+  [46] = {.lex_state = 1, .external_lex_state = 1},
+  [47] = {.lex_state = 1, .external_lex_state = 1},
+  [48] = {.lex_state = 1, .external_lex_state = 1},
+  [49] = {.lex_state = 1, .external_lex_state = 1},
   [50] = {.lex_state = 19, .external_lex_state = 2},
   [51] = {.lex_state = 19, .external_lex_state = 2},
   [52] = {.lex_state = 19, .external_lex_state = 2},
-  [53] = {.lex_state = 19, .external_lex_state = 1},
+  [53] = {.lex_state = 19, .external_lex_state = 2},
   [54] = {.lex_state = 19, .external_lex_state = 2},
   [55] = {.lex_state = 19, .external_lex_state = 2},
-  [56] = {.lex_state = 19, .external_lex_state = 1},
-  [57] = {.lex_state = 19, .external_lex_state = 1},
-  [58] = {.lex_state = 19, .external_lex_state = 1},
-  [59] = {.lex_state = 19, .external_lex_state = 1},
+  [56] = {.lex_state = 19, .external_lex_state = 2},
+  [57] = {.lex_state = 19, .external_lex_state = 2},
+  [58] = {.lex_state = 19, .external_lex_state = 2},
+  [59] = {.lex_state = 19, .external_lex_state = 2},
   [60] = {.lex_state = 19, .external_lex_state = 2},
-  [61] = {.lex_state = 19, .external_lex_state = 1},
-  [62] = {.lex_state = 19, .external_lex_state = 3},
-  [63] = {.lex_state = 19, .external_lex_state = 3},
-  [64] = {.lex_state = 19, .external_lex_state = 3},
-  [65] = {.lex_state = 19, .external_lex_state = 3},
-  [66] = {.lex_state = 19, .external_lex_state = 3},
+  [61] = {.lex_state = 19, .external_lex_state = 2},
+  [62] = {.lex_state = 19, .external_lex_state = 2},
+  [63] = {.lex_state = 19, .external_lex_state = 2},
+  [64] = {.lex_state = 19, .external_lex_state = 2},
+  [65] = {.lex_state = 19, .external_lex_state = 2},
+  [66] = {.lex_state = 19, .external_lex_state = 2},
   [67] = {.lex_state = 19, .external_lex_state = 2},
-  [68] = {.lex_state = 19, .external_lex_state = 3},
-  [69] = {.lex_state = 19, .external_lex_state = 3},
-  [70] = {.lex_state = 19, .external_lex_state = 3},
-  [71] = {.lex_state = 19, .external_lex_state = 3},
-  [72] = {.lex_state = 19, .external_lex_state = 3},
+  [68] = {.lex_state = 19, .external_lex_state = 2},
+  [69] = {.lex_state = 19, .external_lex_state = 2},
+  [70] = {.lex_state = 19, .external_lex_state = 2},
+  [71] = {.lex_state = 19, .external_lex_state = 2},
+  [72] = {.lex_state = 19, .external_lex_state = 2},
   [73] = {.lex_state = 19, .external_lex_state = 2},
   [74] = {.lex_state = 19, .external_lex_state = 2},
   [75] = {.lex_state = 19, .external_lex_state = 2},
@@ -2943,16 +8420,16 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [77] = {.lex_state = 19, .external_lex_state = 2},
   [78] = {.lex_state = 19, .external_lex_state = 2},
   [79] = {.lex_state = 19, .external_lex_state = 2},
-  [80] = {.lex_state = 19, .external_lex_state = 3},
-  [81] = {.lex_state = 3, .external_lex_state = 3},
-  [82] = {.lex_state = 19, .external_lex_state = 3},
-  [83] = {.lex_state = 19, .external_lex_state = 3},
-  [84] = {.lex_state = 19, .external_lex_state = 3},
-  [85] = {.lex_state = 19, .external_lex_state = 3},
-  [86] = {.lex_state = 19, .external_lex_state = 3},
-  [87] = {.lex_state = 19, .external_lex_state = 3},
-  [88] = {.lex_state = 19, .external_lex_state = 3},
-  [89] = {.lex_state = 19, .external_lex_state = 3},
+  [80] = {.lex_state = 19, .external_lex_state = 2},
+  [81] = {.lex_state = 19, .external_lex_state = 2},
+  [82] = {.lex_state = 19, .external_lex_state = 2},
+  [83] = {.lex_state = 1, .external_lex_state = 2},
+  [84] = {.lex_state = 1, .external_lex_state = 2},
+  [85] = {.lex_state = 1, .external_lex_state = 2},
+  [86] = {.lex_state = 1, .external_lex_state = 2},
+  [87] = {.lex_state = 1, .external_lex_state = 2},
+  [88] = {.lex_state = 1, .external_lex_state = 2},
+  [89] = {.lex_state = 1, .external_lex_state = 2},
   [90] = {.lex_state = 19, .external_lex_state = 3},
   [91] = {.lex_state = 19, .external_lex_state = 3},
   [92] = {.lex_state = 19, .external_lex_state = 3},
@@ -2962,211 +8439,311 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [96] = {.lex_state = 19, .external_lex_state = 3},
   [97] = {.lex_state = 19, .external_lex_state = 3},
   [98] = {.lex_state = 19, .external_lex_state = 3},
-  [99] = {.lex_state = 3, .external_lex_state = 3},
-  [100] = {.lex_state = 19, .external_lex_state = 2},
+  [99] = {.lex_state = 19, .external_lex_state = 2},
+  [100] = {.lex_state = 19, .external_lex_state = 3},
   [101] = {.lex_state = 19, .external_lex_state = 3},
   [102] = {.lex_state = 19, .external_lex_state = 3},
   [103] = {.lex_state = 19, .external_lex_state = 3},
   [104] = {.lex_state = 19, .external_lex_state = 3},
-  [105] = {.lex_state = 19, .external_lex_state = 3},
-  [106] = {.lex_state = 19, .external_lex_state = 3},
-  [107] = {.lex_state = 19, .external_lex_state = 3},
-  [108] = {.lex_state = 19, .external_lex_state = 3},
-  [109] = {.lex_state = 19, .external_lex_state = 3},
-  [110] = {.lex_state = 19, .external_lex_state = 3},
-  [111] = {.lex_state = 19, .external_lex_state = 3},
-  [112] = {.lex_state = 19, .external_lex_state = 3},
-  [113] = {.lex_state = 19, .external_lex_state = 3},
+  [105] = {.lex_state = 1, .external_lex_state = 2},
+  [106] = {.lex_state = 19, .external_lex_state = 2},
+  [107] = {.lex_state = 1, .external_lex_state = 2},
+  [108] = {.lex_state = 1, .external_lex_state = 2},
+  [109] = {.lex_state = 1, .external_lex_state = 2},
+  [110] = {.lex_state = 19, .external_lex_state = 2},
+  [111] = {.lex_state = 1, .external_lex_state = 2},
+  [112] = {.lex_state = 19, .external_lex_state = 2},
+  [113] = {.lex_state = 19, .external_lex_state = 2},
   [114] = {.lex_state = 19, .external_lex_state = 3},
   [115] = {.lex_state = 19, .external_lex_state = 3},
   [116] = {.lex_state = 19, .external_lex_state = 3},
   [117] = {.lex_state = 19, .external_lex_state = 3},
   [118] = {.lex_state = 19, .external_lex_state = 3},
-  [119] = {.lex_state = 3, .external_lex_state = 3},
+  [119] = {.lex_state = 19, .external_lex_state = 3},
   [120] = {.lex_state = 19, .external_lex_state = 3},
-  [121] = {.lex_state = 19, .external_lex_state = 2},
-  [122] = {.lex_state = 19, .external_lex_state = 2},
-  [123] = {.lex_state = 19, .external_lex_state = 2},
-  [124] = {.lex_state = 19, .external_lex_state = 2},
-  [125] = {.lex_state = 19, .external_lex_state = 2},
-  [126] = {.lex_state = 19, .external_lex_state = 2},
-  [127] = {.lex_state = 19, .external_lex_state = 2},
-  [128] = {.lex_state = 19, .external_lex_state = 2},
-  [129] = {.lex_state = 19, .external_lex_state = 2},
-  [130] = {.lex_state = 4, .external_lex_state = 3},
-  [131] = {.lex_state = 19, .external_lex_state = 2},
-  [132] = {.lex_state = 19, .external_lex_state = 2},
-  [133] = {.lex_state = 19, .external_lex_state = 2},
-  [134] = {.lex_state = 19, .external_lex_state = 2},
-  [135] = {.lex_state = 3, .external_lex_state = 3},
-  [136] = {.lex_state = 19, .external_lex_state = 2},
-  [137] = {.lex_state = 19, .external_lex_state = 2},
-  [138] = {.lex_state = 19, .external_lex_state = 2},
-  [139] = {.lex_state = 19, .external_lex_state = 2},
-  [140] = {.lex_state = 19, .external_lex_state = 2},
-  [141] = {.lex_state = 19, .external_lex_state = 2},
-  [142] = {.lex_state = 19, .external_lex_state = 2},
-  [143] = {.lex_state = 19, .external_lex_state = 2},
-  [144] = {.lex_state = 19, .external_lex_state = 2},
-  [145] = {.lex_state = 19, .external_lex_state = 2},
-  [146] = {.lex_state = 19, .external_lex_state = 2},
-  [147] = {.lex_state = 4, .external_lex_state = 3},
-  [148] = {.lex_state = 19, .external_lex_state = 2},
-  [149] = {.lex_state = 19, .external_lex_state = 2},
-  [150] = {.lex_state = 19, .external_lex_state = 2},
-  [151] = {.lex_state = 19, .external_lex_state = 2},
-  [152] = {.lex_state = 19, .external_lex_state = 2},
-  [153] = {.lex_state = 19, .external_lex_state = 2},
-  [154] = {.lex_state = 3, .external_lex_state = 3},
-  [155] = {.lex_state = 19, .external_lex_state = 2},
-  [156] = {.lex_state = 19, .external_lex_state = 2},
-  [157] = {.lex_state = 19, .external_lex_state = 2},
-  [158] = {.lex_state = 19, .external_lex_state = 2},
-  [159] = {.lex_state = 19, .external_lex_state = 2},
-  [160] = {.lex_state = 19, .external_lex_state = 2},
-  [161] = {.lex_state = 19, .external_lex_state = 2},
+  [121] = {.lex_state = 19, .external_lex_state = 3},
+  [122] = {.lex_state = 19, .external_lex_state = 3},
+  [123] = {.lex_state = 19, .external_lex_state = 3},
+  [124] = {.lex_state = 19, .external_lex_state = 3},
+  [125] = {.lex_state = 19, .external_lex_state = 3},
+  [126] = {.lex_state = 19, .external_lex_state = 3},
+  [127] = {.lex_state = 19, .external_lex_state = 3},
+  [128] = {.lex_state = 19, .external_lex_state = 3},
+  [129] = {.lex_state = 4, .external_lex_state = 3},
+  [130] = {.lex_state = 19, .external_lex_state = 3},
+  [131] = {.lex_state = 19, .external_lex_state = 3},
+  [132] = {.lex_state = 19, .external_lex_state = 3},
+  [133] = {.lex_state = 19, .external_lex_state = 3},
+  [134] = {.lex_state = 19, .external_lex_state = 3},
+  [135] = {.lex_state = 19, .external_lex_state = 3},
+  [136] = {.lex_state = 19, .external_lex_state = 3},
+  [137] = {.lex_state = 4, .external_lex_state = 3},
+  [138] = {.lex_state = 19, .external_lex_state = 3},
+  [139] = {.lex_state = 19, .external_lex_state = 3},
+  [140] = {.lex_state = 19, .external_lex_state = 3},
+  [141] = {.lex_state = 19, .external_lex_state = 3},
+  [142] = {.lex_state = 19, .external_lex_state = 3},
+  [143] = {.lex_state = 19, .external_lex_state = 3},
+  [144] = {.lex_state = 19, .external_lex_state = 3},
+  [145] = {.lex_state = 19, .external_lex_state = 3},
+  [146] = {.lex_state = 19, .external_lex_state = 3},
+  [147] = {.lex_state = 19, .external_lex_state = 3},
+  [148] = {.lex_state = 19, .external_lex_state = 3},
+  [149] = {.lex_state = 19, .external_lex_state = 3},
+  [150] = {.lex_state = 19, .external_lex_state = 3},
+  [151] = {.lex_state = 19, .external_lex_state = 3},
+  [152] = {.lex_state = 19, .external_lex_state = 3},
+  [153] = {.lex_state = 4, .external_lex_state = 3},
+  [154] = {.lex_state = 19, .external_lex_state = 3},
+  [155] = {.lex_state = 19, .external_lex_state = 3},
+  [156] = {.lex_state = 19, .external_lex_state = 3},
+  [157] = {.lex_state = 19, .external_lex_state = 3},
+  [158] = {.lex_state = 19, .external_lex_state = 3},
+  [159] = {.lex_state = 19, .external_lex_state = 3},
+  [160] = {.lex_state = 19, .external_lex_state = 3},
+  [161] = {.lex_state = 19, .external_lex_state = 3},
   [162] = {.lex_state = 19, .external_lex_state = 2},
   [163] = {.lex_state = 19, .external_lex_state = 2},
-  [164] = {.lex_state = 4, .external_lex_state = 3},
-  [165] = {.lex_state = 4, .external_lex_state = 3},
-  [166] = {.lex_state = 4, .external_lex_state = 3},
+  [164] = {.lex_state = 19, .external_lex_state = 2},
+  [165] = {.lex_state = 19, .external_lex_state = 2},
+  [166] = {.lex_state = 19, .external_lex_state = 2},
   [167] = {.lex_state = 19, .external_lex_state = 2},
   [168] = {.lex_state = 19, .external_lex_state = 2},
   [169] = {.lex_state = 19, .external_lex_state = 2},
   [170] = {.lex_state = 19, .external_lex_state = 2},
   [171] = {.lex_state = 19, .external_lex_state = 2},
-  [172] = {.lex_state = 5, .external_lex_state = 3},
-  [173] = {.lex_state = 5, .external_lex_state = 3},
-  [174] = {.lex_state = 3, .external_lex_state = 3},
-  [175] = {.lex_state = 6, .external_lex_state = 3},
-  [176] = {.lex_state = 5, .external_lex_state = 3},
-  [177] = {.lex_state = 6, .external_lex_state = 3},
-  [178] = {.lex_state = 6, .external_lex_state = 3},
+  [172] = {.lex_state = 19, .external_lex_state = 2},
+  [173] = {.lex_state = 19, .external_lex_state = 2},
+  [174] = {.lex_state = 19, .external_lex_state = 2},
+  [175] = {.lex_state = 19, .external_lex_state = 2},
+  [176] = {.lex_state = 19, .external_lex_state = 2},
+  [177] = {.lex_state = 19, .external_lex_state = 2},
+  [178] = {.lex_state = 19, .external_lex_state = 2},
   [179] = {.lex_state = 19, .external_lex_state = 2},
-  [180] = {.lex_state = 3, .external_lex_state = 3},
-  [181] = {.lex_state = 5, .external_lex_state = 3},
-  [182] = {.lex_state = 5, .external_lex_state = 3},
+  [180] = {.lex_state = 19, .external_lex_state = 2},
+  [181] = {.lex_state = 19, .external_lex_state = 2},
+  [182] = {.lex_state = 19, .external_lex_state = 2},
   [183] = {.lex_state = 19, .external_lex_state = 2},
-  [184] = {.lex_state = 6, .external_lex_state = 3},
-  [185] = {.lex_state = 6, .external_lex_state = 3},
+  [184] = {.lex_state = 19, .external_lex_state = 2},
+  [185] = {.lex_state = 19, .external_lex_state = 2},
   [186] = {.lex_state = 19, .external_lex_state = 2},
-  [187] = {.lex_state = 19, .external_lex_state = 3},
-  [188] = {.lex_state = 2, .external_lex_state = 3},
-  [189] = {.lex_state = 2, .external_lex_state = 3},
-  [190] = {.lex_state = 2, .external_lex_state = 3},
-  [191] = {.lex_state = 19, .external_lex_state = 3},
-  [192] = {.lex_state = 1, .external_lex_state = 3},
-  [193] = {.lex_state = 19, .external_lex_state = 3},
-  [194] = {.lex_state = 19, .external_lex_state = 3},
-  [195] = {.lex_state = 19, .external_lex_state = 3},
-  [196] = {.lex_state = 19, .external_lex_state = 3},
-  [197] = {.lex_state = 19, .external_lex_state = 3},
-  [198] = {.lex_state = 19, .external_lex_state = 3},
-  [199] = {.lex_state = 19, .external_lex_state = 3},
-  [200] = {.lex_state = 19, .external_lex_state = 3},
-  [201] = {.lex_state = 19, .external_lex_state = 3},
-  [202] = {.lex_state = 19, .external_lex_state = 3},
-  [203] = {.lex_state = 19, .external_lex_state = 3},
-  [204] = {.lex_state = 19, .external_lex_state = 3},
-  [205] = {.lex_state = 19, .external_lex_state = 3},
-  [206] = {.lex_state = 19, .external_lex_state = 3},
-  [207] = {.lex_state = 19, .external_lex_state = 3},
-  [208] = {.lex_state = 19, .external_lex_state = 3},
-  [209] = {.lex_state = 19, .external_lex_state = 3},
-  [210] = {.lex_state = 19, .external_lex_state = 3},
-  [211] = {.lex_state = 19, .external_lex_state = 3},
-  [212] = {.lex_state = 19, .external_lex_state = 3},
-  [213] = {.lex_state = 19, .external_lex_state = 3},
-  [214] = {.lex_state = 19, .external_lex_state = 3},
-  [215] = {.lex_state = 19, .external_lex_state = 3},
-  [216] = {.lex_state = 19, .external_lex_state = 3},
-  [217] = {.lex_state = 19, .external_lex_state = 3},
-  [218] = {.lex_state = 19, .external_lex_state = 3},
-  [219] = {.lex_state = 19, .external_lex_state = 3},
-  [220] = {.lex_state = 19, .external_lex_state = 3},
-  [221] = {.lex_state = 19, .external_lex_state = 3},
-  [222] = {.lex_state = 19, .external_lex_state = 3},
-  [223] = {.lex_state = 19, .external_lex_state = 4},
-  [224] = {.lex_state = 19, .external_lex_state = 4},
-  [225] = {.lex_state = 19, .external_lex_state = 4},
-  [226] = {.lex_state = 19, .external_lex_state = 4},
-  [227] = {.lex_state = 19, .external_lex_state = 4},
-  [228] = {.lex_state = 19, .external_lex_state = 4},
-  [229] = {.lex_state = 19, .external_lex_state = 4},
-  [230] = {.lex_state = 19, .external_lex_state = 4},
-  [231] = {.lex_state = 19, .external_lex_state = 4},
-  [232] = {.lex_state = 19, .external_lex_state = 3},
+  [187] = {.lex_state = 19, .external_lex_state = 2},
+  [188] = {.lex_state = 19, .external_lex_state = 2},
+  [189] = {.lex_state = 19, .external_lex_state = 2},
+  [190] = {.lex_state = 1, .external_lex_state = 2},
+  [191] = {.lex_state = 19, .external_lex_state = 2},
+  [192] = {.lex_state = 19, .external_lex_state = 2},
+  [193] = {.lex_state = 19, .external_lex_state = 2},
+  [194] = {.lex_state = 1, .external_lex_state = 2},
+  [195] = {.lex_state = 19, .external_lex_state = 2},
+  [196] = {.lex_state = 19, .external_lex_state = 2},
+  [197] = {.lex_state = 19, .external_lex_state = 2},
+  [198] = {.lex_state = 19, .external_lex_state = 2},
+  [199] = {.lex_state = 19, .external_lex_state = 2},
+  [200] = {.lex_state = 19, .external_lex_state = 2},
+  [201] = {.lex_state = 19, .external_lex_state = 2},
+  [202] = {.lex_state = 19, .external_lex_state = 2},
+  [203] = {.lex_state = 19, .external_lex_state = 2},
+  [204] = {.lex_state = 19, .external_lex_state = 2},
+  [205] = {.lex_state = 19, .external_lex_state = 2},
+  [206] = {.lex_state = 19, .external_lex_state = 2},
+  [207] = {.lex_state = 19, .external_lex_state = 2},
+  [208] = {.lex_state = 19, .external_lex_state = 2},
+  [209] = {.lex_state = 1, .external_lex_state = 2},
+  [210] = {.lex_state = 19, .external_lex_state = 2},
+  [211] = {.lex_state = 19, .external_lex_state = 2},
+  [212] = {.lex_state = 5, .external_lex_state = 3},
+  [213] = {.lex_state = 5, .external_lex_state = 3},
+  [214] = {.lex_state = 4, .external_lex_state = 3},
+  [215] = {.lex_state = 4, .external_lex_state = 3},
+  [216] = {.lex_state = 5, .external_lex_state = 3},
+  [217] = {.lex_state = 5, .external_lex_state = 3},
+  [218] = {.lex_state = 5, .external_lex_state = 3},
+  [219] = {.lex_state = 6, .external_lex_state = 3},
+  [220] = {.lex_state = 4, .external_lex_state = 3},
+  [221] = {.lex_state = 19, .external_lex_state = 2},
+  [222] = {.lex_state = 19, .external_lex_state = 2},
+  [223] = {.lex_state = 7, .external_lex_state = 3},
+  [224] = {.lex_state = 6, .external_lex_state = 3},
+  [225] = {.lex_state = 6, .external_lex_state = 3},
+  [226] = {.lex_state = 7, .external_lex_state = 3},
+  [227] = {.lex_state = 7, .external_lex_state = 3},
+  [228] = {.lex_state = 6, .external_lex_state = 3},
+  [229] = {.lex_state = 6, .external_lex_state = 3},
+  [230] = {.lex_state = 4, .external_lex_state = 3},
+  [231] = {.lex_state = 19, .external_lex_state = 2},
+  [232] = {.lex_state = 19, .external_lex_state = 2},
   [233] = {.lex_state = 19, .external_lex_state = 3},
-  [234] = {.lex_state = 19, .external_lex_state = 3},
-  [235] = {.lex_state = 19, .external_lex_state = 3},
-  [236] = {.lex_state = 19, .external_lex_state = 3},
-  [237] = {.lex_state = 19, .external_lex_state = 3},
-  [238] = {.lex_state = 19, .external_lex_state = 3},
-  [239] = {.lex_state = 19, .external_lex_state = 3},
-  [240] = {.lex_state = 19, .external_lex_state = 3},
+  [234] = {.lex_state = 19, .external_lex_state = 2},
+  [235] = {.lex_state = 19, .external_lex_state = 2},
+  [236] = {.lex_state = 7, .external_lex_state = 3},
+  [237] = {.lex_state = 7, .external_lex_state = 3},
+  [238] = {.lex_state = 3, .external_lex_state = 3},
+  [239] = {.lex_state = 3, .external_lex_state = 3},
+  [240] = {.lex_state = 3, .external_lex_state = 3},
   [241] = {.lex_state = 19, .external_lex_state = 3},
-  [242] = {.lex_state = 19, .external_lex_state = 3},
-  [243] = {.lex_state = 19, .external_lex_state = 3},
+  [242] = {.lex_state = 19, .external_lex_state = 4},
+  [243] = {.lex_state = 2, .external_lex_state = 3},
   [244] = {.lex_state = 19, .external_lex_state = 3},
   [245] = {.lex_state = 19, .external_lex_state = 3},
   [246] = {.lex_state = 19, .external_lex_state = 3},
   [247] = {.lex_state = 19, .external_lex_state = 3},
-  [248] = {.lex_state = 19, .external_lex_state = 2},
-  [249] = {.lex_state = 7, .external_lex_state = 3},
-  [250] = {.lex_state = 7, .external_lex_state = 3},
-  [251] = {.lex_state = 7, .external_lex_state = 3},
-  [252] = {.lex_state = 7, .external_lex_state = 3},
-  [253] = {.lex_state = 7, .external_lex_state = 3},
-  [254] = {.lex_state = 7, .external_lex_state = 3},
-  [255] = {.lex_state = 7, .external_lex_state = 3},
-  [256] = {.lex_state = 7, .external_lex_state = 3},
-  [257] = {.lex_state = 19, .external_lex_state = 2},
-  [258] = {.lex_state = 19, .external_lex_state = 2},
-  [259] = {.lex_state = 7, .external_lex_state = 3},
-  [260] = {.lex_state = 19, .external_lex_state = 2},
-  [261] = {.lex_state = 19, .external_lex_state = 4},
-  [262] = {.lex_state = 19, .external_lex_state = 4},
-  [263] = {.lex_state = 19, .external_lex_state = 4},
-  [264] = {.lex_state = 1, .external_lex_state = 4},
-  [265] = {.lex_state = 19, .external_lex_state = 4},
-  [266] = {.lex_state = 19, .external_lex_state = 4},
-  [267] = {.lex_state = 19, .external_lex_state = 4},
-  [268] = {.lex_state = 19, .external_lex_state = 4},
-  [269] = {.lex_state = 19, .external_lex_state = 4},
-  [270] = {.lex_state = 19, .external_lex_state = 4},
-  [271] = {.lex_state = 19, .external_lex_state = 4},
-  [272] = {.lex_state = 19, .external_lex_state = 4},
-  [273] = {.lex_state = 9, .external_lex_state = 4},
-  [274] = {.lex_state = 19, .external_lex_state = 4},
-  [275] = {.lex_state = 19, .external_lex_state = 4},
-  [276] = {.lex_state = 19, .external_lex_state = 4},
-  [277] = {.lex_state = 9, .external_lex_state = 4},
-  [278] = {.lex_state = 2, .external_lex_state = 4},
-  [279] = {.lex_state = 2, .external_lex_state = 4},
-  [280] = {.lex_state = 9, .external_lex_state = 4},
+  [248] = {.lex_state = 19, .external_lex_state = 3},
+  [249] = {.lex_state = 19, .external_lex_state = 3},
+  [250] = {.lex_state = 19, .external_lex_state = 3},
+  [251] = {.lex_state = 19, .external_lex_state = 3},
+  [252] = {.lex_state = 19, .external_lex_state = 3},
+  [253] = {.lex_state = 19, .external_lex_state = 3},
+  [254] = {.lex_state = 19, .external_lex_state = 3},
+  [255] = {.lex_state = 19, .external_lex_state = 3},
+  [256] = {.lex_state = 19, .external_lex_state = 3},
+  [257] = {.lex_state = 19, .external_lex_state = 3},
+  [258] = {.lex_state = 19, .external_lex_state = 3},
+  [259] = {.lex_state = 19, .external_lex_state = 3},
+  [260] = {.lex_state = 19, .external_lex_state = 3},
+  [261] = {.lex_state = 19, .external_lex_state = 3},
+  [262] = {.lex_state = 19, .external_lex_state = 3},
+  [263] = {.lex_state = 19, .external_lex_state = 3},
+  [264] = {.lex_state = 19, .external_lex_state = 3},
+  [265] = {.lex_state = 19, .external_lex_state = 3},
+  [266] = {.lex_state = 19, .external_lex_state = 3},
+  [267] = {.lex_state = 19, .external_lex_state = 3},
+  [268] = {.lex_state = 19, .external_lex_state = 3},
+  [269] = {.lex_state = 19, .external_lex_state = 3},
+  [270] = {.lex_state = 19, .external_lex_state = 3},
+  [271] = {.lex_state = 19, .external_lex_state = 3},
+  [272] = {.lex_state = 19, .external_lex_state = 3},
+  [273] = {.lex_state = 19, .external_lex_state = 3},
+  [274] = {.lex_state = 19, .external_lex_state = 3},
+  [275] = {.lex_state = 19, .external_lex_state = 3},
+  [276] = {.lex_state = 19, .external_lex_state = 3},
+  [277] = {.lex_state = 19, .external_lex_state = 3},
+  [278] = {.lex_state = 19, .external_lex_state = 4},
+  [279] = {.lex_state = 19, .external_lex_state = 4},
+  [280] = {.lex_state = 19, .external_lex_state = 4},
   [281] = {.lex_state = 19, .external_lex_state = 4},
-  [282] = {.lex_state = 9, .external_lex_state = 4},
-  [283] = {.lex_state = 9, .external_lex_state = 4},
-  [284] = {.lex_state = 2, .external_lex_state = 4},
-  [285] = {.lex_state = 9, .external_lex_state = 4},
+  [282] = {.lex_state = 19, .external_lex_state = 4},
+  [283] = {.lex_state = 19, .external_lex_state = 4},
+  [284] = {.lex_state = 19, .external_lex_state = 4},
+  [285] = {.lex_state = 19, .external_lex_state = 4},
   [286] = {.lex_state = 19, .external_lex_state = 4},
   [287] = {.lex_state = 19, .external_lex_state = 4},
-  [288] = {.lex_state = 4, .external_lex_state = 4},
-  [289] = {.lex_state = 4, .external_lex_state = 4},
-  [290] = {.lex_state = 19, .external_lex_state = 4},
-  [291] = {.lex_state = 19, .external_lex_state = 4},
-  [292] = {.lex_state = 1, .external_lex_state = 4},
-  [293] = {.lex_state = 19, .external_lex_state = 4},
-  [294] = {.lex_state = 19, .external_lex_state = 4},
-  [295] = {.lex_state = 19, .external_lex_state = 4},
-  [296] = {.lex_state = 19, .external_lex_state = 4},
-  [297] = {.lex_state = 0, .external_lex_state = 4},
-  [298] = {.lex_state = 6, .external_lex_state = 4},
-  [299] = {.lex_state = 5, .external_lex_state = 4},
-  [300] = {.lex_state = 5, .external_lex_state = 4},
-  [301] = {.lex_state = 19, .external_lex_state = 4},
-  [302] = {.lex_state = 6, .external_lex_state = 4},
-  [303] = {.lex_state = 19, .external_lex_state = 4},
+  [288] = {.lex_state = 19, .external_lex_state = 3},
+  [289] = {.lex_state = 19, .external_lex_state = 3},
+  [290] = {.lex_state = 19, .external_lex_state = 3},
+  [291] = {.lex_state = 19, .external_lex_state = 3},
+  [292] = {.lex_state = 19, .external_lex_state = 3},
+  [293] = {.lex_state = 19, .external_lex_state = 3},
+  [294] = {.lex_state = 19, .external_lex_state = 3},
+  [295] = {.lex_state = 19, .external_lex_state = 3},
+  [296] = {.lex_state = 19, .external_lex_state = 3},
+  [297] = {.lex_state = 19, .external_lex_state = 3},
+  [298] = {.lex_state = 19, .external_lex_state = 3},
+  [299] = {.lex_state = 19, .external_lex_state = 3},
+  [300] = {.lex_state = 19, .external_lex_state = 3},
+  [301] = {.lex_state = 19, .external_lex_state = 3},
+  [302] = {.lex_state = 19, .external_lex_state = 3},
+  [303] = {.lex_state = 19, .external_lex_state = 3},
+  [304] = {.lex_state = 8, .external_lex_state = 3},
+  [305] = {.lex_state = 8, .external_lex_state = 3},
+  [306] = {.lex_state = 8, .external_lex_state = 3},
+  [307] = {.lex_state = 8, .external_lex_state = 3},
+  [308] = {.lex_state = 8, .external_lex_state = 3},
+  [309] = {.lex_state = 8, .external_lex_state = 3},
+  [310] = {.lex_state = 8, .external_lex_state = 3},
+  [311] = {.lex_state = 8, .external_lex_state = 3},
+  [312] = {.lex_state = 8, .external_lex_state = 3},
+  [313] = {.lex_state = 8, .external_lex_state = 3},
+  [314] = {.lex_state = 8, .external_lex_state = 3},
+  [315] = {.lex_state = 19, .external_lex_state = 4},
+  [316] = {.lex_state = 2, .external_lex_state = 4},
+  [317] = {.lex_state = 19, .external_lex_state = 2},
+  [318] = {.lex_state = 19, .external_lex_state = 4},
+  [319] = {.lex_state = 19, .external_lex_state = 4},
+  [320] = {.lex_state = 19, .external_lex_state = 4},
+  [321] = {.lex_state = 19, .external_lex_state = 4},
+  [322] = {.lex_state = 19, .external_lex_state = 4},
+  [323] = {.lex_state = 19, .external_lex_state = 4},
+  [324] = {.lex_state = 19, .external_lex_state = 2},
+  [325] = {.lex_state = 19, .external_lex_state = 4},
+  [326] = {.lex_state = 19, .external_lex_state = 2},
+  [327] = {.lex_state = 19, .external_lex_state = 4},
+  [328] = {.lex_state = 19, .external_lex_state = 4},
+  [329] = {.lex_state = 19, .external_lex_state = 4},
+  [330] = {.lex_state = 19, .external_lex_state = 4},
+  [331] = {.lex_state = 19, .external_lex_state = 4},
+  [332] = {.lex_state = 19, .external_lex_state = 4},
+  [333] = {.lex_state = 19, .external_lex_state = 4},
+  [334] = {.lex_state = 19, .external_lex_state = 4},
+  [335] = {.lex_state = 19, .external_lex_state = 4},
+  [336] = {.lex_state = 19, .external_lex_state = 4},
+  [337] = {.lex_state = 3, .external_lex_state = 4},
+  [338] = {.lex_state = 3, .external_lex_state = 4},
+  [339] = {.lex_state = 3, .external_lex_state = 4},
+  [340] = {.lex_state = 19, .external_lex_state = 4},
+  [341] = {.lex_state = 19, .external_lex_state = 4},
+  [342] = {.lex_state = 19, .external_lex_state = 4},
+  [343] = {.lex_state = 19, .external_lex_state = 4},
+  [344] = {.lex_state = 19, .external_lex_state = 4},
+  [345] = {.lex_state = 9, .external_lex_state = 4},
+  [346] = {.lex_state = 9, .external_lex_state = 4},
+  [347] = {.lex_state = 9, .external_lex_state = 4},
+  [348] = {.lex_state = 2, .external_lex_state = 4},
+  [349] = {.lex_state = 9, .external_lex_state = 4},
+  [350] = {.lex_state = 9, .external_lex_state = 4},
+  [351] = {.lex_state = 19, .external_lex_state = 4},
+  [352] = {.lex_state = 19, .external_lex_state = 4},
+  [353] = {.lex_state = 19, .external_lex_state = 4},
+  [354] = {.lex_state = 19, .external_lex_state = 4},
+  [355] = {.lex_state = 19, .external_lex_state = 4},
+  [356] = {.lex_state = 19, .external_lex_state = 4},
+  [357] = {.lex_state = 19, .external_lex_state = 4},
+  [358] = {.lex_state = 9, .external_lex_state = 4},
+  [359] = {.lex_state = 19, .external_lex_state = 4},
+  [360] = {.lex_state = 19, .external_lex_state = 4},
+  [361] = {.lex_state = 19, .external_lex_state = 4},
+  [362] = {.lex_state = 5, .external_lex_state = 4},
+  [363] = {.lex_state = 5, .external_lex_state = 4},
+  [364] = {.lex_state = 6, .external_lex_state = 4},
+  [365] = {.lex_state = 0, .external_lex_state = 4},
+  [366] = {.lex_state = 6, .external_lex_state = 4},
+  [367] = {.lex_state = 7, .external_lex_state = 4},
+  [368] = {.lex_state = 7, .external_lex_state = 4},
+};
+
+enum {
+  ts_external_token__eof = 0,
+  ts_external_token_multi_line_comment = 1,
+  ts_external_token_multi_line_string = 2,
+  ts_external_token__raw_string = 3,
+};
+
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+  [ts_external_token__eof] = sym__eof,
+  [ts_external_token_multi_line_comment] = sym_multi_line_comment,
+  [ts_external_token_multi_line_string] = sym_multi_line_string,
+  [ts_external_token__raw_string] = sym__raw_string,
+};
+
+static const bool ts_external_scanner_states[5][EXTERNAL_TOKEN_COUNT] = {
+  [1] = {
+    [ts_external_token__eof] = true,
+    [ts_external_token_multi_line_comment] = true,
+    [ts_external_token_multi_line_string] = true,
+    [ts_external_token__raw_string] = true,
+  },
+  [2] = {
+    [ts_external_token_multi_line_comment] = true,
+    [ts_external_token_multi_line_string] = true,
+    [ts_external_token__raw_string] = true,
+  },
+  [3] = {
+    [ts_external_token__eof] = true,
+    [ts_external_token_multi_line_comment] = true,
+  },
+  [4] = {
+    [ts_external_token_multi_line_comment] = true,
+  },
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -3179,7 +8756,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__identifier_char] = ACTIONS(1),
     [sym___identifier_char_no_digit] = ACTIONS(1),
     [sym___identifier_char_no_digit_sign] = ACTIONS(1),
-    [anon_sym_null] = ACTIONS(1),
     [anon_sym_i8] = ACTIONS(1),
     [anon_sym_i16] = ACTIONS(1),
     [anon_sym_i32] = ACTIONS(1),
@@ -3233,35 +8809,36 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__octal_token1] = ACTIONS(1),
     [anon_sym_0] = ACTIONS(1),
     [anon_sym_1] = ACTIONS(1),
-    [anon_sym_true] = ACTIONS(1),
-    [anon_sym_false] = ACTIONS(1),
     [anon_sym_BSLASH] = ACTIONS(1),
     [aux_sym__newline_token2] = ACTIONS(1),
+    [aux_sym__newline_token3] = ACTIONS(1),
     [aux_sym__newline_token4] = ACTIONS(1),
     [aux_sym__newline_token5] = ACTIONS(1),
     [aux_sym__newline_token6] = ACTIONS(1),
     [aux_sym__newline_token7] = ACTIONS(1),
+    [aux_sym__newline_token8] = ACTIONS(1),
     [sym__bom] = ACTIONS(1),
     [sym__unicode_space] = ACTIONS(1),
     [aux_sym_single_line_comment_token1] = ACTIONS(1),
     [sym__eof] = ACTIONS(1),
     [sym_multi_line_comment] = ACTIONS(3),
+    [sym_multi_line_string] = ACTIONS(1),
     [sym__raw_string] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(297),
-    [sym_node] = STATE(17),
-    [sym_identifier] = STATE(71),
-    [sym__bare_identifier] = STATE(218),
-    [sym_type] = STATE(260),
-    [sym_string] = STATE(218),
-    [sym__escaped_string] = STATE(194),
-    [sym__sign] = STATE(192),
-    [sym__linespace] = STATE(45),
-    [sym__newline] = STATE(45),
-    [sym__ws] = STATE(45),
-    [sym_single_line_comment] = STATE(45),
-    [aux_sym_document_repeat1] = STATE(45),
+    [sym_document] = STATE(365),
+    [sym_node] = STATE(53),
+    [sym_identifier] = STATE(91),
+    [sym__bare_identifier] = STATE(268),
+    [sym_type] = STATE(235),
+    [sym_string] = STATE(268),
+    [sym__escaped_string] = STATE(247),
+    [sym__sign] = STATE(243),
+    [sym__linespace] = STATE(75),
+    [sym__newline] = STATE(75),
+    [sym__ws] = STATE(75),
+    [sym_single_line_comment] = STATE(75),
+    [aux_sym_document_repeat1] = STATE(75),
     [ts_builtin_sym_end] = ACTIONS(5),
     [sym__normal_bare_identifier] = ACTIONS(7),
     [anon_sym_SLASH_DASH] = ACTIONS(9),
@@ -3270,702 +8847,660 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_PLUS] = ACTIONS(15),
     [anon_sym_DASH] = ACTIONS(15),
     [aux_sym__newline_token1] = ACTIONS(17),
-    [aux_sym__newline_token2] = ACTIONS(17),
+    [aux_sym__newline_token2] = ACTIONS(19),
     [aux_sym__newline_token3] = ACTIONS(17),
     [aux_sym__newline_token4] = ACTIONS(17),
     [aux_sym__newline_token5] = ACTIONS(17),
     [aux_sym__newline_token6] = ACTIONS(17),
     [aux_sym__newline_token7] = ACTIONS(17),
+    [aux_sym__newline_token8] = ACTIONS(17),
     [sym__bom] = ACTIONS(17),
     [sym__unicode_space] = ACTIONS(17),
-    [anon_sym_SLASH_SLASH] = ACTIONS(19),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
     [sym_multi_line_comment] = ACTIONS(17),
-    [sym__raw_string] = ACTIONS(21),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [2] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(115),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(183),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(183),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(183),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(31),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(31),
+    [aux_sym__newline_token2] = ACTIONS(53),
+    [aux_sym__newline_token3] = ACTIONS(31),
+    [aux_sym__newline_token4] = ACTIONS(31),
+    [aux_sym__newline_token5] = ACTIONS(31),
+    [aux_sym__newline_token6] = ACTIONS(31),
+    [aux_sym__newline_token7] = ACTIONS(31),
+    [aux_sym__newline_token8] = ACTIONS(31),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(31),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [3] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(145),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(168),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(168),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(168),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(57),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(57),
+    [aux_sym__newline_token2] = ACTIONS(59),
+    [aux_sym__newline_token3] = ACTIONS(57),
+    [aux_sym__newline_token4] = ACTIONS(57),
+    [aux_sym__newline_token5] = ACTIONS(57),
+    [aux_sym__newline_token6] = ACTIONS(57),
+    [aux_sym__newline_token7] = ACTIONS(57),
+    [aux_sym__newline_token8] = ACTIONS(57),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(57),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [4] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(152),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(174),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(174),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(174),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(61),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(61),
+    [aux_sym__newline_token2] = ACTIONS(63),
+    [aux_sym__newline_token3] = ACTIONS(61),
+    [aux_sym__newline_token4] = ACTIONS(61),
+    [aux_sym__newline_token5] = ACTIONS(61),
+    [aux_sym__newline_token6] = ACTIONS(61),
+    [aux_sym__newline_token7] = ACTIONS(61),
+    [aux_sym__newline_token8] = ACTIONS(61),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(61),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [5] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(124),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(210),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(210),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(210),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(65),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(65),
+    [aux_sym__newline_token2] = ACTIONS(67),
+    [aux_sym__newline_token3] = ACTIONS(65),
+    [aux_sym__newline_token4] = ACTIONS(65),
+    [aux_sym__newline_token5] = ACTIONS(65),
+    [aux_sym__newline_token6] = ACTIONS(65),
+    [aux_sym__newline_token7] = ACTIONS(65),
+    [aux_sym__newline_token8] = ACTIONS(65),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(65),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [6] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(160),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(202),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(202),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(202),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(69),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(69),
+    [aux_sym__newline_token2] = ACTIONS(71),
+    [aux_sym__newline_token3] = ACTIONS(69),
+    [aux_sym__newline_token4] = ACTIONS(69),
+    [aux_sym__newline_token5] = ACTIONS(69),
+    [aux_sym__newline_token6] = ACTIONS(69),
+    [aux_sym__newline_token7] = ACTIONS(69),
+    [aux_sym__newline_token8] = ACTIONS(69),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(69),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [7] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(134),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(177),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(177),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(177),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(73),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(73),
+    [aux_sym__newline_token2] = ACTIONS(75),
+    [aux_sym__newline_token3] = ACTIONS(73),
+    [aux_sym__newline_token4] = ACTIONS(73),
+    [aux_sym__newline_token5] = ACTIONS(73),
+    [aux_sym__newline_token6] = ACTIONS(73),
+    [aux_sym__newline_token7] = ACTIONS(73),
+    [aux_sym__newline_token8] = ACTIONS(73),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(73),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [8] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(120),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(207),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(207),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(207),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(77),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(77),
+    [aux_sym__newline_token2] = ACTIONS(79),
+    [aux_sym__newline_token3] = ACTIONS(77),
+    [aux_sym__newline_token4] = ACTIONS(77),
+    [aux_sym__newline_token5] = ACTIONS(77),
+    [aux_sym__newline_token6] = ACTIONS(77),
+    [aux_sym__newline_token7] = ACTIONS(77),
+    [aux_sym__newline_token8] = ACTIONS(77),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(77),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [9] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(154),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(178),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(178),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(178),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(81),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(81),
+    [aux_sym__newline_token2] = ACTIONS(83),
+    [aux_sym__newline_token3] = ACTIONS(81),
+    [aux_sym__newline_token4] = ACTIONS(81),
+    [aux_sym__newline_token5] = ACTIONS(81),
+    [aux_sym__newline_token6] = ACTIONS(81),
+    [aux_sym__newline_token7] = ACTIONS(81),
+    [aux_sym__newline_token8] = ACTIONS(81),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(81),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
+  },
+  [10] = {
+    [sym_node_field] = STATE(253),
+    [sym__node_field_comment] = STATE(252),
+    [sym__node_field] = STATE(252),
+    [sym_node_children] = STATE(142),
+    [sym__node_space] = STATE(47),
+    [sym__node_terminator] = STATE(203),
+    [sym_identifier] = STATE(332),
+    [sym__bare_identifier] = STATE(351),
+    [sym_keyword] = STATE(274),
+    [sym_prop] = STATE(251),
+    [sym_value] = STATE(251),
+    [sym_type] = STATE(39),
+    [sym_string] = STATE(244),
+    [sym__escaped_string] = STATE(247),
+    [sym_number] = STATE(274),
+    [sym__decimal] = STATE(269),
+    [sym__integer] = STATE(215),
+    [sym__sign] = STATE(316),
+    [sym__hex] = STATE(269),
+    [sym__octal] = STATE(269),
+    [sym__binary] = STATE(269),
+    [sym_keyword_number] = STATE(269),
+    [sym_boolean] = STATE(266),
+    [sym__escline] = STATE(43),
+    [sym__newline] = STATE(203),
+    [sym__ws] = STATE(37),
+    [sym_single_line_comment] = STATE(203),
+    [aux_sym_node_repeat1] = STATE(32),
+    [aux_sym_node_repeat3] = STATE(37),
+    [sym__normal_bare_identifier] = ACTIONS(25),
+    [anon_sym_SLASH_DASH] = ACTIONS(27),
+    [anon_sym_LBRACE] = ACTIONS(29),
+    [anon_sym_SEMI] = ACTIONS(85),
+    [anon_sym_null] = ACTIONS(33),
+    [anon_sym_POUNDnull] = ACTIONS(33),
+    [anon_sym_LPAREN] = ACTIONS(35),
+    [anon_sym_DQUOTE] = ACTIONS(13),
+    [sym__digit] = ACTIONS(37),
+    [anon_sym_PLUS] = ACTIONS(39),
+    [anon_sym_DASH] = ACTIONS(39),
+    [anon_sym_0x] = ACTIONS(41),
+    [anon_sym_0o] = ACTIONS(43),
+    [anon_sym_0b] = ACTIONS(45),
+    [anon_sym_POUNDinf] = ACTIONS(47),
+    [anon_sym_POUND_DASHinf] = ACTIONS(47),
+    [anon_sym_POUNDnan] = ACTIONS(47),
+    [anon_sym_true] = ACTIONS(49),
+    [anon_sym_false] = ACTIONS(49),
+    [anon_sym_POUNDtrue] = ACTIONS(49),
+    [anon_sym_POUNDfalse] = ACTIONS(49),
+    [anon_sym_BSLASH] = ACTIONS(51),
+    [aux_sym__newline_token1] = ACTIONS(85),
+    [aux_sym__newline_token2] = ACTIONS(87),
+    [aux_sym__newline_token3] = ACTIONS(85),
+    [aux_sym__newline_token4] = ACTIONS(85),
+    [aux_sym__newline_token5] = ACTIONS(85),
+    [aux_sym__newline_token6] = ACTIONS(85),
+    [aux_sym__newline_token7] = ACTIONS(85),
+    [aux_sym__newline_token8] = ACTIONS(85),
+    [sym__bom] = ACTIONS(55),
+    [sym__unicode_space] = ACTIONS(55),
+    [anon_sym_SLASH_SLASH] = ACTIONS(21),
+    [sym__eof] = ACTIONS(85),
+    [sym_multi_line_comment] = ACTIONS(55),
+    [sym_multi_line_string] = ACTIONS(23),
+    [sym__raw_string] = ACTIONS(23),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 36,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
+  [0] = 2,
+    ACTIONS(89), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
       sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(25), 1,
+      ts_builtin_sym_end,
       anon_sym_SLASH_DASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(79), 1,
-      sym_type,
-    STATE(109), 1,
-      sym_node_children,
-    STATE(154), 1,
-      sym__integer,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
+      anon_sym_RBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(152), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-    ACTIONS(29), 9,
-      sym__eof,
-      anon_sym_SEMI,
+      anon_sym_BSLASH,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [130] = 36,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(25), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(79), 1,
-      sym_type,
-    STATE(118), 1,
-      sym_node_children,
-    STATE(154), 1,
-      sym__integer,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-    STATE(142), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-    ACTIONS(49), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [260] = 36,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
       anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
+    ACTIONS(91), 39,
       sym__normal_bare_identifier,
-    ACTIONS(25), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(79), 1,
-      sym_type,
-    STATE(95), 1,
-      sym_node_children,
-    STATE(154), 1,
-      sym__integer,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(171), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-    ACTIONS(51), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [390] = 36,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(25), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(79), 1,
-      sym_type,
-    STATE(85), 1,
-      sym_node_children,
-    STATE(154), 1,
-      sym__integer,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(141), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-    ACTIONS(53), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [520] = 36,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(25), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(79), 1,
-      sym_type,
-    STATE(90), 1,
-      sym_node_children,
-    STATE(154), 1,
-      sym__integer,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(162), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-    ACTIONS(55), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [650] = 36,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(25), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(79), 1,
-      sym_type,
-    STATE(80), 1,
-      sym_node_children,
-    STATE(154), 1,
-      sym__integer,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(148), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-    ACTIONS(57), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [780] = 36,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(25), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(79), 1,
-      sym_type,
-    STATE(108), 1,
-      sym_node_children,
-    STATE(154), 1,
-      sym__integer,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(160), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-    ACTIONS(59), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [910] = 10,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(63), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(67), 1,
-      sym__raw_string,
-    STATE(292), 1,
-      sym__sign,
-    STATE(296), 1,
-      sym__escaped_string,
-    ACTIONS(65), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(290), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(301), 2,
-      sym_identifier,
-      sym_annotation_type,
-    ACTIONS(61), 37,
       anon_sym_i8,
       anon_sym_i16,
       anon_sym_i32,
@@ -4003,963 +9538,1345 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_uuid,
       anon_sym_regex,
       anon_sym_base64,
-  [980] = 31,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(69), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(71), 1,
-      anon_sym_BSLASH,
-    STATE(74), 1,
-      aux_sym_node_repeat1,
-    STATE(79), 1,
-      sym_type,
-    STATE(125), 1,
-      sym__escline,
-    STATE(154), 1,
-      sym__integer,
-    STATE(186), 1,
-      sym__node_space,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(198), 1,
-      sym_node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(100), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(211), 2,
-      sym__node_field_comment,
-      sym__node_field,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(73), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-  [1085] = 30,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(71), 1,
-      anon_sym_BSLASH,
-    ACTIONS(75), 1,
-      anon_sym_LBRACE,
-    STATE(12), 1,
-      aux_sym_node_repeat1,
-    STATE(79), 1,
-      sym_type,
-    STATE(125), 1,
-      sym__escline,
-    STATE(154), 1,
-      sym__integer,
-    STATE(186), 1,
-      sym__node_space,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(221), 1,
-      sym__node_field,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(100), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(73), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-  [1186] = 30,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(71), 1,
-      anon_sym_BSLASH,
-    ACTIONS(77), 1,
-      anon_sym_LBRACE,
-    STATE(74), 1,
-      aux_sym_node_repeat1,
-    STATE(79), 1,
-      sym_type,
-    STATE(125), 1,
-      sym__escline,
-    STATE(154), 1,
-      sym__integer,
-    STATE(186), 1,
-      sym__node_space,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(209), 1,
-      sym__node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(100), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(73), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-  [1287] = 29,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(71), 1,
-      anon_sym_BSLASH,
-    STATE(14), 1,
-      aux_sym_node_repeat1,
-    STATE(79), 1,
-      sym_type,
-    STATE(125), 1,
-      sym__escline,
-    STATE(154), 1,
-      sym__integer,
-    STATE(186), 1,
-      sym__node_space,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(221), 1,
-      sym__node_field,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(100), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(73), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-  [1385] = 29,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(23), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(31), 1,
-      anon_sym_null,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(71), 1,
-      anon_sym_BSLASH,
-    STATE(74), 1,
-      aux_sym_node_repeat1,
-    STATE(79), 1,
-      sym_type,
-    STATE(125), 1,
-      sym__escline,
-    STATE(154), 1,
-      sym__integer,
-    STATE(186), 1,
-      sym__node_space,
-    STATE(191), 1,
-      sym_string,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(209), 1,
-      sym__node_field,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(264), 1,
-      sym__sign,
-    STATE(290), 1,
-      sym__bare_identifier,
-    STATE(295), 1,
-      sym_identifier,
-    ACTIONS(35), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(43), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(100), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(199), 2,
-      sym_keyword,
-      sym_number,
-    STATE(213), 2,
-      sym_prop,
-      sym_value,
-    ACTIONS(73), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-  [1483] = 8,
-    ACTIONS(83), 1,
-      anon_sym_BSLASH,
-    STATE(15), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(86), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(79), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(81), 20,
-      sym__eof,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      aux_sym__newline_token1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [1534] = 16,
-    ACTIONS(91), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(94), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(97), 1,
-      anon_sym_LPAREN,
-    ACTIONS(100), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(109), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(112), 1,
+  [65] = 2,
+    ACTIONS(93), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
       sym__raw_string,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(89), 2,
       ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
       anon_sym_RBRACE,
-    ACTIONS(103), 2,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(16), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(54), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(106), 10,
-      sym_multi_line_comment,
+      anon_sym_BSLASH,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [1600] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
       anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(115), 1,
-      ts_builtin_sym_end,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
+    ACTIONS(95), 39,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+      aux_sym__newline_token2,
+  [130] = 15,
+    ACTIONS(25), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(99), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(17), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(348), 1,
       sym__sign,
-    STATE(194), 1,
+    STATE(354), 1,
       sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
+    ACTIONS(101), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(29), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(43), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(117), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [1665] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
+    ACTIONS(107), 2,
+      sym_multi_line_string,
       sym__raw_string,
-    ACTIONS(119), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(329), 2,
       sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(20), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
+      sym_annotation_type,
+    STATE(351), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(51), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(121), 10,
+    ACTIONS(105), 3,
       sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
       sym__bom,
       sym__unicode_space,
-  [1730] = 16,
-    ACTIONS(7), 1,
+    ACTIONS(97), 37,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [219] = 15,
+    ACTIONS(25), 1,
       sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
+    ACTIONS(99), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(13), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(348), 1,
+      sym__sign,
+    STATE(354), 1,
+      sym__escaped_string,
+    ACTIONS(101), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(107), 2,
+      sym_multi_line_string,
       sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(323), 2,
+      sym_identifier,
+      sym_annotation_type,
+    STATE(351), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(97), 37,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [308] = 15,
+    ACTIONS(25), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(99), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(16), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(348), 1,
+      sym__sign,
+    STATE(354), 1,
+      sym__escaped_string,
+    ACTIONS(101), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(107), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(319), 2,
+      sym_identifier,
+      sym_annotation_type,
+    STATE(351), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(97), 37,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [397] = 15,
+    ACTIONS(25), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(99), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(17), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(348), 1,
+      sym__sign,
+    STATE(354), 1,
+      sym__escaped_string,
+    ACTIONS(101), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(107), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(330), 2,
+      sym_identifier,
+      sym_annotation_type,
+    STATE(351), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(97), 37,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [486] = 8,
+    ACTIONS(113), 1,
+      anon_sym_BSLASH,
+    STATE(17), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(116), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(111), 6,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(109), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [556] = 6,
     ACTIONS(123), 1,
-      ts_builtin_sym_end,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(16), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(50), 5,
-      sym__linespace,
-      sym__newline,
+      anon_sym_BSLASH,
+    STATE(24), 1,
+      sym__escline,
+    STATE(23), 2,
       sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(125), 10,
+      aux_sym_node_repeat3,
+    ACTIONS(126), 3,
       sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
       sym__bom,
       sym__unicode_space,
-  [1795] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
+    ACTIONS(121), 6,
+      sym_multi_line_string,
+      sym__raw_string,
       anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(119), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [620] = 4,
+    STATE(23), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(133), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(131), 7,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+    ACTIONS(129), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [679] = 4,
+    STATE(19), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(136), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(121), 7,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+    ACTIONS(119), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [738] = 4,
+    STATE(23), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(143), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(141), 7,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+    ACTIONS(139), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [797] = 32,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(127), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(16), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(41), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(129), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [1860] = 16,
-    ACTIONS(7), 1,
+    ACTIONS(25), 1,
       sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
+    ACTIONS(35), 1,
       anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(119), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(16), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(51), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(121), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [1925] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(146), 1,
       anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(131), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(21), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(47), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(133), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [1990] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(135), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(31), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(32), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(137), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2055] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(139), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(25), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(40), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(141), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2120] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(143), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(16), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(37), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(145), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2185] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(143), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(30), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(37), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(145), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2250] = 6,
-    ACTIONS(151), 1,
+    ACTIONS(148), 1,
       anon_sym_BSLASH,
     STATE(39), 1,
+      sym_type,
+    STATE(83), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
       sym__escline,
-    STATE(49), 2,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(244), 1,
+      sym_string,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(253), 1,
+      sym_node_field,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(316), 1,
+      sym__sign,
+    STATE(332), 1,
+      sym_identifier,
+    STATE(351), 1,
+      sym__bare_identifier,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(33), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(39), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(154), 3,
+    STATE(251), 2,
+      sym_prop,
+      sym_value,
+    STATE(252), 2,
+      sym__node_field_comment,
+      sym__node_field,
+    STATE(274), 2,
+      sym_keyword,
+      sym_number,
+    ACTIONS(47), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    ACTIONS(150), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    ACTIONS(147), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
+    ACTIONS(49), 4,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(149), 20,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [912] = 4,
+    STATE(23), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(156), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(154), 7,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+    ACTIONS(152), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [971] = 4,
+    STATE(21), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(159), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(131), 7,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+    ACTIONS(129), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [1030] = 31,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(25), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    ACTIONS(162), 1,
+      anon_sym_LBRACE,
+    STATE(27), 1,
+      aux_sym_node_repeat1,
+    STATE(39), 1,
+      sym_type,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(244), 1,
+      sym_string,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(250), 1,
+      sym__node_field,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(316), 1,
+      sym__sign,
+    STATE(332), 1,
+      sym_identifier,
+    STATE(351), 1,
+      sym__bare_identifier,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(33), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(39), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(251), 2,
+      sym_prop,
+      sym_value,
+    STATE(274), 2,
+      sym_keyword,
+      sym_number,
+    ACTIONS(47), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(49), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [1141] = 2,
+    ACTIONS(166), 10,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(164), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [1194] = 31,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(25), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    ACTIONS(168), 1,
+      anon_sym_LBRACE,
+    STATE(39), 1,
+      sym_type,
+    STATE(83), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(244), 1,
+      sym_string,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(263), 1,
+      sym__node_field,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(316), 1,
+      sym__sign,
+    STATE(332), 1,
+      sym_identifier,
+    STATE(351), 1,
+      sym__bare_identifier,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(33), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(39), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(251), 2,
+      sym_prop,
+      sym_value,
+    STATE(274), 2,
+      sym_keyword,
+      sym_number,
+    ACTIONS(47), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(49), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [1305] = 2,
+    ACTIONS(172), 10,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(170), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [1358] = 2,
+    ACTIONS(176), 10,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(174), 38,
+      sym__normal_bare_identifier,
+      anon_sym_i8,
+      anon_sym_i16,
+      anon_sym_i32,
+      anon_sym_i64,
+      anon_sym_u8,
+      anon_sym_u16,
+      anon_sym_u32,
+      anon_sym_u64,
+      anon_sym_isize,
+      anon_sym_usize,
+      anon_sym_f32,
+      anon_sym_f64,
+      anon_sym_decimal64,
+      anon_sym_decimal128,
+      anon_sym_date_DASHtime,
+      anon_sym_time,
+      anon_sym_date,
+      anon_sym_duration,
+      anon_sym_decimal,
+      anon_sym_currency,
+      anon_sym_country_DASH2,
+      anon_sym_country_DASH3,
+      anon_sym_country_DASHsubdivision,
+      anon_sym_email,
+      anon_sym_idn_DASHemail,
+      anon_sym_hostname,
+      anon_sym_idn_DASHhostname,
+      anon_sym_ipv4,
+      anon_sym_ipv6,
+      anon_sym_url,
+      anon_sym_url_DASHreference,
+      anon_sym_irl,
+      anon_sym_iri_DASHreference,
+      anon_sym_url_DASHtemplate,
+      anon_sym_uuid,
+      anon_sym_regex,
+      anon_sym_base64,
+  [1411] = 30,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(25), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(39), 1,
+      sym_type,
+    STATE(83), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(244), 1,
+      sym_string,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(263), 1,
+      sym__node_field,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(316), 1,
+      sym__sign,
+    STATE(332), 1,
+      sym_identifier,
+    STATE(351), 1,
+      sym__bare_identifier,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(33), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(39), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(251), 2,
+      sym_prop,
+      sym_value,
+    STATE(274), 2,
+      sym_keyword,
+      sym_number,
+    ACTIONS(47), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(49), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [1519] = 30,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(25), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(30), 1,
+      aux_sym_node_repeat1,
+    STATE(39), 1,
+      sym_type,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(244), 1,
+      sym_string,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(250), 1,
+      sym__node_field,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(316), 1,
+      sym__sign,
+    STATE(332), 1,
+      sym_identifier,
+    STATE(351), 1,
+      sym__bare_identifier,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(33), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(39), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(251), 2,
+      sym_prop,
+      sym_value,
+    STATE(274), 2,
+      sym_keyword,
+      sym_number,
+    ACTIONS(47), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(49), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [1627] = 8,
+    ACTIONS(178), 1,
+      anon_sym_BSLASH,
+    STATE(32), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(181), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(109), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(111), 21,
       sym__eof,
+      sym_multi_line_string,
       sym__raw_string,
       anon_sym_SLASH_DASH,
       anon_sym_LBRACE,
@@ -4972,161 +10889,930 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_0o,
       anon_sym_0b,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       anon_sym_SLASH_SLASH,
-  [2295] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
+  [1686] = 25,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(39), 1,
+      sym_type,
+    STATE(83), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(255), 1,
+      sym_value,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(353), 1,
+      sym__sign,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
       sym__raw_string,
-    ACTIONS(157), 1,
+    ACTIONS(184), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(186), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(188), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    STATE(274), 3,
+      sym_keyword,
+      sym_string,
+      sym_number,
+    ACTIONS(190), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [1779] = 25,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(35), 1,
+      aux_sym_node_repeat1,
+    STATE(39), 1,
+      sym_type,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(272), 1,
+      sym_value,
+    STATE(353), 1,
+      sym__sign,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(184), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(186), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(188), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    STATE(274), 3,
+      sym_keyword,
+      sym_string,
+      sym_number,
+    ACTIONS(190), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [1872] = 25,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(39), 1,
+      sym_type,
+    STATE(83), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(260), 1,
+      sym_value,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(353), 1,
+      sym__sign,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(184), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(186), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(188), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    STATE(274), 3,
+      sym_keyword,
+      sym_string,
+      sym_number,
+    ACTIONS(190), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [1965] = 25,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(35), 1,
+      anon_sym_LPAREN,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(33), 1,
+      aux_sym_node_repeat1,
+    STATE(39), 1,
+      sym_type,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(260), 1,
+      sym_value,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(353), 1,
+      sym__sign,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(184), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(186), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(188), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    STATE(274), 3,
+      sym_keyword,
+      sym_string,
+      sym_number,
+    ACTIONS(190), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [2058] = 6,
+    ACTIONS(192), 1,
+      anon_sym_BSLASH,
+    STATE(40), 1,
+      sym__escline,
+    STATE(38), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(195), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(119), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(121), 21,
+      sym__eof,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [2111] = 4,
+    STATE(38), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(198), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(152), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(154), 22,
+      sym__eof,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [2159] = 22,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(44), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(353), 1,
+      sym__sign,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(184), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(186), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(188), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    STATE(254), 3,
+      sym_keyword,
+      sym_string,
+      sym_number,
+    ACTIONS(190), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [2243] = 4,
+    STATE(42), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(201), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(129), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(131), 22,
+      sym__eof,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [2291] = 4,
+    STATE(38), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(204), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(129), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(131), 22,
+      sym__eof,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [2339] = 4,
+    STATE(38), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(207), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(139), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(141), 22,
+      sym__eof,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [2387] = 4,
+    STATE(41), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(210), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(119), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(121), 22,
+      sym__eof,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [2435] = 22,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(41), 1,
+      anon_sym_0x,
+    ACTIONS(43), 1,
+      anon_sym_0o,
+    ACTIONS(45), 1,
+      anon_sym_0b,
+    ACTIONS(148), 1,
+      anon_sym_BSLASH,
+    STATE(83), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(215), 1,
+      sym__integer,
+    STATE(247), 1,
+      sym__escaped_string,
+    STATE(266), 1,
+      sym_boolean,
+    STATE(353), 1,
+      sym__sign,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    ACTIONS(184), 2,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+    ACTIONS(186), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(150), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(188), 3,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+    STATE(276), 3,
+      sym_keyword,
+      sym_string,
+      sym_number,
+    ACTIONS(190), 4,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    STATE(269), 5,
+      sym__decimal,
+      sym__hex,
+      sym__octal,
+      sym__binary,
+      sym_keyword_number,
+  [2519] = 2,
+    ACTIONS(91), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(89), 25,
+      sym__eof,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [2561] = 2,
+    ACTIONS(170), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(172), 25,
+      sym__eof,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [2603] = 2,
+    ACTIONS(174), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(176), 25,
+      sym__eof,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [2645] = 2,
+    ACTIONS(164), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(166), 25,
+      sym__eof,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [2687] = 2,
+    ACTIONS(95), 12,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      aux_sym__newline_token2,
+    ACTIONS(93), 25,
+      sym__eof,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [2729] = 17,
+    ACTIONS(215), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(218), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(221), 1,
+      anon_sym_LPAREN,
+    ACTIONS(224), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(233), 1,
+      aux_sym__newline_token2,
+    ACTIONS(236), 1,
+      anon_sym_SLASH_SLASH,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(213), 2,
       ts_builtin_sym_end,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(19), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(52), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(159), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2360] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(157), 1,
-      ts_builtin_sym_end,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(16), 2,
-      sym_node,
-      aux_sym_document_repeat2,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(52), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(159), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2425] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(161), 1,
       anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
+    ACTIONS(227), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(16), 2,
+    ACTIONS(239), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(50), 2,
       sym_node,
       aux_sym_document_repeat2,
-    STATE(218), 2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(46), 5,
+    STATE(82), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(163), 10,
+    ACTIONS(230), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [2490] = 16,
+  [2799] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5135,47 +11821,50 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(139), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(242), 1,
       anon_sym_RBRACE,
-    STATE(71), 1,
+    ACTIONS(246), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(16), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(55), 2,
       sym_node,
       aux_sym_document_repeat2,
-    STATE(218), 2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(40), 5,
+    STATE(70), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(141), 10,
+    ACTIONS(244), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [2555] = 16,
+  [2868] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5184,26 +11873,30 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(139), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(248), 1,
       anon_sym_RBRACE,
-    STATE(71), 1,
+    ACTIONS(252), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(64), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
     STATE(73), 5,
@@ -5212,18 +11905,18 @@ static const uint16_t ts_small_parse_table[] = {
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(165), 10,
+    ACTIONS(250), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [2619] = 16,
+  [2937] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5232,158 +11925,30 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(135), 1,
-      anon_sym_RBRACE,
-    STATE(24), 1,
-      sym_node,
-    STATE(71), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(254), 1,
+      ts_builtin_sym_end,
+    ACTIONS(258), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(36), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(167), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2683] = 4,
-    STATE(53), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(169), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(147), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(149), 21,
-      sym__eof,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
       sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [2723] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(172), 1,
-      anon_sym_RBRACE,
-    STATE(22), 1,
+    STATE(57), 2,
       sym_node,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(44), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(174), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [2787] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(139), 1,
-      anon_sym_RBRACE,
-    STATE(26), 1,
-      sym_node,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
     STATE(78), 5,
@@ -5392,18 +11957,18 @@ static const uint16_t ts_small_parse_table[] = {
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(176), 10,
+    ACTIONS(256), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [2851] = 16,
+  [3006] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5412,118 +11977,50 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(161), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(260), 1,
+      ts_builtin_sym_end,
+    ACTIONS(264), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(60), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(73), 5,
+    STATE(66), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(165), 10,
+    ACTIONS(262), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [2915] = 4,
-    STATE(49), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(182), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(178), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(180), 21,
-      sym__eof,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [2955] = 4,
-    STATE(38), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(189), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(185), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(187), 21,
-      sym__eof,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [2995] = 16,
+  [3075] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5532,122 +12029,30 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(143), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(266), 1,
       anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(165), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
+    ACTIONS(270), 1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [3059] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(192), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
+    STATE(91), 1,
       sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(165), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [3123] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
       sym__raw_string,
-    ACTIONS(135), 1,
-      anon_sym_RBRACE,
-    STATE(24), 1,
+    STATE(50), 2,
       sym_node,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
     STATE(76), 5,
@@ -5656,18 +12061,18 @@ static const uint16_t ts_small_parse_table[] = {
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(194), 10,
+    ACTIONS(268), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [3187] = 16,
+  [3144] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5676,94 +12081,50 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(157), 1,
-      ts_builtin_sym_end,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(165), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [3251] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
       anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(131), 1,
+    ACTIONS(272), 1,
       anon_sym_RBRACE,
-    STATE(18), 1,
-      sym_node,
-    STATE(71), 1,
+    ACTIONS(276), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(50), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(75), 5,
+    STATE(68), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(196), 10,
+    ACTIONS(274), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [3315] = 16,
+  [3213] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5772,26 +12133,186 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(115), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(260), 1,
       ts_builtin_sym_end,
-    STATE(28), 1,
-      sym_node,
-    STATE(71), 1,
+    ACTIONS(264), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(50), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(66), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(262), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [3282] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(278), 1,
+      anon_sym_RBRACE,
+    ACTIONS(282), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(62), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(74), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(280), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [3351] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(278), 1,
+      anon_sym_RBRACE,
+    ACTIONS(282), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(50), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(74), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(280), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [3420] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(284), 1,
+      ts_builtin_sym_end,
+    ACTIONS(288), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(50), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
     STATE(77), 5,
@@ -5800,18 +12321,18 @@ static const uint16_t ts_small_parse_table[] = {
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(198), 10,
+    ACTIONS(286), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [3379] = 16,
+  [3489] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5820,46 +12341,50 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(200), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(290), 1,
       anon_sym_RBRACE,
-    STATE(71), 1,
+    ACTIONS(294), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(56), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(73), 5,
+    STATE(80), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(165), 10,
+    ACTIONS(292), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [3443] = 16,
+  [3558] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5868,46 +12393,50 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(119), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(290), 1,
       anon_sym_RBRACE,
-    STATE(71), 1,
+    ACTIONS(294), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(50), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(73), 5,
+    STATE(80), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(165), 10,
+    ACTIONS(292), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [3507] = 16,
+  [3627] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -5916,82 +12445,50 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(202), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(296), 1,
       anon_sym_RBRACE,
-    STATE(23), 1,
-      sym_node,
-    STATE(71), 1,
+    ACTIONS(300), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
       sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
+    STATE(235), 1,
       sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
     ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    STATE(218), 2,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(59), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
       sym__bare_identifier,
       sym_string,
-    STATE(42), 5,
+    STATE(65), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(204), 10,
+    ACTIONS(298), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [3571] = 4,
-    STATE(49), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(210), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(206), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(208), 21,
-      sym__eof,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [3611] = 16,
+  [3696] = 17,
     ACTIONS(7), 1,
       sym__normal_bare_identifier,
     ACTIONS(9), 1,
@@ -6000,1762 +12497,995 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(213), 1,
-      ts_builtin_sym_end,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(165), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [3675] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
       anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(127), 1,
-      anon_sym_RBRACE,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(165), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [3739] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(123), 1,
-      ts_builtin_sym_end,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(165), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [3803] = 4,
-    STATE(49), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(215), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(185), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(187), 21,
-      sym__eof,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [3843] = 15,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(9), 1,
-      anon_sym_SLASH_DASH,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    STATE(71), 1,
-      sym_identifier,
-    STATE(153), 1,
-      sym_node,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(260), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(165), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [3904] = 2,
-    ACTIONS(220), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(218), 24,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [3938] = 2,
-    ACTIONS(222), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(224), 24,
-      sym__eof,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [3972] = 2,
-    ACTIONS(226), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(228), 24,
-      sym__eof,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [4006] = 2,
-    ACTIONS(230), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(232), 24,
-      sym__eof,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [4040] = 2,
-    ACTIONS(220), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(218), 24,
-      sym__eof,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [4074] = 2,
-    ACTIONS(236), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(234), 24,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [4108] = 2,
-    ACTIONS(236), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(234), 24,
-      sym__eof,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [4142] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(8), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(85), 1,
-      sym_node_children,
-    STATE(89), 1,
-      aux_sym_node_repeat2,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(141), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(53), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4195] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(7), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(69), 1,
-      aux_sym_node_repeat2,
-    STATE(97), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(169), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(240), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4248] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(3), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(70), 1,
-      aux_sym_node_repeat2,
-    STATE(95), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(171), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(51), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4301] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(3), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(89), 1,
-      aux_sym_node_repeat2,
-    STATE(95), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(171), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(51), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4354] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(4), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(65), 1,
-      aux_sym_node_repeat2,
-    STATE(109), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(152), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(29), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4407] = 19,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
     ACTIONS(242), 1,
-      anon_sym_null,
-    STATE(79), 1,
+      anon_sym_RBRACE,
+    ACTIONS(246), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
       sym_type,
-    STATE(154), 1,
-      sym__integer,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(208), 1,
-      sym_value,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(271), 1,
+    STATE(243), 1,
       sym__sign,
-    ACTIONS(244), 2,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(246), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(199), 3,
-      sym_keyword,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(50), 2,
+      sym_node,
+      aux_sym_document_repeat2,
+    STATE(268), 2,
+      sym__bare_identifier,
       sym_string,
-      sym_number,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-  [4472] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(5), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(62), 1,
-      aux_sym_node_repeat2,
-    STATE(80), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(148), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(57), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4525] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(5), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(80), 1,
-      sym_node_children,
-    STATE(89), 1,
-      aux_sym_node_repeat2,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(148), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(57), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4578] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(6), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(89), 1,
-      aux_sym_node_repeat2,
-    STATE(118), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(142), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(49), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4631] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(2), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(72), 1,
-      aux_sym_node_repeat2,
-    STATE(104), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(156), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(248), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4684] = 13,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(27), 1,
-      anon_sym_LBRACE,
-    ACTIONS(45), 1,
-      anon_sym_BSLASH,
-    ACTIONS(238), 1,
-      anon_sym_SLASH_DASH,
-    STATE(4), 1,
-      aux_sym_node_repeat1,
-    STATE(34), 1,
-      sym__escline,
-    STATE(58), 1,
-      sym__node_space,
-    STATE(89), 1,
-      aux_sym_node_repeat2,
-    STATE(109), 1,
-      sym_node_children,
-    STATE(27), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(47), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(152), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(29), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [4737] = 4,
-    ACTIONS(255), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(73), 5,
+    STATE(70), 5,
       sym__linespace,
       sym__newline,
       sym__ws,
       sym_single_line_comment,
       aux_sym_document_repeat1,
-    ACTIONS(250), 9,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(252), 10,
+    ACTIONS(244), 10,
       sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [4771] = 8,
-    ACTIONS(258), 1,
-      anon_sym_BSLASH,
-    STATE(74), 1,
-      aux_sym_node_repeat1,
-    STATE(125), 1,
-      sym__escline,
-    STATE(186), 1,
-      sym__node_space,
-    STATE(100), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(261), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(79), 5,
+  [3765] = 17,
+    ACTIONS(7), 1,
       sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(81), 10,
-      sym__raw_string,
+    ACTIONS(9), 1,
       anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
+    ACTIONS(11), 1,
       anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-  [4812] = 5,
-    ACTIONS(255), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(264), 1,
-      anon_sym_RBRACE,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(250), 7,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(252), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [4847] = 5,
-    ACTIONS(255), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(267), 1,
-      anon_sym_RBRACE,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(250), 7,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(252), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [4882] = 5,
-    ACTIONS(255), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(270), 1,
-      ts_builtin_sym_end,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(250), 7,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(252), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [4917] = 5,
-    ACTIONS(255), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(273), 1,
-      anon_sym_RBRACE,
-    STATE(73), 5,
-      sym__linespace,
-      sym__newline,
-      sym__ws,
-      sym_single_line_comment,
-      aux_sym_document_repeat1,
-    ACTIONS(250), 7,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(252), 10,
-      sym_multi_line_comment,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-  [4952] = 16,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
     ACTIONS(13), 1,
       anon_sym_DQUOTE,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(37), 1,
-      anon_sym_0x,
-    ACTIONS(39), 1,
-      anon_sym_0o,
-    ACTIONS(41), 1,
-      anon_sym_0b,
-    ACTIONS(242), 1,
-      anon_sym_null,
-    STATE(154), 1,
-      sym__integer,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(217), 1,
-      sym_boolean,
-    STATE(271), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(278), 1,
+      anon_sym_RBRACE,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
       sym__sign,
-    ACTIONS(244), 2,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-    ACTIONS(246), 2,
-      anon_sym_true,
-      anon_sym_false,
-    STATE(220), 3,
-      sym_keyword,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
       sym_string,
-      sym_number,
-    STATE(214), 4,
-      sym__decimal,
-      sym__hex,
-      sym__octal,
-      sym__binary,
-  [5008] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(87), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(86), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(280), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(155), 3,
-      sym__node_terminator,
+    STATE(99), 5,
+      sym__linespace,
       sym__newline,
+      sym__ws,
       sym_single_line_comment,
-    ACTIONS(276), 9,
-      sym__eof,
-      anon_sym_SEMI,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [5049] = 3,
-    STATE(119), 1,
-      aux_sym__integer_repeat1,
-    ACTIONS(284), 2,
-      anon_sym__,
-      sym__digit,
-    ACTIONS(282), 19,
-      sym__eof,
-      sym_multi_line_comment,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [3833] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
       anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_DOT,
-      anon_sym_e,
-      anon_sym_E,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(284), 1,
+      ts_builtin_sym_end,
+    ACTIONS(304), 1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [5078] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(129), 3,
-      sym__node_terminator,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
       sym__newline,
+      sym__ws,
       sym_single_line_comment,
-    ACTIONS(286), 9,
-      sym__eof,
-      anon_sym_SEMI,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [5119] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-    STATE(136), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(290), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
+  [3901] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(306), 1,
+      anon_sym_RBRACE,
+    ACTIONS(310), 1,
       aux_sym__newline_token2,
+    STATE(63), 1,
+      sym_node,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(72), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(308), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [5160] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-    STATE(128), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(292), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
+  [3969] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(304), 1,
       aux_sym__newline_token2,
+    ACTIONS(312), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [5201] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(117), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(114), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(296), 3,
-      sym_multi_line_comment,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-    STATE(131), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(294), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
+  [4037] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(296), 1,
+      anon_sym_RBRACE,
+    ACTIONS(316), 1,
       aux_sym__newline_token2,
+    STATE(58), 1,
+      sym_node,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(79), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(314), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [5242] = 9,
-    ACTIONS(19), 1,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4105] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(266), 1,
+      anon_sym_RBRACE,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4173] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(248), 1,
+      anon_sym_RBRACE,
+    ACTIONS(320), 1,
+      aux_sym__newline_token2,
+    STATE(51), 1,
+      sym_node,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(106), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(318), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4241] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(296), 1,
+      anon_sym_RBRACE,
+    ACTIONS(324), 1,
+      aux_sym__newline_token2,
+    STATE(58), 1,
+      sym_node,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(113), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(322), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4309] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(242), 1,
+      anon_sym_RBRACE,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4377] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(290), 1,
+      anon_sym_RBRACE,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4445] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(254), 1,
+      ts_builtin_sym_end,
+    ACTIONS(328), 1,
+      aux_sym__newline_token2,
+    STATE(54), 1,
+      sym_node,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(112), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(326), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4513] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    ACTIONS(330), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4581] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    ACTIONS(332), 1,
+      ts_builtin_sym_end,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4649] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(260), 1,
+      ts_builtin_sym_end,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4717] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
       anon_sym_SLASH_SLASH,
     ACTIONS(278), 1,
+      anon_sym_RBRACE,
+    ACTIONS(336), 1,
+      aux_sym__newline_token2,
+    STATE(61), 1,
+      sym_node,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(110), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(334), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4785] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(272), 1,
+      anon_sym_RBRACE,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4853] = 17,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(338), 1,
+      anon_sym_RBRACE,
+    ACTIONS(342), 1,
+      aux_sym__newline_token2,
+    STATE(52), 1,
+      sym_node,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(71), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(340), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4921] = 16,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(9), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(304), 1,
+      aux_sym__newline_token2,
+    STATE(91), 1,
+      sym_identifier,
+    STATE(199), 1,
+      sym_node,
+    STATE(235), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(302), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [4986] = 8,
+    ACTIONS(344), 1,
       anon_sym_BSLASH,
     STATE(83), 1,
       aux_sym_node_repeat1,
-    STATE(222), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(195), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(300), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(132), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(298), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5283] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(132), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(298), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5324] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(133), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(302), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5365] = 8,
-    ACTIONS(306), 1,
-      anon_sym_BSLASH,
-    STATE(10), 1,
-      aux_sym_node_repeat1,
     STATE(89), 1,
-      aux_sym_node_repeat2,
-    STATE(125), 1,
       sym__escline,
-    STATE(186), 1,
+    STATE(107), 1,
       sym__node_space,
-    STATE(100), 2,
+    STATE(84), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(309), 3,
+    ACTIONS(347), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    ACTIONS(304), 12,
-      sym__eof,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [5404] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(111), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(103), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(314), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(134), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(312), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5445] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(98), 1,
-      aux_sym_node_repeat1,
-    STATE(222), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(195), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(300), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(151), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(316), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5486] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(151), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(316), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5527] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(137), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(318), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5568] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(102), 1,
-      aux_sym_node_repeat1,
-    STATE(222), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(195), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(300), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(137), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(318), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5609] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(116), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(120), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(322), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(138), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(320), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5650] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(157), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(324), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5691] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(113), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(112), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(328), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(144), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(326), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5732] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(145), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(330), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5773] = 3,
-    STATE(99), 1,
-      aux_sym__integer_repeat1,
-    ACTIONS(334), 2,
-      anon_sym__,
-      sym__digit,
-    ACTIONS(332), 19,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_DOT,
-      anon_sym_e,
-      anon_sym_E,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [5802] = 6,
-    ACTIONS(337), 1,
-      anon_sym_BSLASH,
-    STATE(121), 1,
-      sym__escline,
-    STATE(126), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(340), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(147), 5,
+    ACTIONS(109), 11,
       sym__normal_bare_identifier,
       anon_sym_null,
+      anon_sym_POUNDnull,
       sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(149), 10,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(111), 11,
+      sym_multi_line_string,
       sym__raw_string,
       anon_sym_SLASH_DASH,
       anon_sym_LBRACE,
@@ -7766,569 +13496,278 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_0x,
       anon_sym_0o,
       anon_sym_0b,
-  [5837] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
+  [5034] = 6,
+    ACTIONS(350), 1,
       anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
+    STATE(87), 1,
       sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
+    STATE(86), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(288), 3,
+    ACTIONS(353), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    STATE(143), 3,
+    ACTIONS(119), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(121), 11,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+  [5076] = 4,
+    STATE(86), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(356), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(139), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(141), 12,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+  [5113] = 4,
+    STATE(86), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(359), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(152), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(154), 12,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+  [5150] = 4,
+    STATE(85), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(362), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(129), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(131), 12,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+  [5187] = 4,
+    STATE(86), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(365), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(129), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(131), 12,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+  [5224] = 4,
+    STATE(88), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(368), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(119), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(121), 12,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+  [5261] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(63), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(7), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(152), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(174), 3,
       sym__node_terminator,
       sym__newline,
       sym_single_line_comment,
-    ACTIONS(343), 9,
+    ACTIONS(61), 9,
       sym__eof,
       anon_sym_SEMI,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [5878] = 9,
-    ACTIONS(19), 1,
+      aux_sym__newline_token8,
+  [5317] = 14,
+    ACTIONS(21), 1,
       anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
       anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(167), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(345), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(375), 1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5919] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(84), 1,
+    STATE(4), 1,
       aux_sym_node_repeat1,
-    STATE(222), 1,
+    STATE(43), 1,
       sym__escline,
-    STATE(234), 1,
+    STATE(47), 1,
       sym__node_space,
-    STATE(195), 2,
+    STATE(90), 1,
+      aux_sym_node_repeat2,
+    STATE(161), 1,
+      sym_node_children,
+    STATE(37), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(300), 3,
+    ACTIONS(55), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    STATE(140), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(347), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [5960] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(107), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(106), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(351), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(158), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(349), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6001] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(82), 1,
-      aux_sym_node_repeat1,
-    STATE(222), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(195), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(300), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(143), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(343), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6042] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(115), 1,
-      aux_sym_node_repeat1,
-    STATE(222), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(195), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(300), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(146), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(353), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6083] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(146), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(353), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6124] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(101), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(105), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(357), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(163), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(355), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6165] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(93), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(94), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(361), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(149), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(359), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6206] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(150), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(363), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6247] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(140), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(347), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6288] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(88), 1,
-      aux_sym_node_repeat1,
-    STATE(222), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(195), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(300), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(159), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(365), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6329] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(159), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(365), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6370] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(110), 1,
-      aux_sym_node_repeat1,
-    STATE(222), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(195), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(300), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(139), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(367), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6411] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(161), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(369), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6452] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(168), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(371), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6493] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(193), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(288), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(139), 3,
-      sym__node_terminator,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(367), 9,
-      sym__eof,
-      anon_sym_SEMI,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [6534] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(92), 1,
-      aux_sym_node_repeat1,
-    STATE(212), 1,
-      sym__escline,
-    STATE(234), 1,
-      sym__node_space,
-    STATE(91), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(375), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    STATE(170), 3,
+    STATE(166), 3,
       sym__node_terminator,
       sym__newline,
       sym_single_line_comment,
@@ -8336,4083 +13775,7646 @@ static const uint16_t ts_small_parse_table[] = {
       sym__eof,
       anon_sym_SEMI,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [6575] = 3,
-    STATE(99), 1,
-      aux_sym__integer_repeat1,
-    ACTIONS(379), 2,
-      anon_sym__,
-      sym__digit,
-    ACTIONS(377), 19,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
+      aux_sym__newline_token8,
+  [5373] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
       anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_DOT,
-      anon_sym_e,
-      anon_sym_E,
+    ACTIONS(51), 1,
       anon_sym_BSLASH,
-      aux_sym__newline_token1,
+    ACTIONS(75), 1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [6604] = 9,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    ACTIONS(278), 1,
-      anon_sym_BSLASH,
-    STATE(96), 1,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(2), 1,
       aux_sym_node_repeat1,
-    STATE(222), 1,
+    STATE(43), 1,
       sym__escline,
-    STATE(234), 1,
+    STATE(47), 1,
       sym__node_space,
-    STATE(195), 2,
+    STATE(134), 1,
+      sym_node_children,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(37), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(300), 3,
+    ACTIONS(55), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    STATE(168), 3,
+    STATE(177), 3,
       sym__node_terminator,
       sym__newline,
       sym_single_line_comment,
-    ACTIONS(371), 9,
+    ACTIONS(73), 9,
       sym__eof,
       anon_sym_SEMI,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-  [6645] = 4,
-    STATE(123), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(381), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(185), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(187), 11,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-  [6675] = 4,
-    STATE(126), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(384), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(185), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(187), 11,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-  [6705] = 4,
-    STATE(126), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(387), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(178), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(180), 11,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-  [6735] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
+      aux_sym__newline_token8,
+  [5429] = 14,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(71), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
       anon_sym_BSLASH,
-    STATE(63), 1,
-      sym_identifier,
-    STATE(74), 1,
+    ACTIONS(75), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(2), 1,
       aux_sym_node_repeat1,
-    STATE(125), 1,
+    STATE(43), 1,
       sym__escline,
-    STATE(186), 1,
+    STATE(47), 1,
       sym__node_space,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(257), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(100), 2,
+    STATE(102), 1,
+      aux_sym_node_repeat2,
+    STATE(134), 1,
+      sym_node_children,
+    STATE(37), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    ACTIONS(73), 3,
+    ACTIONS(55), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-  [6789] = 4,
-    STATE(122), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(390), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(147), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(149), 11,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-  [6819] = 4,
-    STATE(126), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(393), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(206), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(208), 11,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-  [6849] = 16,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(11), 1,
-      anon_sym_LPAREN,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
+    STATE(177), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(73), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5485] = 14,
     ACTIONS(21), 1,
-      sym__raw_string,
-    ACTIONS(71), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
       anon_sym_BSLASH,
-    STATE(66), 1,
-      sym_identifier,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    ACTIONS(379), 1,
+      aux_sym__newline_token2,
+    STATE(10), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(101), 1,
+      aux_sym_node_repeat2,
+    STATE(149), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(180), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(377), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5541] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(67), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(9), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(100), 1,
+      aux_sym_node_repeat2,
     STATE(124), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(210), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(65), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5597] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(67), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(9), 1,
       aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(124), 1,
+      sym_node_children,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(210), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(65), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5653] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(71), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(3), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(160), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(202), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(69), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5709] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(63), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(7), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(92), 1,
+      aux_sym_node_repeat2,
+    STATE(152), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(174), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(61), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5765] = 5,
+    ACTIONS(386), 1,
+      aux_sym__newline_token2,
+    ACTIONS(389), 1,
+      anon_sym_SLASH_SLASH,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(381), 10,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(383), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [5803] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(83), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(8), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(154), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(178), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(81), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5859] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(87), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(5), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(142), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(203), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(85), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5915] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(53), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(6), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(115), 1,
+      sym_node_children,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(183), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(31), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [5971] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(53), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(6), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(97), 1,
+      aux_sym_node_repeat2,
+    STATE(115), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(183), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(31), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6027] = 14,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(51), 1,
+      anon_sym_BSLASH,
+    ACTIONS(87), 1,
+      aux_sym__newline_token2,
+    ACTIONS(371), 1,
+      anon_sym_SLASH_DASH,
+    STATE(5), 1,
+      aux_sym_node_repeat1,
+    STATE(43), 1,
+      sym__escline,
+    STATE(47), 1,
+      sym__node_space,
+    STATE(96), 1,
+      aux_sym_node_repeat2,
+    STATE(142), 1,
+      sym_node_children,
+    STATE(37), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(55), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(203), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(85), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6083] = 2,
+    ACTIONS(164), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(166), 15,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [6114] = 6,
+    ACTIONS(386), 1,
+      aux_sym__newline_token2,
+    ACTIONS(389), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(392), 1,
+      anon_sym_RBRACE,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(381), 8,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(383), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [6153] = 2,
+    ACTIONS(174), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(176), 15,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [6184] = 2,
+    ACTIONS(170), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(172), 15,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [6215] = 2,
+    ACTIONS(91), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(89), 15,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [6246] = 6,
+    ACTIONS(386), 1,
+      aux_sym__newline_token2,
+    ACTIONS(389), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(395), 1,
+      anon_sym_RBRACE,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(381), 8,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(383), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [6285] = 2,
+    ACTIONS(95), 11,
+      sym__normal_bare_identifier,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      sym__digit,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+    ACTIONS(93), 15,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [6316] = 6,
+    ACTIONS(386), 1,
+      aux_sym__newline_token2,
+    ACTIONS(389), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(398), 1,
+      ts_builtin_sym_end,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(381), 8,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(383), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [6355] = 6,
+    ACTIONS(386), 1,
+      aux_sym__newline_token2,
+    ACTIONS(389), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(401), 1,
+      anon_sym_RBRACE,
+    STATE(99), 5,
+      sym__linespace,
+      sym__newline,
+      sym__ws,
+      sym_single_line_comment,
+      aux_sym_document_repeat1,
+    ACTIONS(381), 8,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_SLASH_DASH,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(383), 10,
+      sym_multi_line_comment,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+  [6394] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(408), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(195), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(404), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6438] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(414), 1,
+      aux_sym__newline_token2,
+    STATE(158), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(159), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(416), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(198), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(412), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6482] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(420), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(162), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(418), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6526] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(424), 1,
+      aux_sym__newline_token2,
     STATE(125), 1,
-      sym__escline,
-    STATE(186), 1,
-      sym__node_space,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    STATE(258), 1,
-      sym_type,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(100), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-    ACTIONS(73), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [6903] = 1,
-    ACTIONS(396), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [6926] = 1,
-    ACTIONS(398), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [6949] = 3,
-    STATE(130), 1,
-      aux_sym__binary_repeat1,
-    ACTIONS(402), 3,
-      anon_sym__,
-      anon_sym_0,
-      anon_sym_1,
-    ACTIONS(400), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [6976] = 1,
-    ACTIONS(405), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [6999] = 1,
-    ACTIONS(407), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7022] = 1,
-    ACTIONS(409), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7045] = 1,
-    ACTIONS(411), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7068] = 4,
-    ACTIONS(415), 1,
-      anon_sym_DOT,
-    STATE(202), 1,
-      sym__exponent,
-    ACTIONS(417), 2,
-      anon_sym_e,
-      anon_sym_E,
-    ACTIONS(413), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7097] = 1,
-    ACTIONS(419), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7120] = 1,
-    ACTIONS(421), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7143] = 1,
-    ACTIONS(423), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7166] = 1,
-    ACTIONS(425), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7189] = 1,
-    ACTIONS(427), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7212] = 1,
-    ACTIONS(429), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7235] = 1,
-    ACTIONS(431), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7258] = 1,
-    ACTIONS(433), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7281] = 1,
-    ACTIONS(435), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7304] = 1,
-    ACTIONS(437), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7327] = 1,
-    ACTIONS(439), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7350] = 3,
-    STATE(164), 1,
-      aux_sym__binary_repeat1,
-    ACTIONS(443), 3,
-      anon_sym__,
-      anon_sym_0,
-      anon_sym_1,
-    ACTIONS(441), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7377] = 1,
-    ACTIONS(445), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7400] = 1,
-    ACTIONS(447), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7423] = 1,
-    ACTIONS(449), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7446] = 1,
-    ACTIONS(451), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7469] = 1,
-    ACTIONS(453), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7492] = 1,
-    ACTIONS(89), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7515] = 4,
-    ACTIONS(457), 1,
-      anon_sym_DOT,
-    STATE(216), 1,
-      sym__exponent,
-    ACTIONS(417), 2,
-      anon_sym_e,
-      anon_sym_E,
-    ACTIONS(455), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7544] = 1,
-    ACTIONS(459), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7567] = 1,
-    ACTIONS(461), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7590] = 1,
-    ACTIONS(463), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7613] = 1,
-    ACTIONS(465), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7636] = 1,
-    ACTIONS(467), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7659] = 1,
-    ACTIONS(469), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7682] = 1,
-    ACTIONS(471), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7705] = 1,
-    ACTIONS(473), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7728] = 1,
-    ACTIONS(475), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7751] = 3,
-    STATE(130), 1,
-      aux_sym__binary_repeat1,
-    ACTIONS(479), 3,
-      anon_sym__,
-      anon_sym_0,
-      anon_sym_1,
-    ACTIONS(477), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7778] = 3,
-    STATE(130), 1,
-      aux_sym__binary_repeat1,
-    ACTIONS(479), 3,
-      anon_sym__,
-      anon_sym_0,
-      anon_sym_1,
-    ACTIONS(481), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7805] = 3,
-    STATE(165), 1,
-      aux_sym__binary_repeat1,
-    ACTIONS(483), 3,
-      anon_sym__,
-      anon_sym_0,
-      anon_sym_1,
-    ACTIONS(477), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7832] = 1,
-    ACTIONS(485), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7855] = 1,
-    ACTIONS(487), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7878] = 1,
-    ACTIONS(489), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7901] = 1,
-    ACTIONS(491), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7924] = 1,
-    ACTIONS(493), 20,
-      sym_multi_line_comment,
-      sym__raw_string,
-      ts_builtin_sym_end,
-      anon_sym_SLASH_DASH,
-      anon_sym_RBRACE,
-      sym__normal_bare_identifier,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7947] = 3,
-    STATE(181), 1,
-      aux_sym__octal_repeat1,
-    ACTIONS(497), 2,
-      anon_sym__,
-      aux_sym__octal_token1,
-    ACTIONS(495), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7973] = 3,
-    STATE(182), 1,
-      aux_sym__octal_repeat1,
-    ACTIONS(501), 2,
-      anon_sym__,
-      aux_sym__octal_token1,
-    ACTIONS(499), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [7999] = 3,
-    STATE(203), 1,
-      sym__exponent,
-    ACTIONS(417), 2,
-      anon_sym_e,
-      anon_sym_E,
-    ACTIONS(503), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8025] = 3,
-    STATE(178), 1,
-      aux_sym__hex_repeat1,
-    ACTIONS(507), 2,
-      sym__hex_digit,
-      anon_sym__,
-    ACTIONS(505), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8051] = 3,
-    STATE(172), 1,
-      aux_sym__octal_repeat1,
-    ACTIONS(511), 2,
-      anon_sym__,
-      aux_sym__octal_token1,
-    ACTIONS(509), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8077] = 3,
-    STATE(184), 1,
-      aux_sym__hex_repeat1,
-    ACTIONS(513), 2,
-      sym__hex_digit,
-      anon_sym__,
-    ACTIONS(505), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8103] = 3,
-    STATE(184), 1,
-      aux_sym__hex_repeat1,
-    ACTIONS(513), 2,
-      sym__hex_digit,
-      anon_sym__,
-    ACTIONS(515), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8129] = 2,
-    ACTIONS(226), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(228), 14,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      sym__bom,
-      sym__unicode_space,
-  [8153] = 3,
-    STATE(215), 1,
-      sym__exponent,
-    ACTIONS(417), 2,
-      anon_sym_e,
-      anon_sym_E,
-    ACTIONS(517), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8179] = 3,
-    STATE(181), 1,
-      aux_sym__octal_repeat1,
-    ACTIONS(521), 2,
-      anon_sym__,
-      aux_sym__octal_token1,
-    ACTIONS(519), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8205] = 3,
-    STATE(181), 1,
-      aux_sym__octal_repeat1,
-    ACTIONS(497), 2,
-      anon_sym__,
-      aux_sym__octal_token1,
-    ACTIONS(509), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8231] = 2,
-    ACTIONS(222), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(224), 14,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      sym__bom,
-      sym__unicode_space,
-  [8255] = 3,
-    STATE(184), 1,
-      aux_sym__hex_repeat1,
-    ACTIONS(526), 2,
-      sym__hex_digit,
-      anon_sym__,
-    ACTIONS(524), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8281] = 3,
-    STATE(177), 1,
-      aux_sym__hex_repeat1,
-    ACTIONS(531), 2,
-      sym__hex_digit,
-      anon_sym__,
-    ACTIONS(529), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8307] = 2,
-    ACTIONS(230), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(232), 14,
-      sym_multi_line_comment,
-      sym__raw_string,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_LPAREN,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-      anon_sym_BSLASH,
-      sym__bom,
-      sym__unicode_space,
-  [8331] = 7,
-    ACTIONS(533), 1,
-      anon_sym_BSLASH,
-    STATE(187), 1,
       aux_sym_node_repeat1,
-    STATE(212), 1,
+    STATE(265), 1,
       sym__escline,
-    STATE(234), 1,
+    STATE(297), 1,
       sym__node_space,
-    STATE(193), 2,
+    STATE(246), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(536), 3,
+    ACTIONS(426), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    ACTIONS(81), 10,
+    STATE(191), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(422), 9,
       sym__eof,
       anon_sym_SEMI,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6570] = 10,
+    ACTIONS(21), 1,
       anon_sym_SLASH_SLASH,
-  [8365] = 3,
-    ACTIONS(541), 1,
-      sym__identifier_char,
-    STATE(188), 1,
-      aux_sym__bare_identifier_repeat1,
-    ACTIONS(539), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
+    ACTIONS(406), 1,
       anon_sym_BSLASH,
-      aux_sym__newline_token1,
+    ACTIONS(424), 1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8390] = 3,
-    ACTIONS(546), 1,
-      sym__identifier_char,
-    STATE(188), 1,
-      aux_sym__bare_identifier_repeat1,
-    ACTIONS(544), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8415] = 3,
-    ACTIONS(550), 1,
-      sym__identifier_char,
-    STATE(189), 1,
-      aux_sym__bare_identifier_repeat1,
-    ACTIONS(548), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8440] = 2,
-    ACTIONS(554), 1,
-      anon_sym_EQ,
-    ACTIONS(552), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8462] = 2,
-    ACTIONS(558), 1,
-      sym___identifier_char_no_digit,
-    ACTIONS(556), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8484] = 5,
-    ACTIONS(560), 1,
-      anon_sym_BSLASH,
-    STATE(206), 1,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
       sym__escline,
-    STATE(205), 2,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(563), 3,
+    ACTIONS(410), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    ACTIONS(149), 10,
+    STATE(191), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(422), 9,
       sym__eof,
       anon_sym_SEMI,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6614] = 10,
+    ACTIONS(21), 1,
       anon_sym_SLASH_SLASH,
-  [8512] = 1,
-    ACTIONS(566), 17,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(420), 1,
+      aux_sym__newline_token2,
+    STATE(132), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(162), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(418), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6658] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(430), 1,
+      aux_sym__newline_token2,
+    STATE(133), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(146), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(432), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(193), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(428), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6702] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(436), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(205), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(434), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6746] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(440), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(167), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(438), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6790] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(444), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(163), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(442), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6834] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(448), 1,
+      aux_sym__newline_token2,
+    STATE(150), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(151), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(450), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(201), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(446), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6878] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(454), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(176), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(452), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6922] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(458), 1,
+      aux_sym__newline_token2,
+    STATE(148), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(164), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(456), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [6966] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(458), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(164), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(456), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7010] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(462), 1,
+      aux_sym__newline_token2,
+    STATE(114), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(169), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(460), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7054] = 4,
+    ACTIONS(468), 1,
+      aux_sym__newline_token2,
+    STATE(153), 1,
+      aux_sym__integer_repeat1,
+    ACTIONS(466), 2,
+      anon_sym__,
+      sym__digit,
+    ACTIONS(464), 19,
       sym__eof,
       sym_multi_line_comment,
       anon_sym_SLASH_DASH,
       anon_sym_LBRACE,
       anon_sym_SEMI,
-      anon_sym_EQ,
+      anon_sym_DOT,
+      anon_sym_e,
+      anon_sym_E,
       anon_sym_BSLASH,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
       anon_sym_SLASH_SLASH,
-  [8532] = 5,
+  [7086] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(462), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(169), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(460), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7130] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(472), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(188), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(470), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7174] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(476), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(187), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(474), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7218] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(480), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(185), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(478), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7262] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(484), 1,
+      aux_sym__newline_token2,
+    STATE(135), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(136), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(486), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(171), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(482), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7306] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(490), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(196), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(488), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7350] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(490), 1,
+      aux_sym__newline_token2,
+    STATE(157), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(196), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(488), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7394] = 4,
+    ACTIONS(496), 1,
+      aux_sym__newline_token2,
+    STATE(129), 1,
+      aux_sym__integer_repeat1,
+    ACTIONS(494), 2,
+      anon_sym__,
+      sym__digit,
+    ACTIONS(492), 19,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_DOT,
+      anon_sym_e,
+      anon_sym_E,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [7426] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(500), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(179), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(498), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7470] = 9,
+    ACTIONS(504), 1,
+      anon_sym_BSLASH,
+    ACTIONS(507), 1,
+      aux_sym__newline_token2,
+    STATE(22), 1,
+      aux_sym_node_repeat1,
+    STATE(89), 1,
+      sym__escline,
+    STATE(107), 1,
+      sym__node_space,
+    STATE(139), 1,
+      aux_sym_node_repeat2,
+    STATE(84), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(509), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(502), 12,
+      sym__eof,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [7512] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(514), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(204), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(512), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7556] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(514), 1,
+      aux_sym__newline_token2,
+    STATE(122), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(204), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(512), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7600] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(518), 1,
+      aux_sym__newline_token2,
+    STATE(127), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(126), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(520), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(206), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(516), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7644] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(524), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(181), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(522), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7688] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(524), 1,
+      aux_sym__newline_token2,
+    STATE(121), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(181), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(522), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7732] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(528), 1,
+      aux_sym__newline_token2,
+    STATE(123), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(156), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(530), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(184), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(526), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7776] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(480), 1,
+      aux_sym__newline_token2,
+    STATE(147), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(185), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(478), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7820] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(534), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(182), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(532), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7864] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(538), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(186), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(536), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7908] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(542), 1,
+      aux_sym__newline_token2,
+    STATE(140), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(141), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(544), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(197), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(540), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7952] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(548), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(189), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(546), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [7996] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(548), 1,
+      aux_sym__newline_token2,
+    STATE(155), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(189), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(546), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8040] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(552), 1,
+      aux_sym__newline_token2,
+    STATE(130), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(128), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(554), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(172), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(550), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8084] = 4,
+    ACTIONS(561), 1,
+      aux_sym__newline_token2,
+    STATE(153), 1,
+      aux_sym__integer_repeat1,
+    ACTIONS(558), 2,
+      anon_sym__,
+      sym__digit,
+    ACTIONS(556), 19,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_DOT,
+      anon_sym_e,
+      anon_sym_E,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8116] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(565), 1,
+      aux_sym__newline_token2,
+    STATE(116), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(119), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(567), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    STATE(211), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(563), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8160] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
     ACTIONS(571), 1,
-      anon_sym_BSLASH,
-    STATE(206), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
       sym__escline,
-    STATE(205), 2,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(575), 3,
+    ACTIONS(410), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    ACTIONS(568), 10,
+    STATE(200), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(569), 9,
       sym__eof,
       anon_sym_SEMI,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8204] = 10,
+    ACTIONS(21), 1,
       anon_sym_SLASH_SLASH,
-  [8560] = 1,
-    ACTIONS(579), 17,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_EQ,
+    ACTIONS(406), 1,
       anon_sym_BSLASH,
-      aux_sym__newline_token1,
+    ACTIONS(444), 1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8580] = 1,
-    ACTIONS(581), 17,
-      sym__eof,
+    STATE(131), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
       sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_EQ,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
       sym__bom,
       sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8600] = 1,
-    ACTIONS(304), 16,
+    STATE(163), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(442), 9,
       sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
       anon_sym_SEMI,
-      anon_sym_BSLASH,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8248] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(575), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8619] = 1,
-    ACTIONS(552), 16,
+    STATE(175), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(573), 9,
       sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
       anon_sym_SEMI,
-      anon_sym_BSLASH,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8292] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(579), 1,
+      aux_sym__newline_token2,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(410), 3,
+      sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8638] = 1,
-    ACTIONS(583), 16,
+    STATE(173), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(577), 9,
       sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
       anon_sym_SEMI,
-      anon_sym_BSLASH,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8336] = 10,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(579), 1,
+      aux_sym__newline_token2,
+    STATE(138), 1,
+      aux_sym_node_repeat1,
+    STATE(265), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(246), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(426), 3,
+      sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
+    STATE(173), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(577), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8380] = 10,
+    ACTIONS(21), 1,
       anon_sym_SLASH_SLASH,
-  [8657] = 3,
-    STATE(205), 2,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(583), 1,
+      aux_sym__newline_token2,
+    STATE(143), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(144), 2,
       sym__ws,
       aux_sym_node_repeat3,
     ACTIONS(585), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-    ACTIONS(180), 11,
-      sym__eof,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [8680] = 1,
-    ACTIONS(588), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8699] = 1,
-    ACTIONS(590), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8718] = 1,
-    ACTIONS(592), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8737] = 3,
-    STATE(205), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(594), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(208), 11,
-      sym__eof,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [8760] = 3,
-    STATE(201), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(597), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(187), 11,
-      sym__eof,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [8783] = 3,
-    STATE(205), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(600), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(187), 11,
-      sym__eof,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [8806] = 1,
-    ACTIONS(603), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8825] = 1,
-    ACTIONS(605), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8844] = 3,
-    STATE(205), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(610), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(607), 11,
-      sym__eof,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [8867] = 1,
-    ACTIONS(614), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8886] = 3,
-    STATE(207), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(616), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(149), 11,
-      sym__eof,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [8909] = 1,
-    ACTIONS(619), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8928] = 1,
-    ACTIONS(621), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8947] = 1,
-    ACTIONS(623), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8966] = 1,
-    ACTIONS(413), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [8985] = 1,
-    ACTIONS(625), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9004] = 1,
-    ACTIONS(554), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9023] = 1,
-    ACTIONS(627), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9042] = 1,
-    ACTIONS(629), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9061] = 1,
-    ACTIONS(631), 16,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SLASH_DASH,
-      anon_sym_LBRACE,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9080] = 3,
-    STATE(210), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(636), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(633), 11,
-      sym__eof,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [9103] = 5,
-    ACTIONS(644), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(230), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(281), 2,
+    STATE(170), 3,
+      sym__node_terminator,
       sym__newline,
       sym_single_line_comment,
-    ACTIONS(642), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(640), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9129] = 5,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(179), 2,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(230), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(642), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(646), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9155] = 5,
-    ACTIONS(650), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(57), 2,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(230), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(642), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(648), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9181] = 5,
-    ACTIONS(654), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(230), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(236), 2,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(642), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(652), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9207] = 5,
-    ACTIONS(19), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(183), 2,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(224), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(658), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(656), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9233] = 5,
-    ACTIONS(644), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(223), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(276), 2,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(662), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(660), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9259] = 5,
-    ACTIONS(650), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(56), 2,
-      sym__newline,
-      sym_single_line_comment,
-    STATE(225), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(666), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(664), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9285] = 3,
-    STATE(230), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(668), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(208), 10,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      anon_sym_SLASH_SLASH,
-  [9307] = 5,
-    ACTIONS(654), 1,
-      anon_sym_SLASH_SLASH,
-    STATE(226), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    STATE(246), 2,
-      sym__newline,
-      sym_single_line_comment,
-    ACTIONS(673), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-    ACTIONS(671), 7,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9333] = 1,
-    ACTIONS(675), 14,
+    ACTIONS(581), 9,
       sym__eof,
-      sym_multi_line_comment,
       anon_sym_SEMI,
-      anon_sym_BSLASH,
       aux_sym__newline_token1,
-      aux_sym__newline_token2,
       aux_sym__newline_token3,
       aux_sym__newline_token4,
       aux_sym__newline_token5,
       aux_sym__newline_token6,
       aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9350] = 1,
-    ACTIONS(677), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9367] = 1,
-    ACTIONS(232), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9384] = 1,
-    ACTIONS(679), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9401] = 1,
-    ACTIONS(228), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9418] = 1,
-    ACTIONS(218), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9435] = 1,
-    ACTIONS(681), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9452] = 1,
-    ACTIONS(683), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9469] = 1,
-    ACTIONS(685), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9486] = 1,
-    ACTIONS(687), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9503] = 1,
-    ACTIONS(689), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9520] = 1,
-    ACTIONS(691), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9537] = 1,
-    ACTIONS(234), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9554] = 1,
-    ACTIONS(693), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9571] = 1,
-    ACTIONS(224), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9588] = 1,
-    ACTIONS(695), 14,
-      sym__eof,
-      sym_multi_line_comment,
-      anon_sym_SEMI,
-      anon_sym_BSLASH,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-      sym__bom,
-      sym__unicode_space,
-      anon_sym_SLASH_SLASH,
-  [9605] = 3,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(697), 5,
-      sym__normal_bare_identifier,
-      anon_sym_null,
-      sym__digit,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(699), 7,
-      sym__raw_string,
-      anon_sym_DQUOTE,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_0x,
-      anon_sym_0o,
-      anon_sym_0b,
-  [9625] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(703), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(61), 1,
-      sym__newline,
-    STATE(255), 1,
-      aux_sym_single_line_comment_repeat1,
-    ACTIONS(701), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9648] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(707), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(237), 1,
-      sym__newline,
-    STATE(259), 1,
-      aux_sym_single_line_comment_repeat1,
-    ACTIONS(705), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9671] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(707), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(259), 1,
-      aux_sym_single_line_comment_repeat1,
-    STATE(272), 1,
-      sym__newline,
-    ACTIONS(709), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9694] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(713), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(60), 1,
-      sym__newline,
-    STATE(254), 1,
-      aux_sym_single_line_comment_repeat1,
-    ACTIONS(711), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9717] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(717), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(251), 1,
-      aux_sym_single_line_comment_repeat1,
-    STATE(274), 1,
-      sym__newline,
-    ACTIONS(715), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9740] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(707), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(55), 1,
-      sym__newline,
-    STATE(259), 1,
-      aux_sym_single_line_comment_repeat1,
-    ACTIONS(719), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9763] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(707), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(59), 1,
-      sym__newline,
-    STATE(259), 1,
-      aux_sym_single_line_comment_repeat1,
-    ACTIONS(721), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9786] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(725), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(244), 1,
-      sym__newline,
-    STATE(250), 1,
-      aux_sym_single_line_comment_repeat1,
-    ACTIONS(723), 8,
-      sym__eof,
-      aux_sym__newline_token1,
-      aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9809] = 9,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
+      aux_sym__newline_token8,
+  [8424] = 10,
     ACTIONS(21), 1,
-      sym__raw_string,
-    STATE(68), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-  [9839] = 9,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    STATE(64), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-  [9869] = 4,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(729), 1,
-      aux_sym_single_line_comment_token1,
-    STATE(259), 1,
-      aux_sym_single_line_comment_repeat1,
-    ACTIONS(727), 8,
-      sym__eof,
-      aux_sym__newline_token1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(406), 1,
+      anon_sym_BSLASH,
+    ACTIONS(589), 1,
       aux_sym__newline_token2,
-      aux_sym__newline_token3,
-      aux_sym__newline_token4,
-      aux_sym__newline_token5,
-      aux_sym__newline_token6,
-      aux_sym__newline_token7,
-  [9889] = 9,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(7), 1,
-      sym__normal_bare_identifier,
-    ACTIONS(13), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(21), 1,
-      sym__raw_string,
-    STATE(66), 1,
-      sym_identifier,
-    STATE(192), 1,
-      sym__sign,
-    STATE(194), 1,
-      sym__escaped_string,
-    ACTIONS(15), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    STATE(218), 2,
-      sym__bare_identifier,
-      sym_string,
-  [9919] = 7,
-    ACTIONS(75), 1,
-      anon_sym_LBRACE,
-    ACTIONS(732), 1,
-      anon_sym_BSLASH,
-    STATE(263), 1,
+    STATE(118), 1,
       aux_sym_node_repeat1,
-    STATE(269), 1,
-      sym__escline,
-    STATE(275), 1,
-      sym__node_space,
-    STATE(265), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(734), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [9944] = 7,
-    ACTIONS(81), 1,
-      anon_sym_LBRACE,
-    ACTIONS(736), 1,
-      anon_sym_BSLASH,
-    STATE(262), 1,
-      aux_sym_node_repeat1,
-    STATE(269), 1,
-      sym__escline,
-    STATE(275), 1,
-      sym__node_space,
-    STATE(265), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(739), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [9969] = 7,
-    ACTIONS(77), 1,
-      anon_sym_LBRACE,
-    ACTIONS(732), 1,
-      anon_sym_BSLASH,
-    STATE(262), 1,
-      aux_sym_node_repeat1,
-    STATE(269), 1,
-      sym__escline,
-    STATE(275), 1,
-      sym__node_space,
-    STATE(265), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(734), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [9994] = 8,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(556), 1,
-      anon_sym_EQ,
-    ACTIONS(742), 1,
-      sym___identifier_char_no_digit,
-    ACTIONS(744), 1,
-      anon_sym_0x,
-    ACTIONS(746), 1,
-      anon_sym_0o,
-    ACTIONS(748), 1,
-      anon_sym_0b,
-    STATE(135), 1,
-      sym__integer,
-  [10019] = 5,
-    ACTIONS(149), 1,
-      anon_sym_LBRACE,
-    ACTIONS(750), 1,
-      anon_sym_BSLASH,
     STATE(267), 1,
       sym__escline,
-    STATE(230), 2,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(117), 2,
       sym__ws,
       aux_sym_node_repeat3,
-    ACTIONS(753), 3,
+    ACTIONS(591), 3,
       sym_multi_line_comment,
       sym__bom,
       sym__unicode_space,
-  [10038] = 3,
-    ACTIONS(180), 2,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-    STATE(230), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(756), 3,
+    STATE(208), 3,
+      sym__node_terminator,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(587), 9,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [8468] = 2,
+    ACTIONS(595), 1,
+      aux_sym__newline_token2,
+    ACTIONS(593), 21,
       sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [10052] = 3,
-    ACTIONS(187), 2,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-    STATE(266), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(759), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [10066] = 3,
-    ACTIONS(187), 2,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-    STATE(230), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(762), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [10080] = 3,
-    ACTIONS(149), 2,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-    STATE(268), 2,
-      sym__ws,
-      aux_sym_node_repeat3,
-    ACTIONS(765), 3,
-      sym_multi_line_comment,
-      sym__bom,
-      sym__unicode_space,
-  [10094] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(768), 1,
-      sym__digit,
-    STATE(200), 1,
-      sym__integer,
-    STATE(287), 1,
-      sym__sign,
-    ACTIONS(770), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [10111] = 6,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(33), 1,
-      sym__digit,
-    ACTIONS(744), 1,
-      anon_sym_0x,
-    ACTIONS(746), 1,
-      anon_sym_0o,
-    ACTIONS(748), 1,
-      anon_sym_0b,
-    STATE(135), 1,
-      sym__integer,
-  [10130] = 1,
-    ACTIONS(218), 5,
-      sym_multi_line_comment,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
       sym__bom,
       sym__unicode_space,
-  [10138] = 5,
-    ACTIONS(3), 1,
+      anon_sym_SLASH_SLASH,
+  [8495] = 2,
+    ACTIONS(599), 1,
+      aux_sym__newline_token2,
+    ACTIONS(597), 21,
       sym_multi_line_comment,
-    ACTIONS(772), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(774), 1,
-      aux_sym__escaped_string_token1,
-    ACTIONS(776), 1,
-      sym_escape,
-    STATE(282), 1,
-      aux_sym__escaped_string_repeat1,
-  [10154] = 1,
-    ACTIONS(234), 5,
-      sym_multi_line_comment,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-      sym__bom,
-      sym__unicode_space,
-  [10162] = 1,
-    ACTIONS(232), 5,
-      sym_multi_line_comment,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-      sym__bom,
-      sym__unicode_space,
-  [10170] = 1,
-    ACTIONS(224), 5,
-      sym_multi_line_comment,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-      sym__bom,
-      sym__unicode_space,
-  [10178] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(774), 1,
-      aux_sym__escaped_string_token1,
-    ACTIONS(776), 1,
-      sym_escape,
-    ACTIONS(778), 1,
-      anon_sym_DQUOTE,
-    STATE(283), 1,
-      aux_sym__escaped_string_repeat1,
-  [10194] = 4,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(780), 1,
-      sym__identifier_char,
-    STATE(279), 1,
-      aux_sym__bare_identifier_repeat1,
-    ACTIONS(544), 2,
-      anon_sym_EQ,
-      anon_sym_RPAREN,
-  [10208] = 4,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(782), 1,
-      sym__identifier_char,
-    STATE(279), 1,
-      aux_sym__bare_identifier_repeat1,
-    ACTIONS(539), 2,
-      anon_sym_EQ,
-      anon_sym_RPAREN,
-  [10222] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(774), 1,
-      aux_sym__escaped_string_token1,
-    ACTIONS(776), 1,
-      sym_escape,
-    ACTIONS(785), 1,
-      anon_sym_DQUOTE,
-    STATE(277), 1,
-      aux_sym__escaped_string_repeat1,
-  [10238] = 1,
-    ACTIONS(228), 5,
-      sym_multi_line_comment,
-      anon_sym_LBRACE,
-      anon_sym_BSLASH,
-      sym__bom,
-      sym__unicode_space,
-  [10246] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(774), 1,
-      aux_sym__escaped_string_token1,
-    ACTIONS(776), 1,
-      sym_escape,
-    ACTIONS(787), 1,
-      anon_sym_DQUOTE,
-    STATE(283), 1,
-      aux_sym__escaped_string_repeat1,
-  [10262] = 5,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(789), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(791), 1,
-      aux_sym__escaped_string_token1,
-    ACTIONS(794), 1,
-      sym_escape,
-    STATE(283), 1,
-      aux_sym__escaped_string_repeat1,
-  [10278] = 4,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(797), 1,
-      sym__identifier_char,
-    STATE(278), 1,
-      aux_sym__bare_identifier_repeat1,
-    ACTIONS(548), 2,
-      anon_sym_EQ,
-      anon_sym_RPAREN,
-  [10292] = 3,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(801), 1,
-      aux_sym__escaped_string_token1,
-    ACTIONS(799), 2,
-      anon_sym_DQUOTE,
-      sym_escape,
-  [10303] = 3,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(768), 1,
-      sym__digit,
-    STATE(174), 1,
-      sym__integer,
-  [10313] = 3,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(768), 1,
-      sym__digit,
-    STATE(204), 1,
-      sym__integer,
-  [10323] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(803), 2,
-      anon_sym_0,
-      anon_sym_1,
-  [10331] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(805), 2,
-      anon_sym_0,
-      anon_sym_1,
-  [10339] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(554), 2,
-      anon_sym_EQ,
-      anon_sym_RPAREN,
-  [10347] = 3,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(768), 1,
-      sym__digit,
-    STATE(180), 1,
-      sym__integer,
-  [10357] = 3,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(556), 1,
-      anon_sym_RPAREN,
-    ACTIONS(742), 1,
-      sym___identifier_char_no_digit,
-  [10367] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(581), 1,
-      anon_sym_RPAREN,
-  [10374] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(579), 1,
-      anon_sym_RPAREN,
-  [10381] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(807), 1,
-      anon_sym_EQ,
-  [10388] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(566), 1,
-      anon_sym_RPAREN,
-  [10395] = 2,
-    ACTIONS(3), 1,
-      sym_multi_line_comment,
-    ACTIONS(809), 1,
+      sym_multi_line_string,
+      sym__raw_string,
       ts_builtin_sym_end,
-  [10402] = 2,
-    ACTIONS(3), 1,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8522] = 2,
+    ACTIONS(603), 1,
+      aux_sym__newline_token2,
+    ACTIONS(601), 21,
       sym_multi_line_comment,
-    ACTIONS(811), 1,
-      sym__hex_digit,
-  [10409] = 2,
-    ACTIONS(3), 1,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8549] = 16,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(98), 1,
+      sym_identifier,
+    STATE(192), 1,
+      aux_sym_node_repeat1,
+    STATE(221), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
       sym_multi_line_comment,
-    ACTIONS(813), 1,
+      sym__bom,
+      sym__unicode_space,
+  [8604] = 2,
+    ACTIONS(607), 1,
+      aux_sym__newline_token2,
+    ACTIONS(605), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8631] = 2,
+    ACTIONS(611), 1,
+      aux_sym__newline_token2,
+    ACTIONS(609), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8658] = 2,
+    ACTIONS(615), 1,
+      aux_sym__newline_token2,
+    ACTIONS(613), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8685] = 2,
+    ACTIONS(619), 1,
+      aux_sym__newline_token2,
+    ACTIONS(617), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8712] = 2,
+    ACTIONS(623), 1,
+      aux_sym__newline_token2,
+    ACTIONS(621), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8739] = 2,
+    ACTIONS(627), 1,
+      aux_sym__newline_token2,
+    ACTIONS(625), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8766] = 2,
+    ACTIONS(631), 1,
+      aux_sym__newline_token2,
+    ACTIONS(629), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8793] = 2,
+    ACTIONS(635), 1,
+      aux_sym__newline_token2,
+    ACTIONS(633), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8820] = 2,
+    ACTIONS(639), 1,
+      aux_sym__newline_token2,
+    ACTIONS(637), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8847] = 2,
+    ACTIONS(643), 1,
+      aux_sym__newline_token2,
+    ACTIONS(641), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8874] = 2,
+    ACTIONS(647), 1,
+      aux_sym__newline_token2,
+    ACTIONS(645), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8901] = 2,
+    ACTIONS(651), 1,
+      aux_sym__newline_token2,
+    ACTIONS(649), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8928] = 2,
+    ACTIONS(655), 1,
+      aux_sym__newline_token2,
+    ACTIONS(653), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8955] = 2,
+    ACTIONS(659), 1,
+      aux_sym__newline_token2,
+    ACTIONS(657), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [8982] = 2,
+    ACTIONS(663), 1,
+      aux_sym__newline_token2,
+    ACTIONS(661), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9009] = 2,
+    ACTIONS(667), 1,
+      aux_sym__newline_token2,
+    ACTIONS(665), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9036] = 2,
+    ACTIONS(671), 1,
+      aux_sym__newline_token2,
+    ACTIONS(669), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9063] = 2,
+    ACTIONS(675), 1,
+      aux_sym__newline_token2,
+    ACTIONS(673), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9090] = 2,
+    ACTIONS(679), 1,
+      aux_sym__newline_token2,
+    ACTIONS(677), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9117] = 2,
+    ACTIONS(683), 1,
+      aux_sym__newline_token2,
+    ACTIONS(681), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9144] = 2,
+    ACTIONS(687), 1,
+      aux_sym__newline_token2,
+    ACTIONS(685), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9171] = 2,
+    ACTIONS(691), 1,
+      aux_sym__newline_token2,
+    ACTIONS(689), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9198] = 2,
+    ACTIONS(695), 1,
+      aux_sym__newline_token2,
+    ACTIONS(693), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9225] = 2,
+    ACTIONS(699), 1,
+      aux_sym__newline_token2,
+    ACTIONS(697), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9252] = 2,
+    ACTIONS(703), 1,
+      sym__digit,
+    ACTIONS(701), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [9279] = 2,
+    ACTIONS(707), 1,
+      aux_sym__newline_token2,
+    ACTIONS(705), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9306] = 16,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(11), 1,
+      anon_sym_LPAREN,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(17), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(94), 1,
+      sym_identifier,
+    STATE(231), 1,
+      sym_type,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [9361] = 2,
+    ACTIONS(711), 1,
+      aux_sym__newline_token2,
+    ACTIONS(709), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9388] = 2,
+    ACTIONS(715), 1,
+      sym__digit,
+    ACTIONS(713), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [9415] = 2,
+    ACTIONS(719), 1,
+      aux_sym__newline_token2,
+    ACTIONS(717), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9442] = 2,
+    ACTIONS(723), 1,
+      aux_sym__newline_token2,
+    ACTIONS(721), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9469] = 2,
+    ACTIONS(727), 1,
+      aux_sym__newline_token2,
+    ACTIONS(725), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9496] = 2,
+    ACTIONS(731), 1,
+      aux_sym__newline_token2,
+    ACTIONS(729), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9523] = 2,
+    ACTIONS(733), 1,
+      aux_sym__newline_token2,
+    ACTIONS(213), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9550] = 2,
+    ACTIONS(737), 1,
+      aux_sym__newline_token2,
+    ACTIONS(735), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9577] = 2,
+    ACTIONS(741), 1,
+      aux_sym__newline_token2,
+    ACTIONS(739), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9604] = 2,
+    ACTIONS(745), 1,
+      aux_sym__newline_token2,
+    ACTIONS(743), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9631] = 2,
+    ACTIONS(749), 1,
+      aux_sym__newline_token2,
+    ACTIONS(747), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9658] = 2,
+    ACTIONS(753), 1,
+      aux_sym__newline_token2,
+    ACTIONS(751), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9685] = 2,
+    ACTIONS(757), 1,
+      aux_sym__newline_token2,
+    ACTIONS(755), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9712] = 2,
+    ACTIONS(761), 1,
+      aux_sym__newline_token2,
+    ACTIONS(759), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9739] = 2,
+    ACTIONS(765), 1,
+      aux_sym__newline_token2,
+    ACTIONS(763), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9766] = 2,
+    ACTIONS(769), 1,
+      aux_sym__newline_token2,
+    ACTIONS(767), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9793] = 2,
+    ACTIONS(773), 1,
+      sym__digit,
+    ACTIONS(771), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      anon_sym_null,
+      anon_sym_POUNDnull,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_0x,
+      anon_sym_0o,
+      anon_sym_0b,
+      anon_sym_POUNDinf,
+      anon_sym_POUND_DASHinf,
+      anon_sym_POUNDnan,
+      anon_sym_true,
+      anon_sym_false,
+      anon_sym_POUNDtrue,
+      anon_sym_POUNDfalse,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [9820] = 2,
+    ACTIONS(777), 1,
+      aux_sym__newline_token2,
+    ACTIONS(775), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9847] = 2,
+    ACTIONS(781), 1,
+      aux_sym__newline_token2,
+    ACTIONS(779), 21,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      ts_builtin_sym_end,
+      anon_sym_SLASH_DASH,
+      anon_sym_RBRACE,
+      sym__normal_bare_identifier,
+      anon_sym_LPAREN,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9874] = 4,
+    ACTIONS(788), 1,
+      aux_sym__newline_token2,
+    STATE(212), 1,
+      aux_sym__binary_repeat1,
+    ACTIONS(785), 3,
+      anon_sym__,
+      anon_sym_0,
+      anon_sym_1,
+    ACTIONS(783), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9904] = 4,
+    ACTIONS(794), 1,
+      aux_sym__newline_token2,
+    STATE(217), 1,
+      aux_sym__binary_repeat1,
+    ACTIONS(792), 3,
+      anon_sym__,
+      anon_sym_0,
+      anon_sym_1,
+    ACTIONS(790), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9934] = 5,
+    ACTIONS(798), 1,
+      anon_sym_DOT,
+    ACTIONS(802), 1,
+      aux_sym__newline_token2,
+    STATE(275), 1,
+      sym__exponent,
+    ACTIONS(800), 2,
+      anon_sym_e,
+      anon_sym_E,
+    ACTIONS(796), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9966] = 5,
+    ACTIONS(806), 1,
+      anon_sym_DOT,
+    ACTIONS(808), 1,
+      aux_sym__newline_token2,
+    STATE(273), 1,
+      sym__exponent,
+    ACTIONS(800), 2,
+      anon_sym_e,
+      anon_sym_E,
+    ACTIONS(804), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [9998] = 4,
+    ACTIONS(814), 1,
+      aux_sym__newline_token2,
+    STATE(212), 1,
+      aux_sym__binary_repeat1,
+    ACTIONS(812), 3,
+      anon_sym__,
+      anon_sym_0,
+      anon_sym_1,
+    ACTIONS(810), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10028] = 4,
+    ACTIONS(818), 1,
+      aux_sym__newline_token2,
+    STATE(212), 1,
+      aux_sym__binary_repeat1,
+    ACTIONS(812), 3,
+      anon_sym__,
+      anon_sym_0,
+      anon_sym_1,
+    ACTIONS(816), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10058] = 4,
+    ACTIONS(818), 1,
+      aux_sym__newline_token2,
+    STATE(216), 1,
+      aux_sym__binary_repeat1,
+    ACTIONS(820), 3,
+      anon_sym__,
+      anon_sym_0,
+      anon_sym_1,
+    ACTIONS(816), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10088] = 4,
+    ACTIONS(826), 1,
+      aux_sym__newline_token2,
+    STATE(225), 1,
+      aux_sym__octal_repeat1,
+    ACTIONS(824), 2,
+      anon_sym__,
       aux_sym__octal_token1,
-  [10416] = 2,
-    ACTIONS(3), 1,
+    ACTIONS(822), 16,
+      sym__eof,
       sym_multi_line_comment,
-    ACTIONS(815), 1,
-      aux_sym__octal_token1,
-  [10423] = 2,
-    ACTIONS(3), 1,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10117] = 4,
+    ACTIONS(830), 1,
+      aux_sym__newline_token2,
+    STATE(256), 1,
+      sym__exponent,
+    ACTIONS(800), 2,
+      anon_sym_e,
+      anon_sym_E,
+    ACTIONS(828), 16,
+      sym__eof,
       sym_multi_line_comment,
-    ACTIONS(817), 1,
-      anon_sym_RPAREN,
-  [10430] = 2,
-    ACTIONS(3), 1,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10146] = 14,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(93), 1,
+      sym_identifier,
+    STATE(232), 1,
+      aux_sym_node_repeat1,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
       sym_multi_line_comment,
-    ACTIONS(819), 1,
+      sym__bom,
+      sym__unicode_space,
+  [10195] = 14,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(17), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(95), 1,
+      sym_identifier,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [10244] = 4,
+    ACTIONS(837), 1,
+      aux_sym__newline_token2,
+    STATE(223), 1,
+      aux_sym__hex_repeat1,
+    ACTIONS(834), 2,
       sym__hex_digit,
-  [10437] = 2,
+      anon_sym__,
+    ACTIONS(832), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10273] = 4,
+    ACTIONS(844), 1,
+      aux_sym__newline_token2,
+    STATE(224), 1,
+      aux_sym__octal_repeat1,
+    ACTIONS(841), 2,
+      anon_sym__,
+      aux_sym__octal_token1,
+    ACTIONS(839), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10302] = 4,
+    ACTIONS(850), 1,
+      aux_sym__newline_token2,
+    STATE(224), 1,
+      aux_sym__octal_repeat1,
+    ACTIONS(848), 2,
+      anon_sym__,
+      aux_sym__octal_token1,
+    ACTIONS(846), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10331] = 4,
+    ACTIONS(856), 1,
+      aux_sym__newline_token2,
+    STATE(223), 1,
+      aux_sym__hex_repeat1,
+    ACTIONS(854), 2,
+      sym__hex_digit,
+      anon_sym__,
+    ACTIONS(852), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10360] = 4,
+    ACTIONS(860), 1,
+      aux_sym__newline_token2,
+    STATE(223), 1,
+      aux_sym__hex_repeat1,
+    ACTIONS(854), 2,
+      sym__hex_digit,
+      anon_sym__,
+    ACTIONS(858), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10389] = 4,
+    ACTIONS(864), 1,
+      aux_sym__newline_token2,
+    STATE(224), 1,
+      aux_sym__octal_repeat1,
+    ACTIONS(848), 2,
+      anon_sym__,
+      aux_sym__octal_token1,
+    ACTIONS(862), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10418] = 4,
+    ACTIONS(850), 1,
+      aux_sym__newline_token2,
+    STATE(228), 1,
+      aux_sym__octal_repeat1,
+    ACTIONS(866), 2,
+      anon_sym__,
+      aux_sym__octal_token1,
+    ACTIONS(846), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10447] = 4,
+    ACTIONS(870), 1,
+      aux_sym__newline_token2,
+    STATE(258), 1,
+      sym__exponent,
+    ACTIONS(800), 2,
+      anon_sym_e,
+      anon_sym_E,
+    ACTIONS(868), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10476] = 14,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(104), 1,
+      sym_identifier,
+    STATE(222), 1,
+      aux_sym_node_repeat1,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [10525] = 14,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(17), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(103), 1,
+      sym_identifier,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [10574] = 8,
+    ACTIONS(109), 1,
+      aux_sym__newline_token2,
+    ACTIONS(872), 1,
+      anon_sym_BSLASH,
+    STATE(233), 1,
+      aux_sym_node_repeat1,
+    STATE(267), 1,
+      sym__escline,
+    STATE(297), 1,
+      sym__node_space,
+    STATE(248), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(875), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(111), 10,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [10611] = 14,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(17), 1,
+      aux_sym_node_repeat1,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(93), 1,
+      sym_identifier,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [10660] = 14,
+    ACTIONS(7), 1,
+      sym__normal_bare_identifier,
+    ACTIONS(13), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(103), 1,
+      anon_sym_BSLASH,
+    STATE(20), 1,
+      sym__escline,
+    STATE(29), 1,
+      sym__node_space,
+    STATE(98), 1,
+      sym_identifier,
+    STATE(234), 1,
+      aux_sym_node_repeat1,
+    STATE(243), 1,
+      sym__sign,
+    STATE(247), 1,
+      sym__escaped_string,
+    ACTIONS(15), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+    ACTIONS(23), 2,
+      sym_multi_line_string,
+      sym__raw_string,
+    STATE(18), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(268), 2,
+      sym__bare_identifier,
+      sym_string,
+    ACTIONS(105), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [10709] = 4,
+    ACTIONS(882), 1,
+      aux_sym__newline_token2,
+    STATE(226), 1,
+      aux_sym__hex_repeat1,
+    ACTIONS(880), 2,
+      sym__hex_digit,
+      anon_sym__,
+    ACTIONS(878), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10738] = 4,
+    ACTIONS(856), 1,
+      aux_sym__newline_token2,
+    STATE(227), 1,
+      aux_sym__hex_repeat1,
+    ACTIONS(884), 2,
+      sym__hex_digit,
+      anon_sym__,
+    ACTIONS(852), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10767] = 4,
+    ACTIONS(888), 1,
+      sym__identifier_char,
+    ACTIONS(890), 1,
+      aux_sym__newline_token2,
+    STATE(239), 1,
+      aux_sym__bare_identifier_repeat1,
+    ACTIONS(886), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10795] = 4,
+    ACTIONS(894), 1,
+      sym__identifier_char,
+    ACTIONS(897), 1,
+      aux_sym__newline_token2,
+    STATE(239), 1,
+      aux_sym__bare_identifier_repeat1,
+    ACTIONS(892), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10823] = 4,
+    ACTIONS(901), 1,
+      sym__identifier_char,
+    ACTIONS(903), 1,
+      aux_sym__newline_token2,
+    STATE(238), 1,
+      aux_sym__bare_identifier_repeat1,
+    ACTIONS(899), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10851] = 2,
+    ACTIONS(907), 1,
+      aux_sym__newline_token2,
+    ACTIONS(905), 17,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_EQ,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10874] = 4,
+    ACTIONS(152), 1,
+      aux_sym__newline_token2,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(909), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(154), 12,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [10901] = 3,
+    ACTIONS(914), 1,
+      sym___identifier_char_no_digit,
+    ACTIONS(916), 1,
+      aux_sym__newline_token2,
+    ACTIONS(912), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10926] = 4,
+    ACTIONS(920), 1,
+      anon_sym_EQ,
+    ACTIONS(925), 1,
+      aux_sym__newline_token2,
+    ACTIONS(922), 4,
+      sym_multi_line_comment,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(918), 12,
+      sym__eof,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [10953] = 2,
+    ACTIONS(929), 1,
+      aux_sym__newline_token2,
+    ACTIONS(927), 17,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_EQ,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [10976] = 6,
+    ACTIONS(934), 1,
+      anon_sym_BSLASH,
+    ACTIONS(938), 1,
+      aux_sym__newline_token2,
+    STATE(249), 1,
+      sym__escline,
+    STATE(270), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(941), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(931), 10,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11007] = 2,
+    ACTIONS(947), 1,
+      aux_sym__newline_token2,
+    ACTIONS(945), 17,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_EQ,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11030] = 6,
+    ACTIONS(119), 1,
+      aux_sym__newline_token2,
+    ACTIONS(949), 1,
+      anon_sym_BSLASH,
+    STATE(249), 1,
+      sym__escline,
+    STATE(270), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(952), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(121), 10,
+      sym__eof,
+      anon_sym_SEMI,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11061] = 4,
+    ACTIONS(129), 1,
+      aux_sym__newline_token2,
+    STATE(271), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(955), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(131), 11,
+      sym__eof,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11087] = 2,
+    ACTIONS(960), 1,
+      aux_sym__newline_token2,
+    ACTIONS(958), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11109] = 2,
+    ACTIONS(964), 1,
+      aux_sym__newline_token2,
+    ACTIONS(962), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11131] = 2,
+    ACTIONS(968), 1,
+      aux_sym__newline_token2,
+    ACTIONS(966), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11153] = 2,
+    ACTIONS(507), 1,
+      aux_sym__newline_token2,
+    ACTIONS(502), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11175] = 2,
+    ACTIONS(972), 1,
+      aux_sym__newline_token2,
+    ACTIONS(970), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11197] = 2,
+    ACTIONS(976), 1,
+      aux_sym__newline_token2,
+    ACTIONS(974), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11219] = 2,
+    ACTIONS(980), 1,
+      aux_sym__newline_token2,
+    ACTIONS(978), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11241] = 2,
+    ACTIONS(984), 1,
+      aux_sym__newline_token2,
+    ACTIONS(982), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11263] = 2,
+    ACTIONS(988), 1,
+      aux_sym__newline_token2,
+    ACTIONS(986), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11285] = 2,
+    ACTIONS(992), 1,
+      aux_sym__newline_token2,
+    ACTIONS(990), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11307] = 2,
+    ACTIONS(996), 1,
+      aux_sym__newline_token2,
+    ACTIONS(994), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11329] = 2,
+    ACTIONS(1000), 1,
+      aux_sym__newline_token2,
+    ACTIONS(998), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11351] = 4,
+    ACTIONS(1005), 1,
+      aux_sym__newline_token2,
+    STATE(270), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1008), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1002), 11,
+      sym__eof,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11377] = 2,
+    ACTIONS(1014), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1012), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11399] = 4,
+    ACTIONS(129), 1,
+      aux_sym__newline_token2,
+    STATE(270), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1016), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(131), 11,
+      sym__eof,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11425] = 4,
+    ACTIONS(1022), 1,
+      aux_sym__newline_token2,
+    STATE(262), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1025), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1019), 11,
+      sym__eof,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11451] = 2,
+    ACTIONS(1031), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1029), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11473] = 4,
+    ACTIONS(119), 1,
+      aux_sym__newline_token2,
+    STATE(264), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1033), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(121), 11,
+      sym__eof,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11499] = 2,
+    ACTIONS(1036), 1,
+      aux_sym__newline_token2,
+    ACTIONS(920), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11521] = 2,
+    ACTIONS(1040), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1038), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11543] = 4,
+    ACTIONS(152), 1,
+      aux_sym__newline_token2,
+    STATE(270), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1042), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(154), 11,
+      sym__eof,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11569] = 4,
+    ACTIONS(139), 1,
+      aux_sym__newline_token2,
+    STATE(270), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1045), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(141), 11,
+      sym__eof,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      anon_sym_SLASH_SLASH,
+  [11595] = 2,
+    ACTIONS(1050), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1048), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11617] = 2,
+    ACTIONS(802), 1,
+      aux_sym__newline_token2,
+    ACTIONS(796), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11639] = 2,
+    ACTIONS(925), 1,
+      aux_sym__newline_token2,
+    ACTIONS(918), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11661] = 2,
+    ACTIONS(1054), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1052), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11683] = 2,
+    ACTIONS(1058), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1056), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11705] = 2,
+    ACTIONS(1062), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1060), 16,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SLASH_DASH,
+      anon_sym_LBRACE,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [11727] = 6,
+    ACTIONS(1066), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1070), 1,
+      anon_sym_SLASH_SLASH,
+    STATE(108), 2,
+      sym__newline,
+      sym_single_line_comment,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1068), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1064), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11756] = 6,
+    ACTIONS(1074), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1078), 1,
+      anon_sym_SLASH_SLASH,
+    STATE(48), 2,
+      sym__newline,
+      sym_single_line_comment,
+    STATE(283), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1076), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1072), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11785] = 6,
+    ACTIONS(1070), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(1082), 1,
+      aux_sym__newline_token2,
+    STATE(105), 2,
+      sym__newline,
+      sym_single_line_comment,
+    STATE(278), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1084), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1080), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11814] = 6,
+    ACTIONS(1088), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1090), 1,
+      anon_sym_SLASH_SLASH,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(300), 2,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(1068), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1086), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11843] = 6,
+    ACTIONS(1094), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1098), 1,
+      anon_sym_SLASH_SLASH,
+    STATE(286), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(342), 2,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(1096), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1092), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11872] = 6,
+    ACTIONS(1078), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(1102), 1,
+      aux_sym__newline_token2,
+    STATE(46), 2,
+      sym__newline,
+      sym_single_line_comment,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1068), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1100), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11901] = 6,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(1106), 1,
+      aux_sym__newline_token2,
+    STATE(28), 2,
+      sym__newline,
+      sym_single_line_comment,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1068), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1104), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11930] = 6,
+    ACTIONS(21), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(1110), 1,
+      aux_sym__newline_token2,
+    STATE(26), 2,
+      sym__newline,
+      sym_single_line_comment,
+    STATE(284), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1112), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1108), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11959] = 6,
+    ACTIONS(1098), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(1116), 1,
+      aux_sym__newline_token2,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(340), 2,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(1068), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1114), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [11988] = 6,
+    ACTIONS(1090), 1,
+      anon_sym_SLASH_SLASH,
+    ACTIONS(1120), 1,
+      aux_sym__newline_token2,
+    STATE(281), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    STATE(299), 2,
+      sym__newline,
+      sym_single_line_comment,
+    ACTIONS(1122), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(1118), 7,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12017] = 2,
+    ACTIONS(1126), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1124), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12037] = 2,
+    ACTIONS(1130), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1128), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12057] = 2,
+    ACTIONS(1134), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1132), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12077] = 2,
+    ACTIONS(1138), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1136), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12097] = 2,
+    ACTIONS(1142), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1140), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12117] = 2,
+    ACTIONS(1146), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1144), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12137] = 2,
+    ACTIONS(1150), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1148), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12157] = 2,
+    ACTIONS(1154), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1152), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12177] = 2,
+    ACTIONS(1158), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1156), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12197] = 2,
+    ACTIONS(174), 1,
+      aux_sym__newline_token2,
+    ACTIONS(176), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12217] = 2,
+    ACTIONS(95), 1,
+      aux_sym__newline_token2,
+    ACTIONS(93), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12237] = 2,
+    ACTIONS(164), 1,
+      aux_sym__newline_token2,
+    ACTIONS(166), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12257] = 2,
+    ACTIONS(170), 1,
+      aux_sym__newline_token2,
+    ACTIONS(172), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12277] = 2,
+    ACTIONS(91), 1,
+      aux_sym__newline_token2,
+    ACTIONS(89), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12297] = 2,
+    ACTIONS(1162), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1160), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12317] = 2,
+    ACTIONS(1166), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1164), 14,
+      sym__eof,
+      sym_multi_line_comment,
+      anon_sym_SEMI,
+      anon_sym_BSLASH,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+      sym__bom,
+      sym__unicode_space,
+      anon_sym_SLASH_SLASH,
+  [12337] = 6,
     ACTIONS(3), 1,
       sym_multi_line_comment,
-    ACTIONS(821), 1,
+    ACTIONS(1170), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1172), 1,
+      aux_sym_single_line_comment_token1,
+    STATE(49), 1,
+      sym__newline,
+    STATE(312), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1168), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12363] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1176), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1178), 1,
+      aux_sym_single_line_comment_token1,
+    STATE(298), 1,
+      sym__newline,
+    STATE(307), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1174), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12389] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1182), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1184), 1,
+      aux_sym_single_line_comment_token1,
+    STATE(12), 1,
+      sym__newline,
+    STATE(308), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1180), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12415] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1188), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1190), 1,
+      aux_sym_single_line_comment_token1,
+    STATE(301), 1,
+      sym__newline,
+    STATE(314), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1186), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12441] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1190), 1,
+      aux_sym_single_line_comment_token1,
+    ACTIONS(1194), 1,
+      aux_sym__newline_token2,
+    STATE(11), 1,
+      sym__newline,
+    STATE(314), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1192), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12467] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1198), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1200), 1,
+      aux_sym_single_line_comment_token1,
+    STATE(111), 1,
+      sym__newline,
+    STATE(310), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1196), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12493] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1190), 1,
+      aux_sym_single_line_comment_token1,
+    ACTIONS(1204), 1,
+      aux_sym__newline_token2,
+    STATE(109), 1,
+      sym__newline,
+    STATE(314), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1202), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12519] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1208), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1210), 1,
+      aux_sym_single_line_comment_token1,
+    STATE(313), 1,
+      aux_sym_single_line_comment_repeat1,
+    STATE(343), 1,
+      sym__newline,
+    ACTIONS(1206), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12545] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1190), 1,
+      aux_sym_single_line_comment_token1,
+    ACTIONS(1214), 1,
+      aux_sym__newline_token2,
+    STATE(45), 1,
+      sym__newline,
+    STATE(314), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1212), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12571] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1190), 1,
+      aux_sym_single_line_comment_token1,
+    ACTIONS(1218), 1,
+      aux_sym__newline_token2,
+    STATE(314), 1,
+      aux_sym_single_line_comment_repeat1,
+    STATE(341), 1,
+      sym__newline,
+    ACTIONS(1216), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12597] = 5,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1222), 1,
+      aux_sym__newline_token2,
+    ACTIONS(1224), 1,
+      aux_sym_single_line_comment_token1,
+    STATE(314), 1,
+      aux_sym_single_line_comment_repeat1,
+    ACTIONS(1220), 8,
+      sym__eof,
+      aux_sym__newline_token1,
+      aux_sym__newline_token3,
+      aux_sym__newline_token4,
+      aux_sym__newline_token5,
+      aux_sym__newline_token6,
+      aux_sym__newline_token7,
+      aux_sym__newline_token8,
+  [12620] = 7,
+    ACTIONS(1227), 1,
+      anon_sym_BSLASH,
+    STATE(315), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(111), 3,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
       anon_sym_RPAREN,
+    ACTIONS(1230), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12647] = 7,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(1233), 1,
+      sym___identifier_char_no_digit,
+    ACTIONS(1235), 1,
+      anon_sym_0x,
+    ACTIONS(1237), 1,
+      anon_sym_0o,
+    ACTIONS(1239), 1,
+      anon_sym_0b,
+    STATE(214), 1,
+      sym__integer,
+    ACTIONS(912), 5,
+      sym_multi_line_comment,
+      anon_sym_EQ,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [12673] = 1,
+    ACTIONS(701), 10,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      sym__normal_bare_identifier,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [12686] = 7,
+    ACTIONS(1241), 1,
+      anon_sym_RPAREN,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    STATE(315), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12711] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1247), 1,
+      anon_sym_RPAREN,
+    STATE(318), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12736] = 7,
+    ACTIONS(168), 1,
+      anon_sym_LBRACE,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    STATE(315), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12761] = 5,
+    ACTIONS(1249), 1,
+      anon_sym_BSLASH,
+    STATE(334), 1,
+      sym__escline,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(121), 3,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+    ACTIONS(1252), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12782] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1255), 1,
+      anon_sym_EQ,
+    STATE(315), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12807] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1257), 1,
+      anon_sym_RPAREN,
+    STATE(328), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12832] = 1,
+    ACTIONS(713), 10,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      sym__normal_bare_identifier,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [12845] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1259), 1,
+      anon_sym_RPAREN,
+    STATE(315), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12870] = 1,
+    ACTIONS(771), 10,
+      sym_multi_line_comment,
+      sym_multi_line_string,
+      sym__raw_string,
+      sym__normal_bare_identifier,
+      anon_sym_DQUOTE,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [12883] = 7,
+    ACTIONS(162), 1,
+      anon_sym_LBRACE,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    STATE(320), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12908] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1261), 1,
+      anon_sym_RPAREN,
+    STATE(315), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12933] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1261), 1,
+      anon_sym_RPAREN,
+    STATE(331), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12958] = 7,
+    ACTIONS(1241), 1,
+      anon_sym_RPAREN,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    STATE(325), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [12983] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1263), 1,
+      anon_sym_RPAREN,
+    STATE(315), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [13008] = 7,
+    ACTIONS(1243), 1,
+      anon_sym_BSLASH,
+    ACTIONS(1265), 1,
+      anon_sym_EQ,
+    STATE(322), 1,
+      aux_sym_node_repeat1,
+    STATE(336), 1,
+      sym__escline,
+    STATE(344), 1,
+      sym__node_space,
+    STATE(321), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1245), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+  [13033] = 3,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1267), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(141), 4,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+  [13049] = 3,
+    STATE(333), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1270), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(131), 4,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+  [13065] = 3,
+    STATE(242), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1273), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(131), 4,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+  [13081] = 3,
+    STATE(335), 2,
+      sym__ws,
+      aux_sym_node_repeat3,
+    ACTIONS(1276), 3,
+      sym_multi_line_comment,
+      sym__bom,
+      sym__unicode_space,
+    ACTIONS(121), 4,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+  [13097] = 3,
+    ACTIONS(1279), 1,
+      sym__identifier_char,
+    STATE(337), 1,
+      aux_sym__bare_identifier_repeat1,
+    ACTIONS(892), 6,
+      sym_multi_line_comment,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13112] = 3,
+    ACTIONS(1282), 1,
+      sym__identifier_char,
+    STATE(337), 1,
+      aux_sym__bare_identifier_repeat1,
+    ACTIONS(886), 6,
+      sym_multi_line_comment,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13127] = 3,
+    ACTIONS(1284), 1,
+      sym__identifier_char,
+    STATE(338), 1,
+      aux_sym__bare_identifier_repeat1,
+    ACTIONS(899), 6,
+      sym_multi_line_comment,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13142] = 1,
+    ACTIONS(172), 7,
+      sym_multi_line_comment,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13152] = 1,
+    ACTIONS(89), 7,
+      sym_multi_line_comment,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13162] = 1,
+    ACTIONS(166), 7,
+      sym_multi_line_comment,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13172] = 1,
+    ACTIONS(93), 7,
+      sym_multi_line_comment,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13182] = 1,
+    ACTIONS(176), 7,
+      sym_multi_line_comment,
+      anon_sym_LBRACE,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13192] = 5,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1286), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(1288), 1,
+      aux_sym__escaped_string_token1,
+    STATE(345), 1,
+      aux_sym__escaped_string_repeat1,
+    ACTIONS(1291), 2,
+      sym_escape,
+      sym_escaped_whitespace,
+  [13209] = 5,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1294), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(1296), 1,
+      aux_sym__escaped_string_token1,
+    STATE(350), 1,
+      aux_sym__escaped_string_repeat1,
+    ACTIONS(1298), 2,
+      sym_escape,
+      sym_escaped_whitespace,
+  [13226] = 5,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1296), 1,
+      aux_sym__escaped_string_token1,
+    ACTIONS(1300), 1,
+      anon_sym_DQUOTE,
+    STATE(349), 1,
+      aux_sym__escaped_string_repeat1,
+    ACTIONS(1298), 2,
+      sym_escape,
+      sym_escaped_whitespace,
+  [13243] = 2,
+    ACTIONS(1233), 1,
+      sym___identifier_char_no_digit,
+    ACTIONS(912), 5,
+      sym_multi_line_comment,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13254] = 5,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1296), 1,
+      aux_sym__escaped_string_token1,
+    ACTIONS(1302), 1,
+      anon_sym_DQUOTE,
+    STATE(345), 1,
+      aux_sym__escaped_string_repeat1,
+    ACTIONS(1298), 2,
+      sym_escape,
+      sym_escaped_whitespace,
+  [13271] = 5,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1296), 1,
+      aux_sym__escaped_string_token1,
+    ACTIONS(1304), 1,
+      anon_sym_DQUOTE,
+    STATE(345), 1,
+      aux_sym__escaped_string_repeat1,
+    ACTIONS(1298), 2,
+      sym_escape,
+      sym_escaped_whitespace,
+  [13288] = 1,
+    ACTIONS(920), 6,
+      sym_multi_line_comment,
+      anon_sym_EQ,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13297] = 5,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1306), 1,
+      sym__digit,
+    STATE(277), 1,
+      sym__integer,
+    STATE(359), 1,
+      sym__sign,
+    ACTIONS(1308), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [13314] = 6,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(37), 1,
+      sym__digit,
+    ACTIONS(1235), 1,
+      anon_sym_0x,
+    ACTIONS(1237), 1,
+      anon_sym_0o,
+    ACTIONS(1239), 1,
+      anon_sym_0b,
+    STATE(214), 1,
+      sym__integer,
+  [13333] = 1,
+    ACTIONS(945), 5,
+      sym_multi_line_comment,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13341] = 1,
+    ACTIONS(905), 5,
+      sym_multi_line_comment,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13349] = 1,
+    ACTIONS(1310), 5,
+      sym_multi_line_comment,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13357] = 1,
+    ACTIONS(927), 5,
+      sym_multi_line_comment,
+      anon_sym_RPAREN,
+      anon_sym_BSLASH,
+      sym__bom,
+      sym__unicode_space,
+  [13365] = 3,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1314), 1,
+      aux_sym__escaped_string_token1,
+    ACTIONS(1312), 3,
+      anon_sym_DQUOTE,
+      sym_escape,
+      sym_escaped_whitespace,
+  [13377] = 3,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1306), 1,
+      sym__digit,
+    STATE(257), 1,
+      sym__integer,
+  [13387] = 3,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1306), 1,
+      sym__digit,
+    STATE(230), 1,
+      sym__integer,
+  [13397] = 3,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1306), 1,
+      sym__digit,
+    STATE(220), 1,
+      sym__integer,
+  [13407] = 2,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1316), 2,
+      anon_sym_0,
+      anon_sym_1,
+  [13415] = 2,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1318), 2,
+      anon_sym_0,
+      anon_sym_1,
+  [13423] = 2,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1320), 1,
+      aux_sym__octal_token1,
+  [13430] = 2,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1322), 1,
+      ts_builtin_sym_end,
+  [13437] = 2,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1324), 1,
+      aux_sym__octal_token1,
+  [13444] = 2,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1326), 1,
+      sym__hex_digit,
+  [13451] = 2,
+    ACTIONS(3), 1,
+      sym_multi_line_comment,
+    ACTIONS(1328), 1,
+      sym__hex_digit,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 130,
-  [SMALL_STATE(4)] = 260,
-  [SMALL_STATE(5)] = 390,
-  [SMALL_STATE(6)] = 520,
-  [SMALL_STATE(7)] = 650,
-  [SMALL_STATE(8)] = 780,
-  [SMALL_STATE(9)] = 910,
-  [SMALL_STATE(10)] = 980,
-  [SMALL_STATE(11)] = 1085,
-  [SMALL_STATE(12)] = 1186,
-  [SMALL_STATE(13)] = 1287,
-  [SMALL_STATE(14)] = 1385,
-  [SMALL_STATE(15)] = 1483,
-  [SMALL_STATE(16)] = 1534,
-  [SMALL_STATE(17)] = 1600,
-  [SMALL_STATE(18)] = 1665,
-  [SMALL_STATE(19)] = 1730,
-  [SMALL_STATE(20)] = 1795,
-  [SMALL_STATE(21)] = 1860,
-  [SMALL_STATE(22)] = 1925,
-  [SMALL_STATE(23)] = 1990,
-  [SMALL_STATE(24)] = 2055,
-  [SMALL_STATE(25)] = 2120,
-  [SMALL_STATE(26)] = 2185,
-  [SMALL_STATE(27)] = 2250,
-  [SMALL_STATE(28)] = 2295,
-  [SMALL_STATE(29)] = 2360,
-  [SMALL_STATE(30)] = 2425,
-  [SMALL_STATE(31)] = 2490,
-  [SMALL_STATE(32)] = 2555,
-  [SMALL_STATE(33)] = 2619,
-  [SMALL_STATE(34)] = 2683,
-  [SMALL_STATE(35)] = 2723,
-  [SMALL_STATE(36)] = 2787,
-  [SMALL_STATE(37)] = 2851,
-  [SMALL_STATE(38)] = 2915,
-  [SMALL_STATE(39)] = 2955,
-  [SMALL_STATE(40)] = 2995,
-  [SMALL_STATE(41)] = 3059,
-  [SMALL_STATE(42)] = 3123,
-  [SMALL_STATE(43)] = 3187,
-  [SMALL_STATE(44)] = 3251,
-  [SMALL_STATE(45)] = 3315,
-  [SMALL_STATE(46)] = 3379,
-  [SMALL_STATE(47)] = 3443,
-  [SMALL_STATE(48)] = 3507,
-  [SMALL_STATE(49)] = 3571,
-  [SMALL_STATE(50)] = 3611,
-  [SMALL_STATE(51)] = 3675,
-  [SMALL_STATE(52)] = 3739,
-  [SMALL_STATE(53)] = 3803,
-  [SMALL_STATE(54)] = 3843,
-  [SMALL_STATE(55)] = 3904,
-  [SMALL_STATE(56)] = 3938,
-  [SMALL_STATE(57)] = 3972,
-  [SMALL_STATE(58)] = 4006,
-  [SMALL_STATE(59)] = 4040,
-  [SMALL_STATE(60)] = 4074,
-  [SMALL_STATE(61)] = 4108,
-  [SMALL_STATE(62)] = 4142,
-  [SMALL_STATE(63)] = 4195,
-  [SMALL_STATE(64)] = 4248,
-  [SMALL_STATE(65)] = 4301,
-  [SMALL_STATE(66)] = 4354,
-  [SMALL_STATE(67)] = 4407,
-  [SMALL_STATE(68)] = 4472,
-  [SMALL_STATE(69)] = 4525,
-  [SMALL_STATE(70)] = 4578,
-  [SMALL_STATE(71)] = 4631,
-  [SMALL_STATE(72)] = 4684,
-  [SMALL_STATE(73)] = 4737,
-  [SMALL_STATE(74)] = 4771,
-  [SMALL_STATE(75)] = 4812,
-  [SMALL_STATE(76)] = 4847,
-  [SMALL_STATE(77)] = 4882,
-  [SMALL_STATE(78)] = 4917,
-  [SMALL_STATE(79)] = 4952,
-  [SMALL_STATE(80)] = 5008,
-  [SMALL_STATE(81)] = 5049,
-  [SMALL_STATE(82)] = 5078,
-  [SMALL_STATE(83)] = 5119,
-  [SMALL_STATE(84)] = 5160,
-  [SMALL_STATE(85)] = 5201,
-  [SMALL_STATE(86)] = 5242,
-  [SMALL_STATE(87)] = 5283,
-  [SMALL_STATE(88)] = 5324,
-  [SMALL_STATE(89)] = 5365,
-  [SMALL_STATE(90)] = 5404,
-  [SMALL_STATE(91)] = 5445,
-  [SMALL_STATE(92)] = 5486,
-  [SMALL_STATE(93)] = 5527,
-  [SMALL_STATE(94)] = 5568,
-  [SMALL_STATE(95)] = 5609,
-  [SMALL_STATE(96)] = 5650,
-  [SMALL_STATE(97)] = 5691,
-  [SMALL_STATE(98)] = 5732,
-  [SMALL_STATE(99)] = 5773,
-  [SMALL_STATE(100)] = 5802,
-  [SMALL_STATE(101)] = 5837,
-  [SMALL_STATE(102)] = 5878,
-  [SMALL_STATE(103)] = 5919,
-  [SMALL_STATE(104)] = 5960,
-  [SMALL_STATE(105)] = 6001,
-  [SMALL_STATE(106)] = 6042,
-  [SMALL_STATE(107)] = 6083,
-  [SMALL_STATE(108)] = 6124,
-  [SMALL_STATE(109)] = 6165,
-  [SMALL_STATE(110)] = 6206,
-  [SMALL_STATE(111)] = 6247,
-  [SMALL_STATE(112)] = 6288,
-  [SMALL_STATE(113)] = 6329,
-  [SMALL_STATE(114)] = 6370,
-  [SMALL_STATE(115)] = 6411,
-  [SMALL_STATE(116)] = 6452,
-  [SMALL_STATE(117)] = 6493,
-  [SMALL_STATE(118)] = 6534,
-  [SMALL_STATE(119)] = 6575,
-  [SMALL_STATE(120)] = 6604,
-  [SMALL_STATE(121)] = 6645,
-  [SMALL_STATE(122)] = 6675,
-  [SMALL_STATE(123)] = 6705,
-  [SMALL_STATE(124)] = 6735,
-  [SMALL_STATE(125)] = 6789,
-  [SMALL_STATE(126)] = 6819,
-  [SMALL_STATE(127)] = 6849,
-  [SMALL_STATE(128)] = 6903,
-  [SMALL_STATE(129)] = 6926,
-  [SMALL_STATE(130)] = 6949,
-  [SMALL_STATE(131)] = 6976,
-  [SMALL_STATE(132)] = 6999,
-  [SMALL_STATE(133)] = 7022,
-  [SMALL_STATE(134)] = 7045,
-  [SMALL_STATE(135)] = 7068,
-  [SMALL_STATE(136)] = 7097,
-  [SMALL_STATE(137)] = 7120,
-  [SMALL_STATE(138)] = 7143,
-  [SMALL_STATE(139)] = 7166,
-  [SMALL_STATE(140)] = 7189,
-  [SMALL_STATE(141)] = 7212,
-  [SMALL_STATE(142)] = 7235,
-  [SMALL_STATE(143)] = 7258,
-  [SMALL_STATE(144)] = 7281,
-  [SMALL_STATE(145)] = 7304,
-  [SMALL_STATE(146)] = 7327,
-  [SMALL_STATE(147)] = 7350,
-  [SMALL_STATE(148)] = 7377,
-  [SMALL_STATE(149)] = 7400,
-  [SMALL_STATE(150)] = 7423,
-  [SMALL_STATE(151)] = 7446,
-  [SMALL_STATE(152)] = 7469,
-  [SMALL_STATE(153)] = 7492,
-  [SMALL_STATE(154)] = 7515,
-  [SMALL_STATE(155)] = 7544,
-  [SMALL_STATE(156)] = 7567,
-  [SMALL_STATE(157)] = 7590,
-  [SMALL_STATE(158)] = 7613,
-  [SMALL_STATE(159)] = 7636,
-  [SMALL_STATE(160)] = 7659,
-  [SMALL_STATE(161)] = 7682,
-  [SMALL_STATE(162)] = 7705,
-  [SMALL_STATE(163)] = 7728,
-  [SMALL_STATE(164)] = 7751,
-  [SMALL_STATE(165)] = 7778,
-  [SMALL_STATE(166)] = 7805,
-  [SMALL_STATE(167)] = 7832,
-  [SMALL_STATE(168)] = 7855,
-  [SMALL_STATE(169)] = 7878,
-  [SMALL_STATE(170)] = 7901,
-  [SMALL_STATE(171)] = 7924,
-  [SMALL_STATE(172)] = 7947,
-  [SMALL_STATE(173)] = 7973,
-  [SMALL_STATE(174)] = 7999,
-  [SMALL_STATE(175)] = 8025,
-  [SMALL_STATE(176)] = 8051,
-  [SMALL_STATE(177)] = 8077,
-  [SMALL_STATE(178)] = 8103,
-  [SMALL_STATE(179)] = 8129,
-  [SMALL_STATE(180)] = 8153,
-  [SMALL_STATE(181)] = 8179,
-  [SMALL_STATE(182)] = 8205,
-  [SMALL_STATE(183)] = 8231,
-  [SMALL_STATE(184)] = 8255,
-  [SMALL_STATE(185)] = 8281,
-  [SMALL_STATE(186)] = 8307,
-  [SMALL_STATE(187)] = 8331,
-  [SMALL_STATE(188)] = 8365,
-  [SMALL_STATE(189)] = 8390,
-  [SMALL_STATE(190)] = 8415,
-  [SMALL_STATE(191)] = 8440,
-  [SMALL_STATE(192)] = 8462,
-  [SMALL_STATE(193)] = 8484,
-  [SMALL_STATE(194)] = 8512,
-  [SMALL_STATE(195)] = 8532,
-  [SMALL_STATE(196)] = 8560,
-  [SMALL_STATE(197)] = 8580,
-  [SMALL_STATE(198)] = 8600,
-  [SMALL_STATE(199)] = 8619,
-  [SMALL_STATE(200)] = 8638,
-  [SMALL_STATE(201)] = 8657,
-  [SMALL_STATE(202)] = 8680,
-  [SMALL_STATE(203)] = 8699,
-  [SMALL_STATE(204)] = 8718,
-  [SMALL_STATE(205)] = 8737,
-  [SMALL_STATE(206)] = 8760,
-  [SMALL_STATE(207)] = 8783,
-  [SMALL_STATE(208)] = 8806,
-  [SMALL_STATE(209)] = 8825,
-  [SMALL_STATE(210)] = 8844,
-  [SMALL_STATE(211)] = 8867,
-  [SMALL_STATE(212)] = 8886,
-  [SMALL_STATE(213)] = 8909,
-  [SMALL_STATE(214)] = 8928,
-  [SMALL_STATE(215)] = 8947,
-  [SMALL_STATE(216)] = 8966,
-  [SMALL_STATE(217)] = 8985,
-  [SMALL_STATE(218)] = 9004,
-  [SMALL_STATE(219)] = 9023,
-  [SMALL_STATE(220)] = 9042,
-  [SMALL_STATE(221)] = 9061,
-  [SMALL_STATE(222)] = 9080,
-  [SMALL_STATE(223)] = 9103,
-  [SMALL_STATE(224)] = 9129,
-  [SMALL_STATE(225)] = 9155,
-  [SMALL_STATE(226)] = 9181,
-  [SMALL_STATE(227)] = 9207,
-  [SMALL_STATE(228)] = 9233,
-  [SMALL_STATE(229)] = 9259,
-  [SMALL_STATE(230)] = 9285,
-  [SMALL_STATE(231)] = 9307,
-  [SMALL_STATE(232)] = 9333,
-  [SMALL_STATE(233)] = 9350,
-  [SMALL_STATE(234)] = 9367,
-  [SMALL_STATE(235)] = 9384,
-  [SMALL_STATE(236)] = 9401,
-  [SMALL_STATE(237)] = 9418,
-  [SMALL_STATE(238)] = 9435,
-  [SMALL_STATE(239)] = 9452,
-  [SMALL_STATE(240)] = 9469,
-  [SMALL_STATE(241)] = 9486,
-  [SMALL_STATE(242)] = 9503,
-  [SMALL_STATE(243)] = 9520,
-  [SMALL_STATE(244)] = 9537,
-  [SMALL_STATE(245)] = 9554,
-  [SMALL_STATE(246)] = 9571,
-  [SMALL_STATE(247)] = 9588,
-  [SMALL_STATE(248)] = 9605,
-  [SMALL_STATE(249)] = 9625,
-  [SMALL_STATE(250)] = 9648,
-  [SMALL_STATE(251)] = 9671,
-  [SMALL_STATE(252)] = 9694,
-  [SMALL_STATE(253)] = 9717,
-  [SMALL_STATE(254)] = 9740,
-  [SMALL_STATE(255)] = 9763,
-  [SMALL_STATE(256)] = 9786,
-  [SMALL_STATE(257)] = 9809,
-  [SMALL_STATE(258)] = 9839,
-  [SMALL_STATE(259)] = 9869,
-  [SMALL_STATE(260)] = 9889,
-  [SMALL_STATE(261)] = 9919,
-  [SMALL_STATE(262)] = 9944,
-  [SMALL_STATE(263)] = 9969,
-  [SMALL_STATE(264)] = 9994,
-  [SMALL_STATE(265)] = 10019,
-  [SMALL_STATE(266)] = 10038,
-  [SMALL_STATE(267)] = 10052,
-  [SMALL_STATE(268)] = 10066,
-  [SMALL_STATE(269)] = 10080,
-  [SMALL_STATE(270)] = 10094,
-  [SMALL_STATE(271)] = 10111,
-  [SMALL_STATE(272)] = 10130,
-  [SMALL_STATE(273)] = 10138,
-  [SMALL_STATE(274)] = 10154,
-  [SMALL_STATE(275)] = 10162,
-  [SMALL_STATE(276)] = 10170,
-  [SMALL_STATE(277)] = 10178,
-  [SMALL_STATE(278)] = 10194,
-  [SMALL_STATE(279)] = 10208,
-  [SMALL_STATE(280)] = 10222,
-  [SMALL_STATE(281)] = 10238,
-  [SMALL_STATE(282)] = 10246,
-  [SMALL_STATE(283)] = 10262,
-  [SMALL_STATE(284)] = 10278,
-  [SMALL_STATE(285)] = 10292,
-  [SMALL_STATE(286)] = 10303,
-  [SMALL_STATE(287)] = 10313,
-  [SMALL_STATE(288)] = 10323,
-  [SMALL_STATE(289)] = 10331,
-  [SMALL_STATE(290)] = 10339,
-  [SMALL_STATE(291)] = 10347,
-  [SMALL_STATE(292)] = 10357,
-  [SMALL_STATE(293)] = 10367,
-  [SMALL_STATE(294)] = 10374,
-  [SMALL_STATE(295)] = 10381,
-  [SMALL_STATE(296)] = 10388,
-  [SMALL_STATE(297)] = 10395,
-  [SMALL_STATE(298)] = 10402,
-  [SMALL_STATE(299)] = 10409,
-  [SMALL_STATE(300)] = 10416,
-  [SMALL_STATE(301)] = 10423,
-  [SMALL_STATE(302)] = 10430,
-  [SMALL_STATE(303)] = 10437,
+  [SMALL_STATE(11)] = 0,
+  [SMALL_STATE(12)] = 65,
+  [SMALL_STATE(13)] = 130,
+  [SMALL_STATE(14)] = 219,
+  [SMALL_STATE(15)] = 308,
+  [SMALL_STATE(16)] = 397,
+  [SMALL_STATE(17)] = 486,
+  [SMALL_STATE(18)] = 556,
+  [SMALL_STATE(19)] = 620,
+  [SMALL_STATE(20)] = 679,
+  [SMALL_STATE(21)] = 738,
+  [SMALL_STATE(22)] = 797,
+  [SMALL_STATE(23)] = 912,
+  [SMALL_STATE(24)] = 971,
+  [SMALL_STATE(25)] = 1030,
+  [SMALL_STATE(26)] = 1141,
+  [SMALL_STATE(27)] = 1194,
+  [SMALL_STATE(28)] = 1305,
+  [SMALL_STATE(29)] = 1358,
+  [SMALL_STATE(30)] = 1411,
+  [SMALL_STATE(31)] = 1519,
+  [SMALL_STATE(32)] = 1627,
+  [SMALL_STATE(33)] = 1686,
+  [SMALL_STATE(34)] = 1779,
+  [SMALL_STATE(35)] = 1872,
+  [SMALL_STATE(36)] = 1965,
+  [SMALL_STATE(37)] = 2058,
+  [SMALL_STATE(38)] = 2111,
+  [SMALL_STATE(39)] = 2159,
+  [SMALL_STATE(40)] = 2243,
+  [SMALL_STATE(41)] = 2291,
+  [SMALL_STATE(42)] = 2339,
+  [SMALL_STATE(43)] = 2387,
+  [SMALL_STATE(44)] = 2435,
+  [SMALL_STATE(45)] = 2519,
+  [SMALL_STATE(46)] = 2561,
+  [SMALL_STATE(47)] = 2603,
+  [SMALL_STATE(48)] = 2645,
+  [SMALL_STATE(49)] = 2687,
+  [SMALL_STATE(50)] = 2729,
+  [SMALL_STATE(51)] = 2799,
+  [SMALL_STATE(52)] = 2868,
+  [SMALL_STATE(53)] = 2937,
+  [SMALL_STATE(54)] = 3006,
+  [SMALL_STATE(55)] = 3075,
+  [SMALL_STATE(56)] = 3144,
+  [SMALL_STATE(57)] = 3213,
+  [SMALL_STATE(58)] = 3282,
+  [SMALL_STATE(59)] = 3351,
+  [SMALL_STATE(60)] = 3420,
+  [SMALL_STATE(61)] = 3489,
+  [SMALL_STATE(62)] = 3558,
+  [SMALL_STATE(63)] = 3627,
+  [SMALL_STATE(64)] = 3696,
+  [SMALL_STATE(65)] = 3765,
+  [SMALL_STATE(66)] = 3833,
+  [SMALL_STATE(67)] = 3901,
+  [SMALL_STATE(68)] = 3969,
+  [SMALL_STATE(69)] = 4037,
+  [SMALL_STATE(70)] = 4105,
+  [SMALL_STATE(71)] = 4173,
+  [SMALL_STATE(72)] = 4241,
+  [SMALL_STATE(73)] = 4309,
+  [SMALL_STATE(74)] = 4377,
+  [SMALL_STATE(75)] = 4445,
+  [SMALL_STATE(76)] = 4513,
+  [SMALL_STATE(77)] = 4581,
+  [SMALL_STATE(78)] = 4649,
+  [SMALL_STATE(79)] = 4717,
+  [SMALL_STATE(80)] = 4785,
+  [SMALL_STATE(81)] = 4853,
+  [SMALL_STATE(82)] = 4921,
+  [SMALL_STATE(83)] = 4986,
+  [SMALL_STATE(84)] = 5034,
+  [SMALL_STATE(85)] = 5076,
+  [SMALL_STATE(86)] = 5113,
+  [SMALL_STATE(87)] = 5150,
+  [SMALL_STATE(88)] = 5187,
+  [SMALL_STATE(89)] = 5224,
+  [SMALL_STATE(90)] = 5261,
+  [SMALL_STATE(91)] = 5317,
+  [SMALL_STATE(92)] = 5373,
+  [SMALL_STATE(93)] = 5429,
+  [SMALL_STATE(94)] = 5485,
+  [SMALL_STATE(95)] = 5541,
+  [SMALL_STATE(96)] = 5597,
+  [SMALL_STATE(97)] = 5653,
+  [SMALL_STATE(98)] = 5709,
+  [SMALL_STATE(99)] = 5765,
+  [SMALL_STATE(100)] = 5803,
+  [SMALL_STATE(101)] = 5859,
+  [SMALL_STATE(102)] = 5915,
+  [SMALL_STATE(103)] = 5971,
+  [SMALL_STATE(104)] = 6027,
+  [SMALL_STATE(105)] = 6083,
+  [SMALL_STATE(106)] = 6114,
+  [SMALL_STATE(107)] = 6153,
+  [SMALL_STATE(108)] = 6184,
+  [SMALL_STATE(109)] = 6215,
+  [SMALL_STATE(110)] = 6246,
+  [SMALL_STATE(111)] = 6285,
+  [SMALL_STATE(112)] = 6316,
+  [SMALL_STATE(113)] = 6355,
+  [SMALL_STATE(114)] = 6394,
+  [SMALL_STATE(115)] = 6438,
+  [SMALL_STATE(116)] = 6482,
+  [SMALL_STATE(117)] = 6526,
+  [SMALL_STATE(118)] = 6570,
+  [SMALL_STATE(119)] = 6614,
+  [SMALL_STATE(120)] = 6658,
+  [SMALL_STATE(121)] = 6702,
+  [SMALL_STATE(122)] = 6746,
+  [SMALL_STATE(123)] = 6790,
+  [SMALL_STATE(124)] = 6834,
+  [SMALL_STATE(125)] = 6878,
+  [SMALL_STATE(126)] = 6922,
+  [SMALL_STATE(127)] = 6966,
+  [SMALL_STATE(128)] = 7010,
+  [SMALL_STATE(129)] = 7054,
+  [SMALL_STATE(130)] = 7086,
+  [SMALL_STATE(131)] = 7130,
+  [SMALL_STATE(132)] = 7174,
+  [SMALL_STATE(133)] = 7218,
+  [SMALL_STATE(134)] = 7262,
+  [SMALL_STATE(135)] = 7306,
+  [SMALL_STATE(136)] = 7350,
+  [SMALL_STATE(137)] = 7394,
+  [SMALL_STATE(138)] = 7426,
+  [SMALL_STATE(139)] = 7470,
+  [SMALL_STATE(140)] = 7512,
+  [SMALL_STATE(141)] = 7556,
+  [SMALL_STATE(142)] = 7600,
+  [SMALL_STATE(143)] = 7644,
+  [SMALL_STATE(144)] = 7688,
+  [SMALL_STATE(145)] = 7732,
+  [SMALL_STATE(146)] = 7776,
+  [SMALL_STATE(147)] = 7820,
+  [SMALL_STATE(148)] = 7864,
+  [SMALL_STATE(149)] = 7908,
+  [SMALL_STATE(150)] = 7952,
+  [SMALL_STATE(151)] = 7996,
+  [SMALL_STATE(152)] = 8040,
+  [SMALL_STATE(153)] = 8084,
+  [SMALL_STATE(154)] = 8116,
+  [SMALL_STATE(155)] = 8160,
+  [SMALL_STATE(156)] = 8204,
+  [SMALL_STATE(157)] = 8248,
+  [SMALL_STATE(158)] = 8292,
+  [SMALL_STATE(159)] = 8336,
+  [SMALL_STATE(160)] = 8380,
+  [SMALL_STATE(161)] = 8424,
+  [SMALL_STATE(162)] = 8468,
+  [SMALL_STATE(163)] = 8495,
+  [SMALL_STATE(164)] = 8522,
+  [SMALL_STATE(165)] = 8549,
+  [SMALL_STATE(166)] = 8604,
+  [SMALL_STATE(167)] = 8631,
+  [SMALL_STATE(168)] = 8658,
+  [SMALL_STATE(169)] = 8685,
+  [SMALL_STATE(170)] = 8712,
+  [SMALL_STATE(171)] = 8739,
+  [SMALL_STATE(172)] = 8766,
+  [SMALL_STATE(173)] = 8793,
+  [SMALL_STATE(174)] = 8820,
+  [SMALL_STATE(175)] = 8847,
+  [SMALL_STATE(176)] = 8874,
+  [SMALL_STATE(177)] = 8901,
+  [SMALL_STATE(178)] = 8928,
+  [SMALL_STATE(179)] = 8955,
+  [SMALL_STATE(180)] = 8982,
+  [SMALL_STATE(181)] = 9009,
+  [SMALL_STATE(182)] = 9036,
+  [SMALL_STATE(183)] = 9063,
+  [SMALL_STATE(184)] = 9090,
+  [SMALL_STATE(185)] = 9117,
+  [SMALL_STATE(186)] = 9144,
+  [SMALL_STATE(187)] = 9171,
+  [SMALL_STATE(188)] = 9198,
+  [SMALL_STATE(189)] = 9225,
+  [SMALL_STATE(190)] = 9252,
+  [SMALL_STATE(191)] = 9279,
+  [SMALL_STATE(192)] = 9306,
+  [SMALL_STATE(193)] = 9361,
+  [SMALL_STATE(194)] = 9388,
+  [SMALL_STATE(195)] = 9415,
+  [SMALL_STATE(196)] = 9442,
+  [SMALL_STATE(197)] = 9469,
+  [SMALL_STATE(198)] = 9496,
+  [SMALL_STATE(199)] = 9523,
+  [SMALL_STATE(200)] = 9550,
+  [SMALL_STATE(201)] = 9577,
+  [SMALL_STATE(202)] = 9604,
+  [SMALL_STATE(203)] = 9631,
+  [SMALL_STATE(204)] = 9658,
+  [SMALL_STATE(205)] = 9685,
+  [SMALL_STATE(206)] = 9712,
+  [SMALL_STATE(207)] = 9739,
+  [SMALL_STATE(208)] = 9766,
+  [SMALL_STATE(209)] = 9793,
+  [SMALL_STATE(210)] = 9820,
+  [SMALL_STATE(211)] = 9847,
+  [SMALL_STATE(212)] = 9874,
+  [SMALL_STATE(213)] = 9904,
+  [SMALL_STATE(214)] = 9934,
+  [SMALL_STATE(215)] = 9966,
+  [SMALL_STATE(216)] = 9998,
+  [SMALL_STATE(217)] = 10028,
+  [SMALL_STATE(218)] = 10058,
+  [SMALL_STATE(219)] = 10088,
+  [SMALL_STATE(220)] = 10117,
+  [SMALL_STATE(221)] = 10146,
+  [SMALL_STATE(222)] = 10195,
+  [SMALL_STATE(223)] = 10244,
+  [SMALL_STATE(224)] = 10273,
+  [SMALL_STATE(225)] = 10302,
+  [SMALL_STATE(226)] = 10331,
+  [SMALL_STATE(227)] = 10360,
+  [SMALL_STATE(228)] = 10389,
+  [SMALL_STATE(229)] = 10418,
+  [SMALL_STATE(230)] = 10447,
+  [SMALL_STATE(231)] = 10476,
+  [SMALL_STATE(232)] = 10525,
+  [SMALL_STATE(233)] = 10574,
+  [SMALL_STATE(234)] = 10611,
+  [SMALL_STATE(235)] = 10660,
+  [SMALL_STATE(236)] = 10709,
+  [SMALL_STATE(237)] = 10738,
+  [SMALL_STATE(238)] = 10767,
+  [SMALL_STATE(239)] = 10795,
+  [SMALL_STATE(240)] = 10823,
+  [SMALL_STATE(241)] = 10851,
+  [SMALL_STATE(242)] = 10874,
+  [SMALL_STATE(243)] = 10901,
+  [SMALL_STATE(244)] = 10926,
+  [SMALL_STATE(245)] = 10953,
+  [SMALL_STATE(246)] = 10976,
+  [SMALL_STATE(247)] = 11007,
+  [SMALL_STATE(248)] = 11030,
+  [SMALL_STATE(249)] = 11061,
+  [SMALL_STATE(250)] = 11087,
+  [SMALL_STATE(251)] = 11109,
+  [SMALL_STATE(252)] = 11131,
+  [SMALL_STATE(253)] = 11153,
+  [SMALL_STATE(254)] = 11175,
+  [SMALL_STATE(255)] = 11197,
+  [SMALL_STATE(256)] = 11219,
+  [SMALL_STATE(257)] = 11241,
+  [SMALL_STATE(258)] = 11263,
+  [SMALL_STATE(259)] = 11285,
+  [SMALL_STATE(260)] = 11307,
+  [SMALL_STATE(261)] = 11329,
+  [SMALL_STATE(262)] = 11351,
+  [SMALL_STATE(263)] = 11377,
+  [SMALL_STATE(264)] = 11399,
+  [SMALL_STATE(265)] = 11425,
+  [SMALL_STATE(266)] = 11451,
+  [SMALL_STATE(267)] = 11473,
+  [SMALL_STATE(268)] = 11499,
+  [SMALL_STATE(269)] = 11521,
+  [SMALL_STATE(270)] = 11543,
+  [SMALL_STATE(271)] = 11569,
+  [SMALL_STATE(272)] = 11595,
+  [SMALL_STATE(273)] = 11617,
+  [SMALL_STATE(274)] = 11639,
+  [SMALL_STATE(275)] = 11661,
+  [SMALL_STATE(276)] = 11683,
+  [SMALL_STATE(277)] = 11705,
+  [SMALL_STATE(278)] = 11727,
+  [SMALL_STATE(279)] = 11756,
+  [SMALL_STATE(280)] = 11785,
+  [SMALL_STATE(281)] = 11814,
+  [SMALL_STATE(282)] = 11843,
+  [SMALL_STATE(283)] = 11872,
+  [SMALL_STATE(284)] = 11901,
+  [SMALL_STATE(285)] = 11930,
+  [SMALL_STATE(286)] = 11959,
+  [SMALL_STATE(287)] = 11988,
+  [SMALL_STATE(288)] = 12017,
+  [SMALL_STATE(289)] = 12037,
+  [SMALL_STATE(290)] = 12057,
+  [SMALL_STATE(291)] = 12077,
+  [SMALL_STATE(292)] = 12097,
+  [SMALL_STATE(293)] = 12117,
+  [SMALL_STATE(294)] = 12137,
+  [SMALL_STATE(295)] = 12157,
+  [SMALL_STATE(296)] = 12177,
+  [SMALL_STATE(297)] = 12197,
+  [SMALL_STATE(298)] = 12217,
+  [SMALL_STATE(299)] = 12237,
+  [SMALL_STATE(300)] = 12257,
+  [SMALL_STATE(301)] = 12277,
+  [SMALL_STATE(302)] = 12297,
+  [SMALL_STATE(303)] = 12317,
+  [SMALL_STATE(304)] = 12337,
+  [SMALL_STATE(305)] = 12363,
+  [SMALL_STATE(306)] = 12389,
+  [SMALL_STATE(307)] = 12415,
+  [SMALL_STATE(308)] = 12441,
+  [SMALL_STATE(309)] = 12467,
+  [SMALL_STATE(310)] = 12493,
+  [SMALL_STATE(311)] = 12519,
+  [SMALL_STATE(312)] = 12545,
+  [SMALL_STATE(313)] = 12571,
+  [SMALL_STATE(314)] = 12597,
+  [SMALL_STATE(315)] = 12620,
+  [SMALL_STATE(316)] = 12647,
+  [SMALL_STATE(317)] = 12673,
+  [SMALL_STATE(318)] = 12686,
+  [SMALL_STATE(319)] = 12711,
+  [SMALL_STATE(320)] = 12736,
+  [SMALL_STATE(321)] = 12761,
+  [SMALL_STATE(322)] = 12782,
+  [SMALL_STATE(323)] = 12807,
+  [SMALL_STATE(324)] = 12832,
+  [SMALL_STATE(325)] = 12845,
+  [SMALL_STATE(326)] = 12870,
+  [SMALL_STATE(327)] = 12883,
+  [SMALL_STATE(328)] = 12908,
+  [SMALL_STATE(329)] = 12933,
+  [SMALL_STATE(330)] = 12958,
+  [SMALL_STATE(331)] = 12983,
+  [SMALL_STATE(332)] = 13008,
+  [SMALL_STATE(333)] = 13033,
+  [SMALL_STATE(334)] = 13049,
+  [SMALL_STATE(335)] = 13065,
+  [SMALL_STATE(336)] = 13081,
+  [SMALL_STATE(337)] = 13097,
+  [SMALL_STATE(338)] = 13112,
+  [SMALL_STATE(339)] = 13127,
+  [SMALL_STATE(340)] = 13142,
+  [SMALL_STATE(341)] = 13152,
+  [SMALL_STATE(342)] = 13162,
+  [SMALL_STATE(343)] = 13172,
+  [SMALL_STATE(344)] = 13182,
+  [SMALL_STATE(345)] = 13192,
+  [SMALL_STATE(346)] = 13209,
+  [SMALL_STATE(347)] = 13226,
+  [SMALL_STATE(348)] = 13243,
+  [SMALL_STATE(349)] = 13254,
+  [SMALL_STATE(350)] = 13271,
+  [SMALL_STATE(351)] = 13288,
+  [SMALL_STATE(352)] = 13297,
+  [SMALL_STATE(353)] = 13314,
+  [SMALL_STATE(354)] = 13333,
+  [SMALL_STATE(355)] = 13341,
+  [SMALL_STATE(356)] = 13349,
+  [SMALL_STATE(357)] = 13357,
+  [SMALL_STATE(358)] = 13365,
+  [SMALL_STATE(359)] = 13377,
+  [SMALL_STATE(360)] = 13387,
+  [SMALL_STATE(361)] = 13397,
+  [SMALL_STATE(362)] = 13407,
+  [SMALL_STATE(363)] = 13415,
+  [SMALL_STATE(364)] = 13423,
+  [SMALL_STATE(365)] = 13430,
+  [SMALL_STATE(366)] = 13437,
+  [SMALL_STATE(367)] = 13444,
+  [SMALL_STATE(368)] = 13451,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
-  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(290),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(217),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(299),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(288),
-  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(219),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(303),
-  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
-  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(296),
-  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [71] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
-  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0),
-  [83] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(229),
-  [86] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(218),
-  [94] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(127),
-  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(9),
-  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(273),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(192),
-  [106] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(54),
-  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(252),
-  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(194),
-  [115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
-  [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3, 0, 0),
-  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
-  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [147] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_space, 1, 0, 0),
-  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0),
-  [151] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(229),
-  [154] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(49),
-  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
-  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [169] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(53),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [178] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_space, 3, 0, 0),
-  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_space, 3, 0, 0),
-  [182] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3, 0, 0), SHIFT(49),
-  [185] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_space, 2, 0, 0),
-  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0),
-  [189] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(38),
-  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
-  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
-  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
-  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [206] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_node_repeat3, 2, 0, 0),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2, 0, 0),
-  [210] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2, 0, 0), SHIFT_REPEAT(49),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4, 0, 0),
-  [215] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(49),
-  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_single_line_comment, 3, 0, 0),
-  [220] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_single_line_comment, 3, 0, 0),
-  [222] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escline, 2, 0, 0),
-  [224] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escline, 2, 0, 0),
-  [226] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escline, 3, 0, 0),
-  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escline, 3, 0, 0),
-  [230] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_node_repeat1, 1, 0, 0),
-  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 1, 0, 0),
-  [234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_single_line_comment, 2, 0, 0),
-  [236] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_single_line_comment, 2, 0, 0),
-  [238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
-  [240] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
-  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
-  [246] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
-  [248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [250] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [252] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
-  [255] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(252),
-  [258] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(227),
-  [261] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(100),
-  [264] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT(247),
-  [267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT(243),
-  [270] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_document, 2, 0, 0), REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [273] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT(245),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
-  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__integer, 1, 0, 0),
-  [284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [288] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [304] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat2, 2, 0, 0),
-  [306] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat2, 2, 0, 0), SHIFT_REPEAT(227),
-  [309] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat2, 2, 0, 0), SHIFT_REPEAT(100),
-  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
-  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [322] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [324] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__integer_repeat1, 2, 0, 0),
-  [334] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__integer_repeat1, 2, 0, 0), SHIFT_REPEAT(99),
-  [337] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(227),
-  [340] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(126),
-  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
-  [345] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
-  [347] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [351] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [353] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
-  [361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [363] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [365] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
-  [367] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [369] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
-  [373] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [375] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [377] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__integer, 2, 0, 0),
-  [379] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [381] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(123),
-  [384] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(126),
-  [387] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3, 0, 0), SHIFT(126),
-  [390] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(122),
-  [393] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2, 0, 0), SHIFT_REPEAT(126),
-  [396] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, 0, 14),
-  [398] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 10, 0, 16),
-  [400] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__binary_repeat1, 2, 0, 0),
-  [402] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__binary_repeat1, 2, 0, 0), SHIFT_REPEAT(130),
-  [405] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, 0, 15),
-  [407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, 0, 12),
-  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, 0, 8),
-  [411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, 0, 14),
-  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 2, 0, 0),
-  [415] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
-  [417] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
-  [419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, 0, 12),
-  [421] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, 0, 3),
-  [423] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, 0, 7),
-  [425] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, 0, 15),
-  [427] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, 0, 14),
-  [429] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, 0, 4),
-  [431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, 0, 0),
-  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, 0, 16),
-  [435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, 0, 8),
-  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, 0, 11),
-  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4, 0, 2),
-  [441] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__binary, 2, 0, 0),
-  [443] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [445] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, 0, 4),
-  [447] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4, 0, 3),
-  [449] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, 0, 15),
-  [451] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, 0, 11),
-  [453] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 3, 0, 0),
-  [455] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 1, 0, 0),
-  [457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
-  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, 0, 12),
-  [461] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 2, 0, 0),
-  [463] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, 0, 7),
-  [465] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 3, 0, 2),
-  [467] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, 0, 8),
-  [469] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, 0, 4),
-  [471] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, 0, 2),
-  [473] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, 0, 0),
-  [475] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, 0, 16),
-  [477] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__binary, 3, 0, 0),
-  [479] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [481] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__binary, 4, 0, 0),
-  [483] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [485] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, 0, 3),
-  [487] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, 0, 7),
-  [489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4, 0, 4),
-  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, 0, 11),
-  [493] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4, 0, 0),
-  [495] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__octal, 4, 0, 0),
-  [497] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [499] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__octal, 2, 0, 0),
-  [501] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [503] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 3, 0, 10),
-  [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hex, 3, 0, 0),
-  [507] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [509] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__octal, 3, 0, 0),
-  [511] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [513] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
-  [515] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hex, 4, 0, 0),
-  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 4, 0, 13),
-  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__octal_repeat1, 2, 0, 0),
-  [521] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__octal_repeat1, 2, 0, 0), SHIFT_REPEAT(181),
-  [524] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__hex_repeat1, 2, 0, 0),
-  [526] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__hex_repeat1, 2, 0, 0), SHIFT_REPEAT(184),
-  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hex, 2, 0, 0),
-  [531] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [533] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(231),
-  [536] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(193),
-  [539] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__bare_identifier_repeat1, 2, 0, 0),
-  [541] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_identifier_repeat1, 2, 0, 0), SHIFT_REPEAT(188),
-  [544] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_identifier, 3, 0, 0),
-  [546] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [548] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_identifier, 2, 0, 0),
-  [550] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
-  [552] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 1, 0, 0),
-  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1, 0, 0),
-  [556] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_identifier, 1, 0, 0),
-  [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
-  [560] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(231),
-  [563] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(205),
-  [566] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 1, 0, 0),
-  [568] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), REDUCE(aux_sym_node_repeat3, 2, 0, 0),
-  [571] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), REDUCE(aux_sym_node_repeat3, 2, 0, 0), SHIFT(231),
-  [575] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), REDUCE(aux_sym_node_repeat3, 2, 0, 0), SHIFT(205),
-  [579] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escaped_string, 2, 0, 0),
-  [581] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escaped_string, 3, 0, 1),
-  [583] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__exponent, 2, 0, 0),
-  [585] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3, 0, 0), SHIFT(205),
-  [588] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 3, 0, 0),
-  [590] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 4, 0, 10),
-  [592] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__exponent, 3, 0, 0),
-  [594] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2, 0, 0), SHIFT_REPEAT(205),
-  [597] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(201),
-  [600] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(205),
-  [603] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_prop, 3, 0, 0),
-  [605] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_field_comment, 3, 0, 9),
-  [607] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), REDUCE(sym__node_space, 3, 0, 0),
-  [610] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), REDUCE(sym__node_space, 3, 0, 0), SHIFT(205),
-  [614] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_field, 1, 0, 0),
-  [616] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(207),
-  [619] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_field, 1, 0, 0),
-  [621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1, 0, 0),
-  [623] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 5, 0, 13),
-  [625] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword, 1, 0, 0),
-  [627] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1, 0, 0),
-  [629] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 2, 0, 0),
-  [631] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_field_comment, 2, 0, 6),
-  [633] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), REDUCE(sym__node_space, 2, 0, 0),
-  [636] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), REDUCE(sym__node_space, 2, 0, 0), SHIFT(210),
-  [640] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
-  [642] = {.entry = {.count = 1, .reusable = true}}, SHIFT(230),
-  [644] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
-  [646] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
-  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [650] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [652] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
-  [654] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
-  [656] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
-  [658] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
-  [660] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
-  [662] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
-  [664] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [666] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
-  [668] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2, 0, 0), SHIFT_REPEAT(230),
-  [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
-  [673] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
-  [675] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 3, 0, 5),
-  [677] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 8, 0, 5),
-  [679] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 6, 0, 0),
-  [681] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 5, 0, 0),
-  [683] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 4, 0, 5),
-  [685] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 7, 0, 5),
-  [687] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 2, 0, 0),
-  [689] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 3, 0, 0),
-  [691] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 5, 0, 5),
-  [693] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 6, 0, 5),
-  [695] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 4, 0, 0),
-  [697] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 3, 0, 0),
-  [699] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 3, 0, 0),
-  [701] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [703] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
-  [705] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
-  [707] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
-  [709] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
-  [711] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [713] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
-  [715] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
-  [717] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
-  [719] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [721] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [723] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
-  [725] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
-  [727] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_single_line_comment_repeat1, 2, 0, 0),
-  [729] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_single_line_comment_repeat1, 2, 0, 0), SHIFT_REPEAT(259),
-  [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
-  [734] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
-  [736] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(228),
-  [739] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2, 0, 0), SHIFT_REPEAT(265),
-  [742] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
-  [744] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
-  [746] = {.entry = {.count = 1, .reusable = true}}, SHIFT(300),
-  [748] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
-  [750] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(228),
-  [753] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(230),
-  [756] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3, 0, 0), SHIFT(230),
-  [759] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(266),
-  [762] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2, 0, 0), SHIFT(230),
-  [765] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1, 0, 0), SHIFT(268),
-  [768] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [770] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
-  [772] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
-  [774] = {.entry = {.count = 1, .reusable = false}}, SHIFT(285),
-  [776] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
-  [778] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
-  [780] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
-  [782] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_identifier_repeat1, 2, 0, 0), SHIFT_REPEAT(279),
-  [785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(294),
-  [787] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
-  [789] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__escaped_string_repeat1, 2, 0, 0),
-  [791] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__escaped_string_repeat1, 2, 0, 0), SHIFT_REPEAT(285),
-  [794] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__escaped_string_repeat1, 2, 0, 0), SHIFT_REPEAT(285),
-  [797] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
-  [799] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__escaped_string_repeat1, 1, 0, 0),
-  [801] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__escaped_string_repeat1, 1, 0, 0),
-  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [809] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [811] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
-  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
-  [815] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [817] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
-  [819] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
-  [821] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation_type, 1, 0, 0),
-};
-
-enum ts_external_scanner_symbol_identifiers {
-  ts_external_token__eof = 0,
-  ts_external_token_multi_line_comment = 1,
-  ts_external_token__raw_string = 2,
-};
-
-static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
-  [ts_external_token__eof] = sym__eof,
-  [ts_external_token_multi_line_comment] = sym_multi_line_comment,
-  [ts_external_token__raw_string] = sym__raw_string,
-};
-
-static const bool ts_external_scanner_states[5][EXTERNAL_TOKEN_COUNT] = {
-  [1] = {
-    [ts_external_token__eof] = true,
-    [ts_external_token_multi_line_comment] = true,
-    [ts_external_token__raw_string] = true,
-  },
-  [2] = {
-    [ts_external_token_multi_line_comment] = true,
-    [ts_external_token__raw_string] = true,
-  },
-  [3] = {
-    [ts_external_token__eof] = true,
-    [ts_external_token_multi_line_comment] = true,
-  },
-  [4] = {
-    [ts_external_token_multi_line_comment] = true,
-  },
+  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(306),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(351),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(266),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(316),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(261),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(259),
+  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(183),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
+  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [63] = {.entry = {.count = 1, .reusable = false}}, SHIFT(174),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [67] = {.entry = {.count = 1, .reusable = false}}, SHIFT(210),
+  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(202),
+  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(177),
+  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
+  [79] = {.entry = {.count = 1, .reusable = false}}, SHIFT(207),
+  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [83] = {.entry = {.count = 1, .reusable = false}}, SHIFT(178),
+  [85] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [87] = {.entry = {.count = 1, .reusable = false}}, SHIFT(203),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_single_line_comment, 3),
+  [91] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_single_line_comment, 3),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_single_line_comment, 2),
+  [95] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_single_line_comment, 2),
+  [97] = {.entry = {.count = 1, .reusable = false}}, SHIFT(356),
+  [99] = {.entry = {.count = 1, .reusable = true}}, SHIFT(346),
+  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
+  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
+  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [107] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
+  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_node_repeat1, 2),
+  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2),
+  [113] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(285),
+  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(18),
+  [119] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_space, 1),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_space, 1),
+  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(285),
+  [126] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(23),
+  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_space, 2),
+  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_space, 2),
+  [133] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(23),
+  [136] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(19),
+  [139] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_space, 3),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_space, 3),
+  [143] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3), SHIFT(23),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [152] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_node_repeat3, 2),
+  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2),
+  [156] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2), SHIFT_REPEAT(23),
+  [159] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(21),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [164] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escline, 2),
+  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escline, 2),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [170] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escline, 3),
+  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escline, 3),
+  [174] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_node_repeat1, 1),
+  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 1),
+  [178] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(279),
+  [181] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(37),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
+  [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
+  [192] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(279),
+  [195] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(38),
+  [198] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2), SHIFT_REPEAT(38),
+  [201] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(42),
+  [204] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(38),
+  [207] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3), SHIFT(38),
+  [210] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(41),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2),
+  [215] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(268),
+  [218] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(165),
+  [221] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(15),
+  [224] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(347),
+  [227] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(243),
+  [230] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(82),
+  [233] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(82),
+  [236] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(306),
+  [239] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2), SHIFT_REPEAT(247),
+  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(294),
+  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [246] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
+  [248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(288),
+  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [252] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
+  [254] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
+  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [258] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
+  [262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [264] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
+  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [270] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(290),
+  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [276] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
+  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [282] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
+  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3),
+  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [288] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
+  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(296),
+  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [294] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
+  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [300] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [304] = {.entry = {.count = 1, .reusable = false}}, SHIFT(99),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(303),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [310] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
+  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [316] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [320] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
+  [322] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [324] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
+  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
+  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
+  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4),
+  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [336] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
+  [338] = {.entry = {.count = 1, .reusable = true}}, SHIFT(295),
+  [340] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [342] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [344] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(280),
+  [347] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(84),
+  [350] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(280),
+  [353] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(86),
+  [356] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3), SHIFT(86),
+  [359] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2), SHIFT_REPEAT(86),
+  [362] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(85),
+  [365] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(86),
+  [368] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(88),
+  [371] = {.entry = {.count = 1, .reusable = true}}, SHIFT(327),
+  [373] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
+  [375] = {.entry = {.count = 1, .reusable = false}}, SHIFT(166),
+  [377] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [379] = {.entry = {.count = 1, .reusable = false}}, SHIFT(180),
+  [381] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [383] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(99),
+  [386] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(99),
+  [389] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(306),
+  [392] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT(294),
+  [395] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT(296),
+  [398] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_document, 2), REDUCE(aux_sym_document_repeat1, 2),
+  [401] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT(302),
+  [404] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [406] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
+  [408] = {.entry = {.count = 1, .reusable = false}}, SHIFT(195),
+  [410] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [412] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
+  [414] = {.entry = {.count = 1, .reusable = false}}, SHIFT(198),
+  [416] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [418] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [420] = {.entry = {.count = 1, .reusable = false}}, SHIFT(162),
+  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [424] = {.entry = {.count = 1, .reusable = false}}, SHIFT(191),
+  [426] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
+  [430] = {.entry = {.count = 1, .reusable = false}}, SHIFT(193),
+  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [434] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
+  [436] = {.entry = {.count = 1, .reusable = false}}, SHIFT(205),
+  [438] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
+  [440] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
+  [442] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [444] = {.entry = {.count = 1, .reusable = false}}, SHIFT(163),
+  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
+  [448] = {.entry = {.count = 1, .reusable = false}}, SHIFT(201),
+  [450] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [452] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [454] = {.entry = {.count = 1, .reusable = false}}, SHIFT(176),
+  [456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [458] = {.entry = {.count = 1, .reusable = false}}, SHIFT(164),
+  [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [462] = {.entry = {.count = 1, .reusable = false}}, SHIFT(169),
+  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__integer, 2),
+  [466] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__integer, 2),
+  [470] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [472] = {.entry = {.count = 1, .reusable = false}}, SHIFT(188),
+  [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
+  [476] = {.entry = {.count = 1, .reusable = false}}, SHIFT(187),
+  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [480] = {.entry = {.count = 1, .reusable = false}}, SHIFT(185),
+  [482] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [484] = {.entry = {.count = 1, .reusable = false}}, SHIFT(171),
+  [486] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [488] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [490] = {.entry = {.count = 1, .reusable = false}}, SHIFT(196),
+  [492] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__integer, 1),
+  [494] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [496] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__integer, 1),
+  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [500] = {.entry = {.count = 1, .reusable = false}}, SHIFT(179),
+  [502] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_repeat2, 2),
+  [504] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat2, 2), SHIFT_REPEAT(280),
+  [507] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_node_repeat2, 2),
+  [509] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat2, 2), SHIFT_REPEAT(84),
+  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
+  [514] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
+  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
+  [518] = {.entry = {.count = 1, .reusable = false}}, SHIFT(206),
+  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [524] = {.entry = {.count = 1, .reusable = false}}, SHIFT(181),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [528] = {.entry = {.count = 1, .reusable = false}}, SHIFT(184),
+  [530] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [532] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [534] = {.entry = {.count = 1, .reusable = false}}, SHIFT(182),
+  [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
+  [538] = {.entry = {.count = 1, .reusable = false}}, SHIFT(186),
+  [540] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
+  [542] = {.entry = {.count = 1, .reusable = false}}, SHIFT(197),
+  [544] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [546] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [548] = {.entry = {.count = 1, .reusable = false}}, SHIFT(189),
+  [550] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [552] = {.entry = {.count = 1, .reusable = false}}, SHIFT(172),
+  [554] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [556] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__integer_repeat1, 2),
+  [558] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__integer_repeat1, 2), SHIFT_REPEAT(153),
+  [561] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__integer_repeat1, 2),
+  [563] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
+  [565] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
+  [567] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [569] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [571] = {.entry = {.count = 1, .reusable = false}}, SHIFT(200),
+  [573] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [575] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
+  [577] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [579] = {.entry = {.count = 1, .reusable = false}}, SHIFT(173),
+  [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [583] = {.entry = {.count = 1, .reusable = false}}, SHIFT(170),
+  [585] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [587] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
+  [589] = {.entry = {.count = 1, .reusable = false}}, SHIFT(208),
+  [591] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [593] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, .production_id = 17),
+  [595] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 9, .production_id = 17),
+  [597] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, .production_id = 16),
+  [599] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 9, .production_id = 16),
+  [601] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, .production_id = 12),
+  [603] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7, .production_id = 12),
+  [605] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 2),
+  [607] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 2),
+  [609] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, .production_id = 8),
+  [611] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7, .production_id = 8),
+  [613] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7),
+  [615] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7),
+  [617] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, .production_id = 3),
+  [619] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 5, .production_id = 3),
+  [621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, .production_id = 14),
+  [623] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7, .production_id = 14),
+  [625] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, .production_id = 7),
+  [627] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 5, .production_id = 7),
+  [629] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4, .production_id = 3),
+  [631] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 4, .production_id = 3),
+  [633] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, .production_id = 11),
+  [635] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7, .production_id = 11),
+  [637] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 3),
+  [639] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 3),
+  [641] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, .production_id = 7),
+  [643] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7, .production_id = 7),
+  [645] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, .production_id = 2),
+  [647] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 5, .production_id = 2),
+  [649] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4),
+  [651] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 4),
+  [653] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, .production_id = 4),
+  [655] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7, .production_id = 4),
+  [657] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, .production_id = 11),
+  [659] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 8, .production_id = 11),
+  [661] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4, .production_id = 4),
+  [663] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 4, .production_id = 4),
+  [665] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, .production_id = 14),
+  [667] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 8, .production_id = 14),
+  [669] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 11, .production_id = 18),
+  [671] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 11, .production_id = 18),
+  [673] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5),
+  [675] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 5),
+  [677] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, .production_id = 16),
+  [679] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 8, .production_id = 16),
+  [681] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 10, .production_id = 18),
+  [683] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 10, .production_id = 18),
+  [685] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, .production_id = 12),
+  [687] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 8, .production_id = 12),
+  [689] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 10, .production_id = 17),
+  [691] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 10, .production_id = 17),
+  [693] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 10, .production_id = 16),
+  [695] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 10, .production_id = 16),
+  [697] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, .production_id = 15),
+  [699] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 8, .production_id = 15),
+  [701] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 5),
+  [703] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 5),
+  [705] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 4, .production_id = 2),
+  [707] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 4, .production_id = 2),
+  [709] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, .production_id = 18),
+  [711] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 9, .production_id = 18),
+  [713] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 3),
+  [715] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 3),
+  [717] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, .production_id = 3),
+  [719] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 6, .production_id = 3),
+  [721] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, .production_id = 7),
+  [723] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 6, .production_id = 7),
+  [725] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, .production_id = 8),
+  [727] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 5, .production_id = 8),
+  [729] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, .production_id = 11),
+  [731] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 6, .production_id = 11),
+  [733] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat2, 2),
+  [735] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, .production_id = 15),
+  [737] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 9, .production_id = 15),
+  [739] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 7, .production_id = 15),
+  [741] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 7, .production_id = 15),
+  [743] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6),
+  [745] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 6),
+  [747] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 5, .production_id = 4),
+  [749] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 5, .production_id = 4),
+  [751] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, .production_id = 8),
+  [753] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 6, .production_id = 8),
+  [755] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 9, .production_id = 14),
+  [757] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 9, .production_id = 14),
+  [759] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, .production_id = 12),
+  [761] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 6, .production_id = 12),
+  [763] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, .production_id = 4),
+  [765] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 8, .production_id = 4),
+  [767] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 3, .production_id = 2),
+  [769] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 3, .production_id = 2),
+  [771] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 4),
+  [773] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 4),
+  [775] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 6, .production_id = 4),
+  [777] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 6, .production_id = 4),
+  [779] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node, 8, .production_id = 17),
+  [781] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node, 8, .production_id = 17),
+  [783] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__binary_repeat1, 2),
+  [785] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__binary_repeat1, 2), SHIFT_REPEAT(212),
+  [788] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__binary_repeat1, 2),
+  [790] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__binary, 2),
+  [792] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
+  [794] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__binary, 2),
+  [796] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 2),
+  [798] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
+  [800] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
+  [802] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__decimal, 2),
+  [804] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 1),
+  [806] = {.entry = {.count = 1, .reusable = true}}, SHIFT(360),
+  [808] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__decimal, 1),
+  [810] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__binary, 4),
+  [812] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [814] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__binary, 4),
+  [816] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__binary, 3),
+  [818] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__binary, 3),
+  [820] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
+  [822] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__octal, 2),
+  [824] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
+  [826] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__octal, 2),
+  [828] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 4, .production_id = 13),
+  [830] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__decimal, 4, .production_id = 13),
+  [832] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__hex_repeat1, 2),
+  [834] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__hex_repeat1, 2), SHIFT_REPEAT(223),
+  [837] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__hex_repeat1, 2),
+  [839] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__octal_repeat1, 2),
+  [841] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__octal_repeat1, 2), SHIFT_REPEAT(224),
+  [844] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__octal_repeat1, 2),
+  [846] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__octal, 3),
+  [848] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
+  [850] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__octal, 3),
+  [852] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hex, 3),
+  [854] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
+  [856] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hex, 3),
+  [858] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hex, 4),
+  [860] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hex, 4),
+  [862] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__octal, 4),
+  [864] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__octal, 4),
+  [866] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
+  [868] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 3, .production_id = 10),
+  [870] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__decimal, 3, .production_id = 10),
+  [872] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(287),
+  [875] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(248),
+  [878] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hex, 2),
+  [880] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
+  [882] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hex, 2),
+  [884] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
+  [886] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_identifier, 3),
+  [888] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
+  [890] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bare_identifier, 3),
+  [892] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__bare_identifier_repeat1, 2),
+  [894] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_identifier_repeat1, 2), SHIFT_REPEAT(239),
+  [897] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__bare_identifier_repeat1, 2),
+  [899] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_identifier, 2),
+  [901] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
+  [903] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bare_identifier, 2),
+  [905] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escaped_string, 2),
+  [907] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escaped_string, 2),
+  [909] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2), SHIFT_REPEAT(242),
+  [912] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bare_identifier, 1),
+  [914] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
+  [916] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bare_identifier, 1),
+  [918] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 1),
+  [920] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
+  [922] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_identifier, 1), REDUCE(sym_value, 1),
+  [925] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_value, 1),
+  [927] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__escaped_string, 3, .production_id = 1),
+  [929] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__escaped_string, 3, .production_id = 1),
+  [931] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), REDUCE(aux_sym_node_repeat3, 2),
+  [934] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 1), REDUCE(aux_sym_node_repeat3, 2), SHIFT(287),
+  [938] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__node_space, 1), REDUCE(aux_sym_node_repeat3, 2),
+  [941] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 1), REDUCE(aux_sym_node_repeat3, 2), SHIFT(270),
+  [945] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 1),
+  [947] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 1),
+  [949] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(287),
+  [952] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(270),
+  [955] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(271),
+  [958] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_field_comment, 2, .production_id = 6),
+  [960] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_field_comment, 2, .production_id = 6),
+  [962] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_field, 1),
+  [964] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_field, 1),
+  [966] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_field, 1),
+  [968] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_field, 1),
+  [970] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 2),
+  [972] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_value, 2),
+  [974] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_prop, 5),
+  [976] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prop, 5),
+  [978] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 5, .production_id = 13),
+  [980] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__decimal, 5, .production_id = 13),
+  [982] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__exponent, 3),
+  [984] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__exponent, 3),
+  [986] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 4, .production_id = 10),
+  [988] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__decimal, 4, .production_id = 10),
+  [990] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1),
+  [992] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1),
+  [994] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_prop, 4),
+  [996] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prop, 4),
+  [998] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_number, 1),
+  [1000] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_number, 1),
+  [1002] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), REDUCE(sym__node_space, 3),
+  [1005] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__node_space, 2), REDUCE(sym__node_space, 3),
+  [1008] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 2), REDUCE(sym__node_space, 3), SHIFT(270),
+  [1012] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__node_field_comment, 3, .production_id = 9),
+  [1014] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__node_field_comment, 3, .production_id = 9),
+  [1016] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(270),
+  [1019] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), REDUCE(sym__node_space, 2),
+  [1022] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__node_space, 1), REDUCE(sym__node_space, 2),
+  [1025] = {.entry = {.count = 3, .reusable = true}}, REDUCE(sym__node_space, 1), REDUCE(sym__node_space, 2), SHIFT(262),
+  [1029] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword, 1),
+  [1031] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword, 1),
+  [1033] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(264),
+  [1036] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_identifier, 1),
+  [1038] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_number, 1),
+  [1040] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_number, 1),
+  [1042] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat3, 2), SHIFT_REPEAT(270),
+  [1045] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3), SHIFT(270),
+  [1048] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_prop, 3),
+  [1050] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prop, 3),
+  [1052] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__decimal, 3),
+  [1054] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__decimal, 3),
+  [1056] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_value, 3),
+  [1058] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_value, 3),
+  [1060] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__exponent, 2),
+  [1062] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__exponent, 2),
+  [1064] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [1066] = {.entry = {.count = 1, .reusable = false}}, SHIFT(108),
+  [1068] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [1070] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
+  [1072] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [1074] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [1076] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
+  [1078] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
+  [1080] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [1082] = {.entry = {.count = 1, .reusable = false}}, SHIFT(105),
+  [1084] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
+  [1086] = {.entry = {.count = 1, .reusable = true}}, SHIFT(300),
+  [1088] = {.entry = {.count = 1, .reusable = false}}, SHIFT(300),
+  [1090] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
+  [1092] = {.entry = {.count = 1, .reusable = true}}, SHIFT(342),
+  [1094] = {.entry = {.count = 1, .reusable = false}}, SHIFT(342),
+  [1096] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
+  [1098] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
+  [1100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [1102] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [1104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [1106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [1108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [1110] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [1112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
+  [1114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(340),
+  [1116] = {.entry = {.count = 1, .reusable = false}}, SHIFT(340),
+  [1118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(299),
+  [1120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(299),
+  [1122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
+  [1124] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 3),
+  [1126] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 3),
+  [1128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 5),
+  [1130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 5),
+  [1132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 7, .production_id = 5),
+  [1134] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 7, .production_id = 5),
+  [1136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 4, .production_id = 5),
+  [1138] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 4, .production_id = 5),
+  [1140] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 6),
+  [1142] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 6),
+  [1144] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 8, .production_id = 5),
+  [1146] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 8, .production_id = 5),
+  [1148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 4),
+  [1150] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 4),
+  [1152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 2),
+  [1154] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 2),
+  [1156] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 6, .production_id = 5),
+  [1158] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 6, .production_id = 5),
+  [1160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 5, .production_id = 5),
+  [1162] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 5, .production_id = 5),
+  [1164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_children, 3, .production_id = 5),
+  [1166] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_children, 3, .production_id = 5),
+  [1168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [1170] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [1172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
+  [1174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
+  [1176] = {.entry = {.count = 1, .reusable = false}}, SHIFT(298),
+  [1178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
+  [1180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [1182] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [1184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
+  [1186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(301),
+  [1188] = {.entry = {.count = 1, .reusable = false}}, SHIFT(301),
+  [1190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(314),
+  [1192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [1194] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [1196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [1198] = {.entry = {.count = 1, .reusable = false}}, SHIFT(111),
+  [1200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
+  [1202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [1204] = {.entry = {.count = 1, .reusable = false}}, SHIFT(109),
+  [1206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
+  [1208] = {.entry = {.count = 1, .reusable = false}}, SHIFT(343),
+  [1210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
+  [1212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [1214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [1216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
+  [1218] = {.entry = {.count = 1, .reusable = false}}, SHIFT(341),
+  [1220] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_single_line_comment_repeat1, 2),
+  [1222] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_single_line_comment_repeat1, 2),
+  [1224] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_single_line_comment_repeat1, 2), SHIFT_REPEAT(314),
+  [1227] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(282),
+  [1230] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_repeat1, 2), SHIFT_REPEAT(321),
+  [1233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
+  [1235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(367),
+  [1237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(366),
+  [1239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
+  [1241] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
+  [1243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
+  [1245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
+  [1247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
+  [1249] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(282),
+  [1252] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(242),
+  [1255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [1257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
+  [1259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(317),
+  [1261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
+  [1263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
+  [1265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [1267] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 3), SHIFT(242),
+  [1270] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(333),
+  [1273] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 2), SHIFT(242),
+  [1276] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__node_space, 1), SHIFT(335),
+  [1279] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__bare_identifier_repeat1, 2), SHIFT_REPEAT(337),
+  [1282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(337),
+  [1284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(338),
+  [1286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__escaped_string_repeat1, 2),
+  [1288] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__escaped_string_repeat1, 2), SHIFT_REPEAT(358),
+  [1291] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__escaped_string_repeat1, 2), SHIFT_REPEAT(358),
+  [1294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
+  [1296] = {.entry = {.count = 1, .reusable = false}}, SHIFT(358),
+  [1298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
+  [1300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
+  [1302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
+  [1304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(357),
+  [1306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [1308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [1310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation_type, 1),
+  [1312] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__escaped_string_repeat1, 1),
+  [1314] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__escaped_string_repeat1, 1),
+  [1316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
+  [1318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
+  [1320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
+  [1322] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [1324] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
+  [1326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
+  [1328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
 };
 
 #ifdef __cplusplus
@@ -12424,15 +21426,11 @@ bool tree_sitter_kdl_external_scanner_scan(void *, TSLexer *, const bool *);
 unsigned tree_sitter_kdl_external_scanner_serialize(void *, char *);
 void tree_sitter_kdl_external_scanner_deserialize(void *, const char *, unsigned);
 
-#ifdef TREE_SITTER_HIDE_SYMBOLS
-#define TS_PUBLIC
-#elif defined(_WIN32)
-#define TS_PUBLIC __declspec(dllexport)
-#else
-#define TS_PUBLIC __attribute__((visibility("default")))
+#ifdef _WIN32
+#define extern __declspec(dllexport)
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_kdl(void) {
+extern const TSLanguage *tree_sitter_kdl(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,8 +1,6 @@
 #include "tree_sitter/parser.h"
-#include "wctype.h"
-#include <ctype.h>
 
-enum { _EOF, MULTI_LINE_COMMENT, _RAW_STRING };
+enum { _EOF, MULTI_LINE_COMMENT, MULTI_LINE_STRING, _RAW_STRING };
 
 void *tree_sitter_kdl_external_scanner_create() { return NULL; }
 
@@ -14,65 +12,260 @@ void tree_sitter_kdl_external_scanner_deserialize(void *payload, const char *buf
 
 static void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 
+static bool scan_multiline_body(TSLexer *lexer, unsigned num_hashes);
+
+// According to the KDL v2 spec: https://kdl.dev/spec/#name-whitespace
+static bool is_unicode_space(int32_t c) {
+    switch (c) {
+        case '\t':
+        case ' ':
+        case 0x00A0:
+        case 0x1680:
+        case 0x2000:
+        case 0x2001:
+        case 0x2002:
+        case 0x2003:
+        case 0x2004:
+        case 0x2005:
+        case 0x2006:
+        case 0x2007:
+        case 0x2008:
+        case 0x2009:
+        case 0x200A:
+        case 0x202F:
+        case 0x205F:
+        case 0x3000:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool is_newline_start(int32_t c) {
+    return c == '\r' || c == '\n' || c == 0x0085 || c == 0x000B || c == 0x000C || c == 0x2028 || c == 0x2029;
+}
+
+static void advance_newline(TSLexer *lexer) {
+    if (lexer->lookahead == '\r') {
+        advance(lexer);
+        if (lexer->lookahead == '\n') {
+            advance(lexer);
+        }
+    } else {
+        advance(lexer);
+    }
+}
+
+static bool consume_closing_hashes(TSLexer *lexer, unsigned num_hashes) {
+    for (unsigned i = 0; i < num_hashes; i++) {
+        if (lexer->lookahead != '#') {
+            return false;
+        }
+        advance(lexer);
+    }
+
+    return true;
+}
+
+// Consume exactly three consecutive quote characters.
+// This is used for KDL v2 multiline string delimiters such as:
+//   """
+//   #""" ... """#
+//   ##""" ... """##
+static bool consume_triple_quote(TSLexer *lexer) {
+    if (lexer->lookahead != '"') {
+        return false;
+    }
+    advance(lexer);
+
+    if (lexer->lookahead != '"') {
+        return false;
+    }
+    advance(lexer);
+
+    if (lexer->lookahead != '"') {
+        return false;
+    }
+    advance(lexer);
+
+    return true;
+}
+
+
+// After reading the first quote of a v2 raw string opener, check if the
+// following input makes it a raw multiline string (`#"""\n` / `##"""\n`).
+// If it does, consume the opening newline and start scanning the multiline body.
+static bool try_scan_v2_raw_multiline_string(TSLexer *lexer, unsigned num_hashes, unsigned *consumed_quotes) {
+    if (lexer->lookahead != '"') {
+        return false;
+    }
+    advance(lexer);
+    *consumed_quotes = 1;
+
+    if (lexer->lookahead != '"') {
+        return false;
+    }
+    advance(lexer);
+    *consumed_quotes = 2;
+
+    if (!is_newline_start(lexer->lookahead)) {
+        return false;
+    }
+
+    advance_newline(lexer);
+    if (!scan_multiline_body(lexer, num_hashes)) {
+        return false;
+    }
+
+    lexer->result_symbol = _RAW_STRING;
+    return true;
+}
+
+static bool scan_multiline_body(TSLexer *lexer, unsigned num_hashes) {
+    bool at_line_start = true;
+
+    for (;;) {
+        if (lexer->eof(lexer)) {
+            return false;
+        }
+
+        if (at_line_start) {
+            // In KDL v2, a multiline string closes near the start of a line:
+            // indentation is allowed, then the closing """ or """### delimiter.
+            while (is_unicode_space(lexer->lookahead)) {
+                advance(lexer);
+            }
+
+            if (consume_triple_quote(lexer)) {
+                return consume_closing_hashes(lexer, num_hashes);
+            }
+        }
+
+        if (is_newline_start(lexer->lookahead)) {
+            advance_newline(lexer);
+            at_line_start = true;
+            continue;
+        }
+
+        at_line_start = false;
+        advance(lexer);
+    }
+}
+
+static bool scan_multiline_string(TSLexer *lexer, unsigned num_hashes, int result_symbol) {
+    if (!consume_triple_quote(lexer)) return false;
+
+    if (!is_newline_start(lexer->lookahead)) {
+        return false;
+    }
+
+    advance_newline(lexer);
+    if (!scan_multiline_body(lexer, num_hashes)) {
+        return false;
+    }
+
+    lexer->result_symbol = result_symbol;
+    return true;
+}
+
+static bool scan_single_line_raw_string(TSLexer *lexer, unsigned num_hashes) {
+    for (;;) {
+        if (lexer->eof(lexer)) {
+            return false;
+        }
+
+        int32_t c = lexer->lookahead;
+        advance(lexer);
+
+        if (c != '"') {
+            continue;
+        }
+
+        // After the closing quote, the number of `#` characters must match the opener.
+        if (consume_closing_hashes(lexer, num_hashes)) {
+            lexer->result_symbol = _RAW_STRING;
+            return true;
+        }
+    }
+}
+
+static bool scan_v2_raw_string(TSLexer *lexer) {
+    unsigned num_hashes = 0;
+    while (lexer->lookahead == '#') {
+        num_hashes += 1;
+        advance(lexer);
+    }
+
+    if (num_hashes == 0 || lexer->lookahead != '"') {
+        return false;
+    }
+
+    advance(lexer);
+
+    unsigned consumed_quotes = 0;
+
+    if (try_scan_v2_raw_multiline_string(lexer, num_hashes, &consumed_quotes)) {
+        return true;
+    }
+
+    if (consumed_quotes > 0) {
+        // This handles the shortest legal forms such as #""#.
+        // We already consumed the first opening quote, so here we check whether
+        // the next one or two quotes were actually the empty-string closing delimiter.
+        if (consume_closing_hashes(lexer, num_hashes)) {
+            lexer->result_symbol = _RAW_STRING;
+            return true;
+        }
+    }
+
+    return scan_single_line_raw_string(lexer, num_hashes);
+}
+
+static bool scan_v1_raw_string(TSLexer *lexer) {
+    if (lexer->lookahead != 'r') {
+        return false;
+    }
+    advance(lexer);
+
+    unsigned num_hashes = 0;
+    while (lexer->lookahead == '#') {
+        num_hashes += 1;
+        advance(lexer);
+    }
+
+    if (lexer->lookahead != '"') {
+        return false;
+    }
+
+    advance(lexer);
+    return scan_single_line_raw_string(lexer, num_hashes);
+}
+
 bool tree_sitter_kdl_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
-    // check for End-of-file
     if (valid_symbols[_EOF] && lexer->lookahead == 0) {
         lexer->result_symbol = _EOF;
         advance(lexer);
         return true;
     }
 
-    if (valid_symbols[_RAW_STRING] && lexer->lookahead == 'r') {
-        advance(lexer);
-
-        unsigned num_hashes = 0;
-        while (lexer->lookahead == '#') {
-            num_hashes += 1;
-            advance(lexer);
+    if (valid_symbols[MULTI_LINE_STRING] && lexer->lookahead == '"') {
+        if (scan_multiline_string(lexer, 0, MULTI_LINE_STRING)) {
+            return true;
         }
-
-        if (lexer->lookahead != '"') {
-            return false;
-        }
-
-        advance(lexer);
-
-        for (;;) {
-            if (lexer->eof(lexer)) {
-                // Unclosed raw string caused by EOF.
-                return false;
-            }
-
-            int32_t c = lexer->lookahead;
-            advance(lexer);
-
-            if (c != '"') {
-                continue;
-            }
-
-            // Try to match `num_hashes` closing hashes.
-            unsigned closing_hashes = 0;
-            for (;;) {
-                if (closing_hashes == num_hashes) {
-                    goto success;
-                }
-
-                if (lexer->lookahead != '#') {
-                    break;
-                }
-
-                advance(lexer);
-
-                closing_hashes += 1;
-            }
-        }
-
-    success:
-        lexer->result_symbol = _RAW_STRING;
-        return true;
     }
 
-    // multi-line-comment := '/*' commented-block
+    if (valid_symbols[_RAW_STRING]) {
+        // Support both raw-string families at once:
+        //   v1: r#"..."#
+        //   v2: #"..."#
+        if (lexer->lookahead == 'r' && scan_v1_raw_string(lexer)) {
+            return true;
+        }
+        if (lexer->lookahead == '#' && scan_v2_raw_string(lexer)) {
+            return true;
+        }
+    }
+
     if (lexer->lookahead == '/') {
         advance(lexer);
         if (lexer->lookahead != '*')
@@ -81,8 +274,6 @@ bool tree_sitter_kdl_external_scanner_scan(void *payload, TSLexer *lexer, const 
 
         bool after_star = false;
         unsigned nesting_depth = 1;
-        // commented-block := '*/' | (multi-line-comment | '*' | '/' | [^*/]+)
-        // commented-block
         for (;;) {
             switch (lexer->lookahead) {
                 case '\0':

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -86,11 +87,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,38 +126,13 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -175,17 +146,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -206,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -216,7 +176,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -224,7 +184,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}
@@ -237,15 +197,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/node.txt
+++ b/test/corpus/node.txt
@@ -107,6 +107,414 @@ node1
       (node
         (identifier)))
 
+========================
+Test V2 Boolean And Null
+========================
+
+node #true #false #null
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword)))))
+
+========================
+Test V2 Keyword Numbers
+========================
+
+node #inf #-inf #nan
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (number
+              (keyword_number))))
+        (node_field
+          (value
+            (number
+              (keyword_number))))
+        (node_field
+          (value
+            (number
+              (keyword_number))))))
+
+========================
+Test V2 Raw String Arg
+========================
+
+node #""# ##"value"##
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (string)))
+        (node_field
+          (value
+            (string)))))
+
+==============================
+Test V2 Multiline String Arg
+==============================
+
+node """
+hello
+world
+"""
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (string
+              (multi_line_string))))))
+
+==================================
+Test V2 Raw Multiline String Arg
+==================================
+
+node #"""
+hello
+world
+"""#
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (string)))))
+
+========================
+Test V2 Type Spacing
+========================
+
+( type ) node key = #true
+
+---
+
+    (document
+      (node
+        (type
+          (identifier))
+        (identifier)
+        (node_field
+          (prop
+            (identifier)
+            (value
+              (keyword
+                (boolean)))))))
+
+===================================
+Test Mixed V1 And V2 Literal Forms
+===================================
+
+node true #true null #null #inf
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword)))
+        (node_field
+          (value
+            (keyword)))
+        (node_field
+          (value
+            (number
+              (keyword_number))))))
+
+=========================================
+Test Mixed V1 And V2 Literal Forms Full
+=========================================
+
+node true #true false #false null #null #inf
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword
+              (boolean))))
+        (node_field
+          (value
+            (keyword)))
+        (node_field
+          (value
+            (keyword)))
+        (node_field
+          (value
+            (number
+              (keyword_number))))))
+
+===================================
+Test Quoted Node And Property Names
+===================================
+
+"node name" "arg value" "prop name"="prop value"
+
+---
+
+    (document
+      (node
+        (identifier
+          (string
+            (string_fragment)))
+        (node_field
+          (value
+            (string
+              (string_fragment))))
+        (node_field
+          (prop
+            (identifier
+              (string
+                (string_fragment)))
+            (value
+              (string
+                (string_fragment)))))))
+
+=========================
+Test Raw Quoted Node Names
+=========================
+
+#"node"# #"arg"# #"prop"#=#"value"#
+
+---
+
+    (document
+      (node
+        (identifier
+          (string))
+        (node_field
+          (value
+            (string)))
+        (node_field
+          (prop
+            (identifier
+              (string))
+            (value
+              (string))))))
+
+============================
+Test Quoted Type Mixed Forms
+============================
+
+( "tag" ) "node" #"prop"# = #true
+
+---
+
+    (document
+      (node
+        (type
+          (identifier
+            (string
+              (string_fragment))))
+        (identifier
+          (string
+            (string_fragment)))
+        (node_field
+          (prop
+            (identifier
+              (string))
+            (value
+              (keyword
+                (boolean)))))))
+
+=================================
+Test Slashdash Field And Children
+=================================
+
+node /- old=true /- "old arg" /- {
+  child
+}
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (node_field_comment)
+          (node_field_comment)
+          (node_field_comment
+            (prop
+              (identifier)
+              (value
+                (keyword
+                  (boolean))))))
+        (node_field
+          (node_field_comment)
+          (node_field_comment)
+          (node_field_comment
+            (value
+              (string
+                (string_fragment)))))
+        (node_children
+          (node_children_comment)
+          (node
+            (identifier)))))
+
+============================
+Test Slashdash Prop And Keep
+============================
+
+node /- old=true keep=true
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (node_field_comment)
+          (node_field_comment)
+          (node_field_comment
+            (prop
+              (identifier)
+              (value
+                (keyword
+                  (boolean))))))
+        (node_field
+          (prop
+            (identifier)
+            (value
+              (keyword
+                (boolean)))))))
+
+===========================
+Test Slashdash Arg And Keep
+===========================
+
+node /- "old" keep="new"
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (node_field_comment)
+          (node_field_comment)
+          (node_field_comment
+            (value
+              (string
+                (string_fragment)))))
+        (node_field
+          (prop
+            (identifier)
+            (value
+              (string
+                (string_fragment)))))))
+
+===========================
+Test Slashdash Version Hint
+===========================
+
+/- kdl-version 2
+node #true
+
+---
+
+    (document
+      (node
+        (node_comment)
+        (node_comment)
+        (identifier)
+        (node_field
+          (value
+            (number))))
+      (node
+        (identifier)
+        (node_field
+          (value
+            (keyword
+              (boolean))))))
+
+========================================
+Test V2 Raw Multiline String Indentation
+========================================
+
+node ##"""
+hello
+world
+  """##
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (string)))))
+
+========================================
+Test V2 Raw Multiline String With Quotes
+========================================
+
+node ##"""
+hello "" world
+  """##
+
+---
+
+    (document
+      (node
+        (identifier)
+        (node_field
+          (value
+            (string)))))
+
 =====================================
 Test Slashdash Arg Before Newline Esc
 =====================================


### PR DESCRIPTION
Add permissive KDL v2 syntax support while preserving existing KDL v1 editor compatibility.

This grammar is intended for editor/tooling use-cases and should not be treated as a strict KDL version validator.

### Changes

- Added KDL v2 boolean and null literals:
  - `#true`
  - `#false`
  - `#null`

- Added KDL v2 keyword-like numeric literals:
  - `#inf`
  - `#-inf`
  - `#nan`

- Relaxed spacing in a few places commonly used by KDL v2, including:
  - type annotations
  - properties around `=`

- Added support for KDL v2 multiline strings

- Added support for KDL v2 raw strings such as:
  - `#"value"#`
  - `##"value"##`
  while keeping KDL v1 raw strings such as:
  - `r#"value"#`

It may successfully parse documents that mix KDL v1 and KDL v2 literal forms.

### Notes

This PR used AI assistance for parts of the work, including Unicode-related rewrites, test case generation, and discussions around how to implement KDL v2 specification details.
